### PR TITLE
Fix add-sampler-values.yaml example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ Final OTel config will be created by merging the custom config provided in
 ```yaml
 otelAgent:
   config:
-    processor:
+    processors:
       probabilistic_sampler:
         hash_seed: 22
         sampling_percentage: 15.3

--- a/examples/add-sampler-values.yaml
+++ b/examples/add-sampler-values.yaml
@@ -4,7 +4,7 @@ splunkAccessToken: my-access-token
 
 otelAgent:
   config:
-    processor:
+    processors:
       probabilistic_sampler:
         hash_seed: 22
         sampling_percentage: 15.3

--- a/helm-charts/splunk-otel-collector/ci/sampler-gateway-env-vars-java-logs-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/sampler-gateway-env-vars-java-logs-values.yaml
@@ -4,7 +4,7 @@ splunkAccessToken: fake-token
 
 otelAgent:
   config:
-    processor:
+    processors:
       probabilistic_sampler:
         hash_seed: 22
         sampling_percentage: 15.3


### PR DESCRIPTION
We didn't catch it in CI because chart-testing doesn't validate daemonsets rollout https://github.com/helm/chart-testing/issues/333