### PR TITLE
Add signalfx receiver to otelCollector configuration

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -26,6 +26,9 @@ receivers:
   fluentforward:
     endpoint: 0.0.0.0:8006
 
+  signalfx:
+    endpoint: 0.0.0.0:9943
+
 # By default k8s_tagger, memory_limiter and batch processors enabled.
 processors:
   k8s_tagger:


### PR DESCRIPTION
This commit fixes the issue https://github.com/signalfx/splunk-otel-collector-chart/issues/66