### PR TITLE
Set daemonset collector agent's k8s resource attributes by env

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -103,6 +103,8 @@ processors:
       {{- else if eq .Values.provider "azure" }}
       - azure
       {{- end }}
+    # Don't override existing resource attributes to maintain identification of data sources
+    override: false
     timeout: 10s
 
   {{- include "splunk-otel-collector.otelMemoryLimiterConfig" .Values.otelAgent | nindent 2 }}

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -120,6 +120,18 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SPLUNK_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
@@ -142,8 +154,8 @@ spec:
             value: /hostfs/dev
 
           # Host specific resource attributes
-          - name: OTEL_RESOURCE
-            value: host.name=$(K8S_NODE_NAME),k8s.node.name=$(K8S_NODE_NAME)
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: host.name=$(K8S_NODE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.namespace.name=$(K8S_NAMESPACE)
           {{- end }}
 
         readinessProbe:


### PR DESCRIPTION
These changes add the three resource attributes generally set by the receiver creator for all resource detection processor users: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/aa9e5432748c83db8701f53c3a569f2e3c2559b1/receiver/receivercreator/factory.go#L54.  This way all other receiver types can benefit from these identifiers.

Also updates to no longer use the deprecated env var.