### PR TITLE
Add an optional "environment" helm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ $ helm install my-splunk-otel-collector \
   splunk-otel-collector-chart/splunk-otel-collector
 ```
 
+### Deployment environment
+
+Optional `environment` parameter can be used to specify an additional `deployment.environment`
+attribute that will be added to all the telemetry data. It will help Splunk Observability 
+users to investigate data coming from different source separately. 
+Value examples: development, staging, production, etc.
+
+```yaml
+environment: production
+```
+
 ## License
 
 [Apache Software License version 2.0](LICENSE).

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -113,6 +113,14 @@ processors:
         key: {{ .name }}
       {{- end }}
 
+  {{- if .Values.environment }}
+  resource/add_environment:
+    attributes:
+      - action: insert
+        value: {{ .Values.environment }}
+        key: deployment.environment
+  {{- end }}
+
 # By default only SAPM exporter enabled. It will be pointed to collector deployment if enabled,
 # Otherwise it's pointed directly to signalfx backend based on the values provided in signalfx setting.
 # These values should not be specified manually and will be set in the templates.
@@ -150,7 +158,15 @@ service:
     # default traces pipeline
     traces:
       receivers: [otlp, jaeger, zipkin, opencensus]
-      processors: [memory_limiter, resourcedetection, k8s_tagger, resource/add_cluster_name, batch]
+      processors: 
+        - memory_limiter
+        - resourcedetection
+        - k8s_tagger
+        - resource/add_cluster_name
+        {{- if .Values.environment }}
+        - resource/add_environment
+        {{- end }}
+        - batch
       exporters:
         {{- if .Values.otelCollector.enabled }}
         - otlp

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -59,6 +59,14 @@ processors:
         key: {{ .name }}
       {{- end }}
 
+  {{- if .Values.environment }}
+  resource/add_environment:
+    attributes:
+      - action: insert
+        value: {{ .Values.environment }}
+        key: deployment.environment
+  {{- end }}
+
 exporters:
   {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
   signalfx:
@@ -76,7 +84,14 @@ service:
     # default traces pipeline
     traces:
       receivers: [otlp, jaeger, zipkin, opencensus, sapm]
-      processors: [memory_limiter, batch, k8s_tagger, resource/add_cluster_name]
+      processors: 
+        - memory_limiter
+        - batch
+        - k8s_tagger
+        - resource/add_cluster_name
+        {{- if .Values.environment }}
+        - resource/add_environment
+        {{- end }}
       exporters: [sapm]
 
     # default metrics pipeline

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -233,6 +233,9 @@ data:
           {{- range .Values.extraAttributes.custom }}
           {{ .name }} "{{ .value }}"
           {{- end }}
+          {{- if .Values.environment }}
+          deployment.environment "{{ .Values.environment }}"
+          {{- end }}
         </record>
       </filter>
       <filter tail.containers.**>
@@ -365,6 +368,9 @@ data:
           {{- end }}
           {{- range .Values.extraAttributes.podLabels }}
           k8s.pod.labels.{{ . }}
+          {{- end }}
+          {{- if .Values.environment }}
+          deployment.environment
           {{- end }}
         </fields>
         {{- with .Values.fluentd.config.buffer }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -54,6 +54,14 @@ metricsEnabled: true
 tracesEnabled: true
 logsEnabled: true
 
+################################################################################
+# Optional "environment" parameter that will be added to all the telemetry
+# data (traces/logs/metrics) as an attribute. It will allow Splunk Observability
+# users to investigate data coming from different source separately.
+################################################################################
+
+# environment: production
+
 # Configuration for additional metadata that will be added to all the telemetry
 # as extra attributes.
 extraAttributes:


### PR DESCRIPTION
It adds an easy way to add a specific "development.environment" attribute to telemetry data