### PR TITLE
Enable batch for metrics

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -111,8 +111,6 @@ processors:
   {{- include "splunk-otel-collector.otelMemoryLimiterConfig" .Values.otelAgent | nindent 2 }}
 
   batch:
-    timeout: 200ms
-    send_batch_size: 128
 
   resource:
     # General resource attributes that apply to all telemetry passing through the agent.
@@ -188,13 +186,13 @@ service:
       receivers: [otlp, jaeger, zipkin]
       processors:
         - memory_limiter
+        - batch
         - resource
         - resourcedetection
         - k8s_tagger
         {{- if .Values.environment }}
         - resource/add_environment
         {{- end }}
-        - batch
       exporters:
         {{- if .Values.otelCollector.enabled }}
         - otlp
@@ -208,6 +206,7 @@ service:
       receivers: [hostmetrics, kubeletstats, receiver_creator]
       processors:
         - memory_limiter
+        - batch
         - resource
         - resourcedetection
       exporters:
@@ -222,6 +221,7 @@ service:
       receivers: [prometheus/agent]
       processors:
         - memory_limiter
+        - batch
         - resource
         - resource/add_agent_k8s
         - resourcedetection

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -48,8 +48,6 @@ processors:
   {{- include "splunk-otel-collector.otelMemoryLimiterConfig" .Values.otelCollector | nindent 2 }}
 
   batch:
-    timeout: 1s
-    send_batch_size: 1024
 
   resource/add_cluster_name:
     attributes:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -22,6 +22,8 @@ receivers:
 processors:
   {{- include "splunk-otel-collector.otelMemoryLimiterConfig" .Values.otelK8sClusterReceiver | nindent 2 }}
 
+  batch:
+
   # k8s_tagger to enrich its own metrics
   k8s_tagger:
     filter:
@@ -59,6 +61,6 @@ service:
     # k8s metrics pipeline
     metrics:
       receivers: [prometheus, k8s_cluster]
-      processors: [memory_limiter, resource]
+      processors: [memory_limiter, batch, resource]
       exporters: [signalfx]
 {{- end }}


### PR DESCRIPTION
Use default config for batch (send every 200ms or 8192 items). This is same
that
https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector/gateway_config.yaml
is using.

Resolves #32