### PR TITLE
Explicitly define OTLP receiver ports

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -27,7 +27,9 @@ Common config for the otel-collector traces receivers
 otlp:
   protocols:
     grpc:
+      endpoint: 0.0.0.0:4317
     http:
+      endpoint: 0.0.0.0:55681
 sapm:
   endpoint: 0.0.0.0:7276
 jaeger:


### PR DESCRIPTION
For better user experience, we want to have default endpoint values always to be in the config, so user don't have to check receiver docs.