### PR TITLE
Remove `v2/datapoint` from end of ingest_url

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.20.3
+version: 0.20.4
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -130,7 +130,7 @@ exporters:
         # TODO: Change to otel conventions when mappings are changed.
         k8s.pod.uid: kubernetes_pod_uid
         container.id: container_id
-    ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}/v2/datapoint
+    ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}
     api_url: {{ include "splunk-otel-collector.apiUrl" . }}
     access_token: ${SPLUNK_ACCESS_TOKEN}
     send_compatible_metrics: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -62,7 +62,7 @@ processors:
 exporters:
   {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
   signalfx:
-    ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}/v2/datapoint
+    ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}
     api_url: {{ include "splunk-otel-collector.apiUrl" . }}
     access_token: ${SPLUNK_ACCESS_TOKEN}
     send_compatible_metrics: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -44,7 +44,7 @@ processors:
 
 exporters:
   signalfx:
-    ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}/v2/datapoint
+    ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}
     api_url: {{ include "splunk-otel-collector.apiUrl" . }}
     access_token: ${SPLUNK_ACCESS_TOKEN}
     send_compatible_metrics: true


### PR DESCRIPTION
With `v2/datapoint` set on the end it results in trying to send events to
`/v2/datapoint/v2/event` which is not correct. Removing the path will result in
the right suffix being used for metrics and events.