### PR TITLE
Prometheus doesn't like labels with . in them

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.2
+version: 0.24.3
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.3
+version: 0.24.2
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -34,17 +34,11 @@ data:
     # input plugin that collects metrics from MonitorAgent
     <source>
       @type prometheus_monitor
-      <labels>
-        host.name ${hostname}
-      </labels>
     </source>
 
     # input plugin that collects metrics for output plugin
     <source>
       @type prometheus_output_monitor
-      <labels>
-        host.name ${hostname}
-      </labels>
     </source>
 
   source.containers.conf: |-


### PR DESCRIPTION
Since host.name is added by processor can just skip adding host entirely to
these.