### PR TITLE
Redirect html to project site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+
+<head>
+<meta http-equiv="refresh" content="0; url=https://github.com/signalfx/splunk-otel-collector-chart">
+<meta charset="utf-8">
+<script type="text/javascript">
+    window.location.href = "https://github.com/signalfx/splunk-otel-collector-chart"
+</script>
+<title>Splunk OpenTelemetry Connector for Kubernetes</title>
+</head>
+
+<body>
+<h1>Splunk OpenTelemetry Connector for Kubernetes</h1>
+<p>
+The OpenTelemetry Connector for Kubernetes is a Helm repository.
+Please <a href="https://github.com/signalfx/splunk-otel-collector-chart">click here</a> to visit the project site.
+</p>
+</body>
+
+</html>


### PR DESCRIPTION
It's likely not clear to many users that the github.io page is only intended for helm so it's better to redirect to github.