### PR TITLE
remove dnsPolicy from PodSecurityPolicy

### DIFF
--- a/helm-charts/o11y-collector/templates/podsecuritypolicy.yaml
+++ b/helm-charts/o11y-collector/templates/podsecuritypolicy.yaml
@@ -19,7 +19,6 @@ spec:
   allowedCapabilities:
   - '*'
   hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   hostIPC: false
   hostPID: false
   volumes:


### PR DESCRIPTION
This field doesn't exist in PodSecurityPolicy