### PR TITLE
release chart 0.23.0

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.22.0
+version: 0.23.0
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -538,7 +538,7 @@ image:
     # The registry and name of the opentelemetry collector image to pull
     repository: quay.io/signalfx/splunk-otel-collector-dev
     # The tag of the opentelemetry collector image to pull
-    tag: 8a52d529697078b26c86774f20e44098b5287c1a
+    tag: 609e1fff7c2db5bc9fbed3e4c8c7277f13e3fb9f
     # The policy that specifies when the user wants the opentelemetry collector images to be pulled
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
These changes update the splunk-otel-collector-dep to https://github.com/signalfx/splunk-otel-collector/commit/609e1fff7c2db5bc9fbed3e4c8c7277f13e3fb9f and bump the chart version.