### PR TITLE
Fix issue with traces getting agent's k8s.pod.uid

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.2
+version: 0.24.3
 description: Splunk OpenTelemetry Connector for Kubernetes
 type: application
 keywords:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -152,10 +152,6 @@ spec:
             value: /hostfs/run
           - name: HOST_DEV
             value: /hostfs/dev
-
-          # Host specific resource attributes
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: host.name=$(K8S_NODE_NAME),k8s.node.name=$(K8S_NODE_NAME)
           {{- end }}
 
         readinessProbe:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -155,7 +155,7 @@ spec:
 
           # Host specific resource attributes
           - name: OTEL_RESOURCE_ATTRIBUTES
-            value: host.name=$(K8S_NODE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID),k8s.namespace.name=$(K8S_NAMESPACE)
+            value: host.name=$(K8S_NODE_NAME),k8s.node.name=$(K8S_NODE_NAME)
           {{- end }}
 
         readinessProbe:


### PR DESCRIPTION
In change 3c312b6f4 we added some globally set resource attributes like
k8s.pod.uid. The problem is these attributes would get set before k8s_tagger
was run so you would get traces with the k8s.pod.uid of the agent itself
instead of the pod the trace came from.

Instead add a separate metrics pipeline that adds the agent k8s metadata only
to prometheus metrics.