### PR TITLE
Make image registry and tag optional

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -90,14 +90,14 @@ Get splunkAccessToken.
 Create the fluentd image name.
 */}}
 {{- define "splunk-otel-collector.image.fluentd" -}}
-{{- printf "%s/%s:%s" .Values.image.fluentd.registry .Values.image.fluentd.name .Values.image.fluentd.tag -}}
+{{- printf "%s/%s:%s" .Values.image.fluentd.registry .Values.image.fluentd.name .Values.image.fluentd.tag | trimPrefix "/" | trimSuffix ":" -}}
 {{- end -}}
 
 {{/*
 Create the opentelemetry collector image name.
 */}}
 {{- define "splunk-otel-collector.image.otelcol" -}}
-{{- printf "%s/%s:%s" .Values.image.otelcol.registry .Values.image.otelcol.name .Values.image.otelcol.tag -}}
+{{- printf "%s/%s:%s" .Values.image.otelcol.registry .Values.image.otelcol.name .Values.image.otelcol.tag | trimPrefix "/" | trimSuffix ":" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
It's helpful for testing purposes if user wants to run an image that is built locally