### PR TITLE
Change the way to configure "concat" filter for container logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.24.11] - 2021-04-29
+
+- Change the way to configure "concat" filter for container logs (#117)
+
 ## [0.24.10] - 2021-04-21
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.10
+version: 0.24.11
 description: Splunk OpenTelemetry Connector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -167,7 +167,8 @@ data:
       # = filters for container logs =
       {{- range $name, $logDef := .Values.fluentd.config.logs }}
       {{- if and $logDef.from.pod $logDef.multiline }}
-      <filter tail.containers.var.log.containers.{{ $logDef.from.pod }}*{{ or $logDef.from.container $name }}*.log>
+      {{- $filenameGlob := regexReplaceAll "\\*+" (printf "%s*%s*" $logDef.from.pod ($logDef.from.container | default "")) "*" }}
+      <filter tail.containers.var.log.containers.{{ $filenameGlob }}.log>
         @type concat
         key log
         timeout_label @SPLUNK

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -346,7 +346,10 @@ fluentd:
     #       path: /var/log/docker.log
     # ```
     #
-    # For `container` logs, pod name is required. You can also provide the container name, if it's not provided, the name of this source will be used as the container name:
+    # For `container` logs, `pod` field is required. It represents part of
+    # the pod name, can be name of a deployment or replica set. Use "*" to
+    # apply the configuration to all pods. Optional `container` value can be
+    # used to apply configuration to a particular container.
     # ```
     # kube-apiserver:
     #   from:


### PR DESCRIPTION
- Add support to configure the "concat" filter section to be applied for all the container logs. For example, to parse multiline java stack trace from every container:
```
fluentd:
  config:
    logs:
      java-stacktrace:
        from:
          pod: "*"
        multiline:
          firstline: /\d{4}-\d{1,2}-\d{1,2}/
```
- Do not use the name of the source as fallback for `container` field. If `container` value is not set, apply configuration to all containers in the pod.