### PR TITLE
Add host.name by default to fluentd logs

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.1
+version: 0.24.2
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -35,7 +35,7 @@ data:
     <source>
       @type prometheus_monitor
       <labels>
-        host ${hostname}
+        host.name ${hostname}
       </labels>
     </source>
 
@@ -43,7 +43,7 @@ data:
     <source>
       @type prometheus_output_monitor
       <labels>
-        host ${hostname}
+        host.name ${hostname}
       </labels>
     </source>
 
@@ -204,6 +204,12 @@ data:
       </match>
     </label>
     <label @SPLUNK>
+      <filter **>
+        @type record_transformer
+        <record>
+          host.name "#{ENV['K8S_NODE_NAME']}"
+        </record>
+      </filter>
       # Enrich log with k8s metadata
       <filter tail.containers.**>
         @type kubernetes_metadata
@@ -360,6 +366,7 @@ data:
           k8s.node.name node_name
           k8s.cluster.name cluster_name
           container.id container_id
+          host.name
           {{- range .Values.extraAttributes.custom }}
           {{ .name }}
           {{- end }}


### PR DESCRIPTION
Related content uses host.name and previously this was being added by a
org-only index rule.