### PR TITLE
change health_check value in k8s cluster configmap to null value

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -4,7 +4,7 @@ The values can be overridden in .Values.otelK8sClusterReceiver.config
 */}}
 {{- define "splunk-otel-collector.otelK8sClusterReceiverConfig" -}}
 extensions:
-  health_check: {}
+  health_check:
 
 receivers:
   # Prometheus receiver scraping metrics from the pod itself, both otel and fluentd

--- a/rendered/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:
-      health_check: {}
+      health_check: null
     processors:
       batch: null
       k8s_tagger:

--- a/rendered/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 01ad27bccf780fbc93a487d8079569112453c7e9f9a1cd84baedfb1860aa4ced
+        checksum/config: 0253ceaecbb09e8065006646e7c25082d3e7364281dc07e11b7b402559698539
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:

--- a/rendered/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:
-      health_check: {}
+      health_check: null
     processors:
       batch: null
       k8s_tagger:

--- a/rendered/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 01ad27bccf780fbc93a487d8079569112453c7e9f9a1cd84baedfb1860aa4ced
+        checksum/config: 0253ceaecbb09e8065006646e7c25082d3e7364281dc07e11b7b402559698539
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:


### PR DESCRIPTION
For parity with the rest of our health_check extensions: 
- https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl#L7
- https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl#L7

In my local testing I am using minikube v1.15.1 and
`kubectl version`
```

Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.4", GitCommit:"d360454c9bcd1634cf4cc52d1867af5491dc9c5f", GitTreeState:"clean", BuildDate:"2020-11-12T01:09:16Z", GoVersion:"go1.15.4", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.19.4", GitCommit:"d360454c9bcd1634cf4cc52d1867af5491dc9c5f", GitTreeState:"clean", BuildDate:"2020-11-11T13:09:17Z", GoVersion:"go1.15.2", Compiler:"gc", Platform:"linux/amd64"}

```
and
 
`helm version`

```
version.BuildInfo{Version:"v3.2.4-sfx", GitCommit:"3dd0f71f2952a99886b4006af95dfb7d2be792ca", GitTreeState:"clean", GoVersion:"go1.13.8"}
```

I am getting crash loop errors on the k8s cluster receiver pod, due to the health check extension not being defined, but used in the services.

```
2021-05-06T20:41:52.655Z	info	service/application.go:224	Loading configuration...
Error: invalid configuration: service references extension "health_check" which does not exist
2021/05/06 20:41:52 main.go:86: application run finished with error: invalid configuration: service references extension "health_check" which does not exist
```

Unsure how this wasn't caught before, so wondering if this was a versioning issue.
Any way, I don't think it is a bad idea to change this to match the rest of the health_check configs.