### PR TITLE
lint-test action: enable check-version-increment back

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -3,5 +3,4 @@ remote: origin
 chart-dirs:
   - helm-charts
 helm-extra-args: --timeout 600s
-check-version-increment: false
 validate-chart-schema: false


### PR DESCRIPTION
There is no easy way to make releaser action publish the build only when version changed. So we will be publishing for every change in the chart