### PR TITLE
Enable APM correlation

### DIFF
--- a/helm-charts/o11y-collector/templates/daemonset.yaml
+++ b/helm-charts/o11y-collector/templates/daemonset.yaml
@@ -96,7 +96,7 @@ spec:
           {{- toYaml $port | trim | nindent 10 }}
         {{- end }}
         image: {{ template "o11y-collector.image.otelcol" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         {{- if .Values.otelAgent.securityContext }}
         securityContext:
           {{ toYaml .Values.otelAgent.securityContext | nindent 10 }}

--- a/helm-charts/o11y-collector/templates/deployment-collector.yaml
+++ b/helm-charts/o11y-collector/templates/deployment-collector.yaml
@@ -53,7 +53,7 @@ spec:
         - {{ . }}
         {{- end }}
         image: {{ template "o11y-collector.image.otelcol" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:
           - name: K8S_NODE_NAME
             valueFrom:

--- a/helm-charts/o11y-collector/templates/deployment-k8s-cluster-receiver.yaml
+++ b/helm-charts/o11y-collector/templates/deployment-k8s-cluster-receiver.yaml
@@ -53,7 +53,7 @@ spec:
         - {{ . }}
         {{- end }}
         image: {{ template "o11y-collector.image.otelcol" . }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:
           - name: K8S_NODE_NAME
             valueFrom:


### PR DESCRIPTION
This adds the signalfx_correlation exporter. Enable resourcedetection processor on traces pipeline so we get cloud attributes on traces.

Also fix the pull policy variables.