### PR TITLE
Remove pages branch customization in releaser action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,5 +34,3 @@ jobs:
           charts_dir: helm-charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          # TODO: Remove this line to publish charts once the repo turned public
-          CR_PAGES_BRANCH: gh-pages-unpublished


### PR DESCRIPTION
Instead, keep gh-pages-unpublished branch as a branch temporarily used by github pages