### PR TITLE
Route all metrics and traces through the gateway deployment, if enabled

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.4
+version: 0.24.5
 description: Splunk OpenTelemetry Connector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -167,8 +167,13 @@ exporters:
   {{- end }}
   signalfx:
     correlation:
+    {{- if .Values.otelCollector.enabled }}
+    ingest_url: http://{{ include "splunk-otel-collector.fullname" . }}:9943
+    api_url: http://{{ include "splunk-otel-collector.fullname" . }}:6060
+    {{- else }}
     ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}
     api_url: {{ include "splunk-otel-collector.apiUrl" . }}
+    {{- end }}
     access_token: ${SPLUNK_ACCESS_TOKEN}
     sync_host_metadata: true
 
@@ -226,9 +231,7 @@ service:
         - resource/add_agent_k8s
         - resourcedetection
       exporters:
-        {{- if .Values.otelCollector.enabled }}
-        - otlp
-        {{- else }}
+        # Use signalfx instead of otlp even if collector is enabled 
+        # in order to sync host metadata.
         - signalfx
-        {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -28,6 +28,7 @@ receivers:
 
   signalfx:
     endpoint: 0.0.0.0:9943
+    access_token_passthrough: true
 
 # By default k8s_tagger, memory_limiter and batch processors enabled.
 processors:
@@ -97,7 +98,7 @@ service:
 
     # default metrics pipeline
     metrics:
-      receivers: [otlp, prometheus]
+      receivers: [otlp, prometheus, signalfx]
       processors: [memory_limiter, batch, resource/add_cluster_name]
       exporters: [signalfx]
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -50,8 +50,13 @@ processors:
 
 exporters:
   signalfx:
+    {{- if .Values.otelCollector.enabled }}
+    ingest_url: http://{{ include "splunk-otel-collector.fullname" . }}:9943
+    api_url: http://{{ include "splunk-otel-collector.fullname" . }}:6060
+    {{- else }}
     ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}
     api_url: {{ include "splunk-otel-collector.apiUrl" . }}
+    {{- end }}
     access_token: ${SPLUNK_ACCESS_TOKEN}
     timeout: 10s
 


### PR DESCRIPTION
Make sure that all metrics, traces, correlation and metadata updates are coming through the standalone collector deployment if it's enabled.