### PR TITLE
Fix the otel agent in the gateway (otelCollector.enabled=true) mode

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.20.8
+version: 0.20.9
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -132,6 +132,7 @@ exporters:
   {{- else }}
   # If collector is disabled, metrics and traces will be set to to SignalFx backend
   {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
+  {{- end }}
   signalfx:
     correlation:
       sync_attributes:
@@ -142,7 +143,6 @@ exporters:
     api_url: {{ include "splunk-otel-collector.apiUrl" . }}
     access_token: ${SPLUNK_ACCESS_TOKEN}
     sync_host_metadata: true
-  {{- end }}
 
 service:
   extensions: [health_check, k8s_observer, zpages]


### PR DESCRIPTION
Let's make correlation reporting directly from agent to unblock the start. Then we can reconfigure the correlation.

Resolves: https://github.com/signalfx/splunk-otel-collector-chart/issues/73