### PR TITLE
Change OTLP receiver port to 4317

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -163,7 +163,7 @@ exporters:
   {{- if .Values.otelCollector.enabled }}
   # If collector is enabled, metrics and traces will be sent to collector
   otlp:
-    endpoint: {{ include "splunk-otel-collector.fullname" . }}:55680
+    endpoint: {{ include "splunk-otel-collector.fullname" . }}:4317
     insecure: true
   {{- else }}
   # If collector is disabled, metrics and traces will be set to to SignalFx backend

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -107,8 +107,8 @@ otelAgent:
   # For example to disable zipkin ports set `otelAgent.ports.zipkin: null`.
   ports:
     otlp:
-      containerPort: 55680
-      hostPort: 55680
+      containerPort: 4317
+      hostPort: 4317
       protocol: TCP
     zipkin:
       containerPort: 9411
@@ -618,7 +618,7 @@ otelCollector:
   # Any changes should be alligned with service.ports configuraition below.
   ports:
     otlp:
-      containerPort: 55680
+      containerPort: 4317
       protocol: TCP
     jaeger-thrift:
       containerPort: 14268
@@ -681,7 +681,7 @@ service:
   # Ports exposed by the opentelemetry collector service. Container named ports used.
   ports:
     otlp:
-      containerPort: 55680
+      containerPort: 4317
       targetPort: otlp
       protocol: TCP
     jaeger-thrift:


### PR DESCRIPTION
OTLP port 55680 is deprecated now. 4317 is the default