### PR TITLE
Fluentd cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- fluentd logs are now sent through the collector instead of being sent directly to the backend.
+
+### Removed
+
+- Removed `ingestHost`, `ingestPort`, `ingestProtocol`, use `ingestUrl` instead.
+- Removed `logsBackend`, configure `splunk_hec` exporter directly.
+- Removed `splunk.com/index` annotation for logs.
+- Removed `fluentd.config.indexFields` as all fields sent are indexed.
+
 ## [0.24.13] - 2021-05-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- fluentd logs are now sent through the collector instead of being sent directly to the backend.
+- fluentd logs are now sent through the collector instead of being sent directly to the backend (#109)
 
 ### Removed
 
-- Removed `ingestHost`, `ingestPort`, `ingestProtocol`, use `ingestUrl` instead.
-- Removed `logsBackend`, configure `splunk_hec` exporter directly.
-- Removed `splunk.com/index` annotation for logs.
-- Removed `fluentd.config.indexFields` as all fields sent are indexed.
+- Removed `ingestHost`, `ingestPort`, `ingestProtocol`, use `ingestUrl` instead (#123)
+- Removed `logsBackend`, configure `splunk_hec` exporter directly (#123)
+- Removed `splunk.com/index` annotation for logs (#123)
+- Removed `fluentd.config.indexFields` as all fields sent are indexed (#123)
 
 ## [0.24.13] - 2021-05-04
 

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -51,37 +51,11 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Get Splunk ingest host
-*/}}
-{{- define "splunk-otel-collector.ingestHost" -}}
-{{- $_ := required "splunkRealm or ingestHost must be provided" (or .Values.ingestHost .Values.splunkRealm) }}
-{{- .Values.ingestHost | default (printf "ingest.%s.signalfx.com" .Values.splunkRealm) }}
-{{- end -}}
-
-{{/*
-Get Splunk log URL
-*/}}
-{{- define "splunk-otel-collector.logUrl" -}}
-{{- $host := include "splunk-otel-collector.ingestHost" . }}
-{{- $endpoint := printf "%s://%s" .Values.ingestProtocol $host }}
-{{- if or (and (eq .Values.ingestProtocol "http") (ne (toString .Values.ingestPort) "80")) (and (eq .Values.ingestProtocol "https") (ne (toString .Values.ingestPort) "443")) }}
-{{- printf "%s:%s/v1/log" $endpoint (toString .Values.ingestPort) }}
-{{- else }}
-{{- $endpoint }}
-{{- end }}
-{{- end -}}
-
-{{/*
 Get Splunk ingest URL
 */}}
 {{- define "splunk-otel-collector.ingestUrl" -}}
-{{- $host := include "splunk-otel-collector.ingestHost" . }}
-{{- $endpoint := printf "%s://%s" .Values.ingestProtocol $host }}
-{{- if or (and (eq .Values.ingestProtocol "http") (ne (toString .Values.ingestPort) "80")) (and (eq .Values.ingestProtocol "https") (ne (toString .Values.ingestPort) "443")) }}
-{{- printf "%s:%s" $endpoint (toString .Values.ingestPort) }}
-{{- else }}
-{{- $endpoint }}
-{{- end }}
+{{- $_ := required "splunkRealm or ingestUrl must be provided" (or .Values.ingestUrl .Values.splunkRealm) }}
+{{- .Values.ingestUrl | default (printf "https://ingest.%s.signalfx.com" .Values.splunkRealm) }}
 {{- end -}}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -187,7 +187,7 @@ exporters:
   {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
   splunk_hec:
     endpoint: {{ include "splunk-otel-collector.logUrl" . }}
-    token: "${SPLUNK_HEC_TOKEN}"
+    token: "${SPLUNK_ACCESS_TOKEN}"
     index: "{{ .Values.logsBackend.hec.indexName }}"
     insecure_skip_verify: {{ .Values.logsBackend.hec.insecureSSL | default false }}
   {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -186,10 +186,8 @@ exporters:
   # If collector is disabled, metrics, logs and traces will be sent to to SignalFx backend
   {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
   splunk_hec:
-    endpoint: {{ include "splunk-otel-collector.logUrl" . }}
+    endpoint: {{ include "splunk-otel-collector.ingestUrl" . }}
     token: "${SPLUNK_ACCESS_TOKEN}"
-    index: "{{ .Values.logsBackend.hec.indexName }}"
-    insecure_skip_verify: {{ .Values.logsBackend.hec.insecureSSL | default false }}
   {{- end }}
 
   signalfx:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -72,10 +72,8 @@ processors:
 exporters:
   {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
   splunk_hec:
-    endpoint: {{ include "splunk-otel-collector.logUrl" . }}
+    endpoint: {{ include "splunk-otel-collector.ingestUrl" . }}
     token: "${SPLUNK_ACCESS_TOKEN}"
-    index: "{{ .Values.logsBackend.hec.indexName }}"
-    insecure_skip_verify: {{ .Values.logsBackend.hec.insecureSSL | default false }}
   signalfx:
     ingest_url: {{ include "splunk-otel-collector.ingestUrl" . }}
     api_url: {{ include "splunk-otel-collector.apiUrl" . }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -73,7 +73,7 @@ exporters:
   {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
   splunk_hec:
     endpoint: {{ include "splunk-otel-collector.logUrl" . }}
-    token: "${SPLUNK_HEC_TOKEN}"
+    token: "${SPLUNK_ACCESS_TOKEN}"
     index: "{{ .Values.logsBackend.hec.indexName }}"
     insecure_skip_verify: {{ .Values.logsBackend.hec.insecureSSL | default false }}
   signalfx:

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -215,8 +215,6 @@ data:
         <record>
           # set the sourcetype from splunk.com/sourcetype pod annotation or set it to kube:container:CONTAINER_NAME
           sourcetype ${record.dig("kubernetes", "annotations", "splunk.com/sourcetype") ? "kube:"+record.dig("kubernetes", "annotations", "splunk.com/sourcetype") : "kube:container:"+record.dig("kubernetes","container_name")}
-          # set the index field to the value found in the pod splunk.com/index annotations. if not set, use namespace annotation, or default to the default_index
-          index ${record.dig("kubernetes", "annotations", "splunk.com/index") ? record.dig("kubernetes", "annotations", "splunk.com/index") : record.dig("kubernetes", "namespace_annotations", "splunk.com/index")}
 
           k8s.container.name ${record.dig("kubernetes","container_name")}
           k8s.namespace.name ${record.dig("kubernetes","namespace_name")}
@@ -294,9 +292,8 @@ data:
         <record>
           com.splunk.sourcetype ${record.dig("sourcetype") ? record.dig("sourcetype") : ""}
           com.splunk.source ${record.dig("source") ? record.dig("source") : ""}
-          com.splunk.index ${record.dig("index") ? record.dig("index") : "{{ .Values.logsBackend.hec.indexName | default "main"}}"}
         </record>
-        remove_keys denylist,docker,kubernetes,source,sourcetype,index
+        remove_keys denylist,docker,kubernetes,source,sourcetype
       </filter>
 
       # = output =

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -63,6 +63,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          {{- with .Values.fluentd.extraEnvs }}
+          {{- . | toYaml | nindent 10 }}
+          {{- end }}
         resources:
           {{- toYaml .Values.fluentd.resources | nindent 10 }}
         volumeMounts:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -147,11 +147,6 @@ spec:
           - name: HOST_DEV
             value: /hostfs/dev
           {{- end }}
-          - name: SPLUNK_HEC_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "splunk-otel-collector.secret" . }}
-                key: splunk_hec_token
           {{- with .Values.otelAgent.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
@@ -70,11 +70,6 @@ spec:
               secretKeyRef:
                 name: {{ include "splunk-otel-collector.secret" . }}
                 key: splunk_access_token
-          - name: SPLUNK_HEC_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "splunk-otel-collector.secret" . }}
-                key: splunk_hec_token
           {{- with .Values.otelCollector.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/secret.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret.yaml
@@ -11,13 +11,4 @@ metadata:
 type: Opaque
 data:
   splunk_access_token: {{ include "splunk-otel-collector.accessToken" . | b64enc }}
-  {{- with .Values.logsBackend.hec.clientCert }}
-  hec_client_cert: {{ . | b64enc }}
-  {{- end }}
-  {{- with .Values.logsBackend.hec.clientKey }}
-  hec_client_key: {{ . | b64enc }}
-  {{- end }}
-  {{- with .Values.logsBackend.hec.caFile }}
-  hec_ca_file: {{ . | b64enc }}
-  {{- end }}
 {{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/secret.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret.yaml
@@ -11,7 +11,6 @@ metadata:
 type: Opaque
 data:
   splunk_access_token: {{ include "splunk-otel-collector.accessToken" . | b64enc }}
-  splunk_hec_token: {{ .Values.logsBackend.hec.token | default (include "splunk-otel-collector.accessToken" .) | b64enc }}
   {{- with .Values.logsBackend.hec.clientCert }}
   hec_client_cert: {{ . | b64enc }}
   {{- end }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -23,17 +23,11 @@ splunkRealm: us0
 # (REQUIRED) SignalFx org access token.
 splunkAccessToken:
 
-# SignalFx ingest server host, default: "ingest.<realm>.signalfx.com".
-ingestHost:
+# SignalFx ingest URL, default: "https://ingest.<realm>.signalfx.com".
+ingestUrl:
 
 # The SignalFx API URL, default: "https://api.<realm>.signalfx.com".
 apiUrl:
-
-# Signalfx ingest endpoint port.
-ingestPort: 443
-
-# Signalfx ingest protocol: "http" and "https".
-ingestProtocol: https
 
 ################################################################################
 # Cloud provider, if any, the collector is running on. Leave empty for none/other.
@@ -291,26 +285,6 @@ fluentd:
     # ```
     customFilters: {}
 
-    #
-    # You can find more information on indexed fields here - http://dev.splunk.com/view/event-collector/SP-CAAAFB6
-    # The scheme to define an indexed field is:
-    #
-    # ```
-    # ["field_1", "field_2"]
-    # ```
-    #
-    # `indexFields` defines the fields from the fluentd record to be indexed.
-    # You can find more information on indexed fields here - http://dev.splunk.com/view/event-collector/SP-CAAAFB6
-    # The input is in the form of an array(comma separated list) of the values you want to use as indexed fields.
-    #
-    # For example if you want to define indexed fields for "field_1" and "field_2"
-    # you will have to define an indexFields section as follows in values.yaml file.
-    # ```
-    # indexFields: ["field_1", "field_2"]
-    # ```
-    # WARNING: The fields being used here must be available inside the fluentd record.
-    indexFields: []
-
     # `logs` defines the source of logs, multiline support, and their sourcetypes.
     #
     # The scheme to define a log is:
@@ -476,44 +450,6 @@ fluentd:
         timestampExtraction:
           format: "%Y-%m-%dT%H:%M:%SZ"
         sourcetype: kube:apiserver-audit
-
-################################################################################
-# Additional configuration for logs backend.
-# It allows to configure o11y collector send logs to a Splunk backend,
-# instead of Signalfx.
-################################################################################
-
-logsBackend:
-  # Configurations for HEC (HTTP Event Collector)
-  hec:
-    # host will be set to `signalfx.ingestUrl` used by default
-    host:
-    # port to HEC, optional, default 443
-    port:
-    # token is required, `signalfx.token` used by default
-    token:
-    # protocol has two options: "http" and "https", default is "https"
-    protocol:
-    # indexName tells which splunk index to use, this is optional.
-    indexName: main
-    # insecureSSL is a boolean, it indicates should it allow inscure SSL connection (when protocol is "https"). Default is false.
-    insecureSSL: false
-
-    # TODO: Remaining options are unsupported in splunkhec exporter.
-    # The PEM-format CA certificate for this client.
-    # NOTE: The content of the certificate itself should be used here, not the file path.
-    #       The certificate will be stored as a secret in kubernetes.
-    clientCert:
-    # The private key for this client.
-    # NOTE: The content of the key itself should be used here, not the file path.
-    #       The key will be stored as a secret in kubernetes.
-    clientKey:
-    # The PEM-format CA certificate file.
-    # NOTE: The content of the file itself should be used here, not the file path.
-    #       The file will be stored as a secret in kubernetes.
-    caFile:
-  # Configurations for Splunk Ingest API which will be used instead of HEC logs backend if logsBackend.splunkIngestAPI.ingestAPIHost is set
-
 
 ################################################################################
 # Docker image configuration


### PR DESCRIPTION
Gets rid of splunk hec token, ingestHost, ingestPort, ingestProtocol. Most users will be using splunkRealm option instead.