### PR TITLE
Do not require version increment in lint action for now

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -3,3 +3,4 @@ remote: origin
 chart-dirs:
   - helm-charts
 helm-extra-args: --timeout 600s
+check-version-increment: false


### PR DESCRIPTION
Since there are a lot changes going right now, on we don't want to release for every change