### PR TITLE
Allow for us to send logs, metrics and traces to a local splunk instance additionally to cloud

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -137,6 +137,28 @@ exporters:
     sync_host_metadata: true
   {{- end }}
 
+  {{- if .Values.splunkHEC.metrics.enabled }}
+  splunk_hec/metrics:
+    {{- with .Values.splunkHEC.metrics }}
+    token: {{ .token }}
+    endpoint: {{ .endpoint }}
+    sourcetype: {{ .sourcetype }}
+    index: {{ .index }}
+    insecure_skip_verify: {{ .insecure }}
+    {{- end }}
+  {{- end }}
+
+  {{- if .Values.splunkHEC.traces.enabled }}
+  splunk_hec/traces:
+    {{- with .Values.splunkHEC.traces }}
+    token: {{ .token }}
+    endpoint: {{ .endpoint }}
+    sourcetype: {{ .sourcetype }}
+    index: {{ .index }}
+    insecure_skip_verify: {{ .insecure }}
+    {{- end }}
+  {{- end }}
+
 service:
   extensions: [health_check, k8s_observer, zpages]
 
@@ -156,7 +178,9 @@ service:
         {{- else }}
         - sapm
         {{- end }}
-        - signalfx
+        {{- if .Values.splunkHEC.traces.enabled }}
+        - splunk_hec/traces
+        {{- end }}
 
     # default metrics pipeline
     metrics:
@@ -167,5 +191,8 @@ service:
         - otlp
         {{- else }}
         - signalfx
+        {{- end }}
+        {{- if .Values.splunkHEC.metrics.enabled }}
+        - splunk_hec/metrics
         {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -287,8 +287,8 @@ data:
       {{- end }}
 
       # = output =
+      {{- if .Values.logsBackend.splunkIngestAPI.ingestAPIHost }}
       <match **>
-        {{- if .Values.logsBackend.splunkIngestAPI.ingestAPIHost }}
         @type splunk_ingest_api
         {{- with .Values.logsBackend.splunkIngestAPI.serviceClientIdentifier }}
         service_client_identifier {{ . }}
@@ -314,7 +314,9 @@ data:
         {{- with .Values.logsBackend.splunkIngestAPI.debugIngestAPI }}
         debug_http {{ . }}
         {{- end }}
-        {{- else }}
+      </match>
+      {{- end }}
+      <match **>
         @type splunk_hec
         {{- with .Values.logsBackend.hec.protocol | default .Values.ingestProtocol }}
         protocol {{ . }}
@@ -336,7 +338,6 @@ data:
         {{- end }}
         {{- if .Values.logsBackend.hec.caFile }}
         ca_file /fluentd/etc/splunk/hec_ca_file
-        {{- end }}
         {{- end }}
         host "#{ENV['K8S_NODE_NAME']}"
         source_key source

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -54,6 +54,22 @@ metricsEnabled: true
 tracesEnabled: true
 logsEnabled: true
 
+splunkHEC:
+  metrics:
+    enabled: false
+    endpoint: "http://example.com"
+    index: metrics
+    insecure: false
+    sourcetype: o11y:metrics
+    token: "<HEC token>"
+  traces:
+    enabled: false
+    endpoint: "http://example.com"
+    index: traces
+    insecure: false
+    sourcetype: o11y:traces
+    token: "<HEC token>"
+
 # Configuration for additional metadata that will be added to all the telemetry
 # as extra attributes.
 extraAttributes:


### PR DESCRIPTION
This allows to set additional outputs for logs, metrics and traces that would duplicate data to go to a local Splunk Enterprise.

Right now, you have to choose to send logs to a local cloud or the remote ingest. This allows to do both.
