### PR TITLE
Fix fluentd customFilters configuration

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.20.7
+version: 0.20.8
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -278,12 +278,12 @@ data:
       </filter>
 
       # = custom filters specified by users =
-      {{- range $name, $filterDef := .Values.customFilters }}
+      {{- range $name, $filterDef := .Values.fluentd.config.customFilters }}
       {{- if and $filterDef.tag $filterDef.type }}
       <filter {{ $filterDef.tag }}>
         @type {{ $filterDef.type }}
         {{- if $filterDef.body }}
-        {{ $filterDef.body | indent 8 }}
+        {{- $filterDef.body | nindent 8 }}
         {{- end }}
       </filter>
       {{- end }}


### PR DESCRIPTION
- Move the `customFilters` configuration from global scope under `.fluentd.config`
- Fix the config indentation