### PR TITLE
updates for resource enrichment

### DIFF
--- a/helm-charts/o11y-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/o11y-collector/templates/config/_otel-agent.tpl
@@ -131,6 +131,11 @@ exporters:
   # If collector is disabled, metrics and traces will be set to to SignalFx backend
   {{- include "o11y-collector.otelSapmExporter" . | nindent 2 }}
   signalfx:
+    correlation:
+      sync_attributes:
+        # TODO: Change to otel conventions when mappings are changed.
+        k8s.pod.uid: kubernetes_pod_uid
+        container.id: container_id
     ingest_url: {{ include "o11y-collector.ingestUrl" . }}/v2/datapoint
     api_url: {{ include "o11y-collector.apiUrl" . }}
     access_token: ${SPLUNK_ACCESS_TOKEN}
@@ -162,7 +167,7 @@ service:
     # default metrics pipeline
     metrics:
       receivers: [hostmetrics, prometheus, kubeletstats, receiver_creator]
-      processors: [memory_limiter, k8s_tagger, resource/add_cluster_name, resourcedetection]
+      processors: [memory_limiter, resource/add_cluster_name, resourcedetection]
       exporters:
         {{- if .Values.otelCollector.enabled }}
         - otlp

--- a/helm-charts/o11y-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/o11y-collector/templates/config/_otel-collector.tpl
@@ -76,6 +76,6 @@ service:
     # default metrics pipeline
     metrics:
       receivers: [otlp, prometheus]
-      processors: [memory_limiter, k8s_tagger, resource/add_cluster_name]
+      processors: [memory_limiter, resource/add_cluster_name]
       exporters: [signalfx]
 {{- end }}

--- a/helm-charts/o11y-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/o11y-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -56,6 +56,6 @@ service:
     # k8s metrics pipeline
     metrics:
       receivers: [prometheus, k8s_cluster]
-      processors: [memory_limiter, k8s_tagger, resource/add_cluster_name]
+      processors: [memory_limiter, resource/add_cluster_name]
       exporters: [signalfx]
 {{- end }}

--- a/helm-charts/o11y-collector/values.yaml
+++ b/helm-charts/o11y-collector/values.yaml
@@ -523,7 +523,7 @@ image:
     # The name of the opentelemetry collector image to pull
     name: otel/opentelemetry-collector-contrib-dev
     # The tag of the opentelemetry collector image to pull
-    tag: bb44b79b25ae061f6bfeaf319144423a2cfb067a
+    tag: 9677f5b3a3cca335aae23938de07d2296468572e
     # The policy that specifies when the user wants the opentelemetry collector images to be pulled
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
We now enrich metrics coming from a discovered instance by adding k8s.pod.uid,
etc. as default dimensions. This is more reliable than using k8s_tagger so also
disable k8s_tagger for metrics.

Also change APM correlation to use kubernetes_pod_uid.