### PR TITLE
Add provider and distro options

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.21.1
+version: 0.22.0
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -86,13 +86,22 @@ processors:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
   resourcedetection:
     detectors:
+      # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
+      # before it gets set later by the cloud provider detector.
       - env
-      {{- if eq .Values.platform "gcp" }}
+      {{- if eq .Values.distro "gke" }}
       - gke
-      - gce
-      {{- else if eq .Values.platform "aws" }}
+      {{- else if eq .Values.distro "eks" }}
       - eks
+      {{- else if eq .Values.distro "aks" }}
+      - aks
+      {{- end }}
+      {{- if eq .Values.provider "gcp" }}
+      - gce
+      {{- else if eq .Values.provider "aws" }}
       - ec2
+      {{- else if eq .Values.provider "azure" }}
+      - azure
       {{- end }}
     timeout: 10s
 

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -3,7 +3,8 @@
   "type": "object",
   "required": [
     "clusterName",
-    "platform",
+    "provider",
+    "distro",
     "tracesEnabled",
     "metricsEnabled",
     "logsEnabled"
@@ -15,10 +16,15 @@
       "minLength": 1,
       "type": "string"
     },
-    "platform": {
-      "description": "Kubernetes platform used to run the collector on",
+    "provider": {
+      "description": "Cloud provider where the collector is running",
       "type": "string",
-      "enum": ["aws", "gcp", "default"]
+      "enum": ["aws", "gcp", "azure", " ", ""]
+    },
+    "distro": {
+      "description": "Kubernetes distribution where the collector is running",
+      "type": "string",
+      "enum": ["eks", "gke", "aks", " ", ""]
     },
     "metricsEnabled": {
       "description": "Metrics telemetry enabled",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -26,7 +26,7 @@ splunkAccessToken:
 # SignalFx ingest server host, default: "ingest.<realm>.signalfx.com".
 ingestHost:
 
-# The SignalFx API URL, default: "htpps://api.<realm>.signalfx.com".
+# The SignalFx API URL, default: "https://api.<realm>.signalfx.com".
 apiUrl:
 
 # Signalfx ingest endpoint port.
@@ -36,13 +36,22 @@ ingestPort: 443
 ingestProtocol: https
 
 ################################################################################
-# Kubernetes platform used to run the collector on. Valid options are:
-# - "aws" (Amazon EKS and self-managed k8s cluster on AWS EC2)
-# - "gcp" (Google GKE and self-managed k8s cluster on GCP GCE)
-# - "default"
+# Cloud provider, if any, the collector is running on. Leave empty for none/other.
+# - "aws" (Amazon Web Services)
+# - "gcp" (Google Cloud Platform)
+# - "azure" (Microsoft Azure)
 ################################################################################
 
-platform: default
+provider: ""
+
+################################################################################
+# Kubernetes distribution being run. Leave empty for other.
+# - "eks" (Amazon Elastic Kubernetes Service)
+# - "gke" (Google Google Kubernetes Engine)
+# - "aks" (Azure Kubernetes Service)
+################################################################################
+
+distro: ""
 
 ################################################################################
 # Telemetry configuration.


### PR DESCRIPTION
The previous option of platform has been split into two separate options,
provider and distro. This allows us to distinguish between cloud-managed
clusters and user-managed clusters.

The reason " " (with a space) is allowed as an option is to work around UI
wizard that is not able to omit the option or provide just an empty space.