### PR TITLE
update correlation dimensions

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -137,10 +137,6 @@ exporters:
   {{- end }}
   signalfx:
     correlation:
-      sync_attributes:
-        # TODO: Change to otel conventions when mappings are changed.
-        k8s.pod.uid: kubernetes_pod_uid
-        container.id: container_id
     ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}
     api_url: {{ include "splunk-otel-collector.apiUrl" . }}
     access_token: ${SPLUNK_ACCESS_TOKEN}


### PR DESCRIPTION
for pod correlation we can now sync to k8s.pod.uid and container.id since we're
sending those as dimensions.