### PR TITLE
Remove monitor_agent events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.24.13] - 2021-05-04
+
+### Changed
+
+- Remove internal fluentd metrics sent as logs with monitor_agent. Prometheus
+  metrics exposed on 0.0.0.0:24231 should be used instead (#122)
+
 ## [0.24.12] - 2021-05-03
 
 ### Fixed

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.24.12
+version: 0.24.13
 description: Splunk OpenTelemetry Connector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -14,7 +14,6 @@ data:
     @include source.containers.conf
     @include source.files.conf
     @include source.journald.conf
-    @include monit.conf
     @include output.conf
     @include prometheus.conf
 
@@ -155,14 +154,6 @@ data:
     {{- end }}
     {{- end }}
 
-  monit.conf: |-
-    <source>
-      @id fluentd-monitor-agent
-      @type monitor_agent
-      @label @SPLUNK
-      tag monitor_agent
-    </source>
-
   output.conf: |-
     #Events are emitted to the CONCAT label from the container, file and journald sources for multiline processing.
     <label @CONCAT>
@@ -285,12 +276,6 @@ data:
       </filter>
       {{- end }}
 
-      # = filters for monitor agent =
-      <filter monitor_agent>
-        @type jq_transformer
-        jq ".record.source = \"namespace:#{ENV['MY_NAMESPACE']}/pod:#{ENV['MY_POD_NAME']}\" | .record.sourcetype = \"fluentd:monitor-agent\" | .record.cluster_name = \"{{ .Values.clusterName }}\" | .record.index = \"{{ .Values.logsBackend.hec.indexName | default "main" }}\" {{- range .Values.extraAttributes.custom }}| .record.{{ .name }} = \"{{ .value }}\" {{- end }} | .record"
-      </filter>
-
       # = custom filters specified by users =
       {{- range $name, $filterDef := .Values.fluentd.config.customFilters }}
       {{- if and $filterDef.tag $filterDef.type }}
@@ -395,9 +380,6 @@ data:
         {{- end }}
         </buffer>
         {{- end }}
-        <format monitor_agent>
-          @type json
-        </format>
         <format>
           # we just want to keep the raw logs, not the structure created by docker or journald
           @type single_value


### PR DESCRIPTION
Internal metrics already exposed via Prometheus that should be used for monitoring instead of emitting monitor_agent events.