### PR TITLE
Enable hostNetwork in collector pod

### DIFF
--- a/helm-charts/o11y-collector/templates/daemonset.yaml
+++ b/helm-charts/o11y-collector/templates/daemonset.yaml
@@ -23,6 +23,8 @@ spec:
       annotations:
         checksum/config: {{ print (include (print $.Template.BasePath "/configmap-fluentd.yaml") .) (include (print $.Template.BasePath "/configmap-otel-agent.yaml") .) | sha256sum }}
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ template "o11y-collector.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-charts/o11y-collector/templates/podsecuritypolicy.yaml
+++ b/helm-charts/o11y-collector/templates/podsecuritypolicy.yaml
@@ -18,7 +18,8 @@ spec:
   allowPrivilegeEscalation: true
   allowedCapabilities:
   - '*'
-  hostNetwork: false
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   hostIPC: false
   hostPID: false
   volumes:


### PR DESCRIPTION
When hostNetwork is disabled, the otel collector does not have access to the underlying node's networking metrics.
K8s docs state ```For Pods running with hostNetwork, you should explicitly set its DNS policy "ClusterFirstWithHostNet".```