### PR TITLE
Use clusterName to work with gdi ui logs inventory

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -359,6 +359,7 @@ data:
           k8s.namespace.name namespace
           k8s.node.name node_name
           k8s.cluster.name cluster_name
+          clusterName cluster_name
           container.id container_id
           host.name
           {{- range .Values.extraAttributes.custom }}


### PR DESCRIPTION
`k8s.cluster.name` isn't used by the wizard's* log queries so we need to work around this.