### PR TITLE
Fix logs collection configuration for CRI-O / containerd runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.24.12] - 2021-05-03
+
+### Fixed
+
+- Fix logs collection configuration for CRI-O / containerd runtimes (#120)
+
 ## [0.24.11] - 2021-04-29
+
+### Changed
 
 - Change the way to configure "concat" filter for container logs (#117)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -114,3 +114,20 @@ fluentd:
         multiline:
           firstline: /\d{4}-\d{1,2}-\d{1,2}/
 ```
+
+# Logs collection configuration for CRI-O container runtime
+
+Default logs collection is configured for Docker container runtime.
+The following configuration should be set for CRI-O or containerd runtimes,
+e.g. OpenShift.
+
+```yaml
+fluentd:
+  config:
+    containers:
+      logFormatType: cri
+      criTimeFormat: "%Y-%m-%dT%H:%M:%S.%N%:z"
+```
+
+`criTimeFormat` can be used to configure logs collection for different log
+formats, e.g. `criTimeFormat: "%Y-%m-%dT%H:%M:%S.%NZ"` for IBM IKS.

--- a/examples/crio-logging-values.yaml
+++ b/examples/crio-logging-values.yaml
@@ -1,0 +1,9 @@
+clusterName: my-cluster
+splunkRealm: us0
+splunkAccessToken: my-access-token
+
+fluentd:
+  config:
+    containers:
+      logFormatType: cri
+      criTimeFormat: "%Y-%m-%dT%H:%M:%S.%N%:z"

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.11
+version: 0.24.12
 description: Splunk OpenTelemetry Connector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/ci/basic-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/basic-values.yaml
@@ -1,3 +1,10 @@
 clusterName: fake-cluster
 splunkRealm: fake-realm
 splunkAccessToken: fake-token
+
+# Logs collection config for Kind cluster
+fluentd:
+  config:
+    containers:
+      logFormatType: cri
+      criTimeFormat: "%Y-%m-%dT%H:%M:%S.%NZ"

--- a/helm-charts/splunk-otel-collector/ci/sampler-gateway-env-vars-java-logs-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/sampler-gateway-env-vars-java-logs-values.yaml
@@ -43,3 +43,8 @@ fluentd:
           pod: "java-app"
         multiline:
           firstline: /\d{4}-\d{1,2}-\d{1,2}/
+
+    # Logs collection config for Kind cluster
+    containers:
+      logFormatType: cri
+      criTimeFormat: "%Y-%m-%dT%H:%M:%S.%NZ"

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -56,7 +56,9 @@ data:
     # Json Log Example:
     # {"log":"[info:2016-02-16T16:04:05.930-08:00] Some log text here\n","stream":"stdout","time":"2016-02-17T00:04:05.931087621Z"}
     # CRI Log Example (not supported):
-    # 2016-02-17T00:04:05.931087621Z stdout [info:2016-02-16T16:04:05.930-08:00] Some log text here
+    # 2016-02-17T00:04:05.931087621Z stdout P { 'long': { 'json', 'object output' },
+    # 2016-02-17T00:04:05.931087621Z stdout F 'splitted': 'partial-lines' }
+    # 2016-02-17T00:04:05.931087621Z stdout F [info:2016-02-16T16:04:05.930-08:00] Some log text here
     <source>
       @id containers.log
       @type tail
@@ -72,8 +74,8 @@ data:
       <parse>
       {{- if eq .Values.fluentd.config.containers.logFormatType "cri" }}
         @type regexp
-        expression /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
-        time_format  {{ .Values.fluentd.containers.logFormat | default "%Y-%m-%dT%H:%M:%S.%N%:z" }}
+        expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<partial_flag>[FP]))? (?<log>.*)$/
+        time_format {{ .Values.fluentd.config.containers.criTimeFormat }}
       {{- else if eq .Values.fluentd.config.containers.logFormatType "json" }}
         @type json
         time_format %Y-%m-%dT%H:%M:%S.%NZ
@@ -164,7 +166,18 @@ data:
   output.conf: |-
     #Events are emitted to the CONCAT label from the container, file and journald sources for multiline processing.
     <label @CONCAT>
-      # = filters for container logs =
+      # = handle cri/containerd multiline format =
+      {{- if eq .Values.fluentd.config.containers.logFormatType "cri" }}
+      <filter tail.containers.var.log.containers.**>
+        @type concat
+        key log
+        partial_key partial_flag
+        partial_value P
+        separator ''
+        timeout_label @SPLUNK
+      </filter>
+      {{- end }}
+      # = handle custom multiline logs =
       {{- range $name, $logDef := .Values.fluentd.config.logs }}
       {{- if and $logDef.from.pod $logDef.multiline }}
       {{- $filenameGlob := regexReplaceAll "\\*+" (printf "%s*%s*" $logDef.from.pod ($logDef.from.container | default "")) "*" }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -215,7 +215,7 @@ fluentd:
       logFormatType: json
       # Specify the log format for "cri" logFormatType
       # It can be "%Y-%m-%dT%H:%M:%S.%N%:z" for openshift and "%Y-%m-%dT%H:%M:%S.%NZ" for IBM IKS
-      logFormat:
+      criTimeFormat: "%Y-%m-%dT%H:%M:%S.%N%:z"
 
     # Directory where to read journald logs. (docker daemon logs, kubelet logs, and anyother specified serivce logs)
     journalLogPath: /run/log/journal


### PR DESCRIPTION
- Fix fluentd.config.containers.criTimeFormat config path
- Add support for CRI-O multiline logs
- Fix CI values to not throwing parsing errors in kind cluster, resolves https://github.com/signalfx/splunk-otel-collector-chart/issues/93