### PR TITLE
Remove unnecessary privileged mode from fluentd container

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/podsecuritypolicy.yaml
+++ b/helm-charts/splunk-otel-collector/templates/podsecuritypolicy.yaml
@@ -14,15 +14,16 @@ metadata:
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
 spec:
-  privileged: true
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-  - '*'
+  privileged: false
+  allowPrivilegeEscalation: false
   hostNetwork: true
   hostIPC: false
   hostPID: false
   volumes:
-  - '*'
+  - 'configMap'
+  - 'emptyDir'
+  - 'hostPath'
+  - 'secret'
   runAsUser:
     rule: 'RunAsAny'
   seLinux:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -183,9 +183,7 @@ fluentd:
       cpu: 100m
       memory: 200Mi
 
-  # Currently fluentd logging component need to be run in privileged mode.
   securityContext:
-    privileged: true
     runAsUser: 0
 
   config:


### PR DESCRIPTION
Fluentd container doesn't require privileged mode to work. 

Also restrict more PodSecurityPolicy.