### PR TITLE
Fix traces enrichment with k8s metadata

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.7
+version: 0.24.8
 description: Splunk OpenTelemetry Connector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -195,10 +195,10 @@ service:
       receivers: [otlp, jaeger, smartagent/signalfx-forwarder, zipkin]
       processors:
         - memory_limiter
+        - k8s_tagger
         - batch
         - resource
         - resourcedetection
-        - k8s_tagger
         {{- if .Values.environment }}
         - resource/add_environment
         {{- end }}


### PR DESCRIPTION
`k8s_tagger` processor has to be placed before `batch` processor otherwise we lose http client context on batch processor and cannot get trace source IP address on k8s_tagger processor to fetch k8s metadata