### PR TITLE
Add signalfx metrics receiver to the otel-agent template

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -71,6 +71,9 @@ receivers:
       - container.id
       # - k8s.volume.type
 
+  signalfx:
+    endpoint: 0.0.0.0:9943
+
   smartagent/signalfx-forwarder:
     type: signalfx-forwarder
     listenAddress: 0.0.0.0:9080
@@ -226,7 +229,7 @@ service:
 
     # default metrics pipeline
     metrics:
-      receivers: [hostmetrics, kubeletstats, receiver_creator]
+      receivers: [hostmetrics, kubeletstats, receiver_creator, signalfx]
       processors:
         - memory_limiter
         - batch

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -130,6 +130,10 @@ otelAgent:
       containerPort: 8006
       hostPort: 8006
       protocol: TCP
+    signalfx:
+      containerPort: 9943
+      hostPort: 9943
+      protocol: TCP
 
   resources:
     limits:

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -116,10 +116,8 @@ data:
         receivers:
           prometheus_simple:
             config:
-              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
-                : 9090`'
-              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
-                : "/metrics"`'
+              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
             rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
         watch_observers:
         - k8s_observer

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -116,13 +116,17 @@ data:
         receivers:
           prometheus_simple:
             config:
-              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
-              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                : 9090`'
+              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                : "/metrics"`'
             rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
         watch_observers:
         - k8s_observer
       sapm:
         endpoint: 0.0.0.0:7276
+      signalfx:
+        endpoint: 0.0.0.0:9943
       smartagent/signalfx-forwarder:
         listenAddress: 0.0.0.0:9080
         type: signalfx-forwarder
@@ -146,6 +150,7 @@ data:
           - hostmetrics
           - kubeletstats
           - receiver_creator
+          - signalfx
         metrics/agent:
           exporters:
           - signalfx

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f7bda3b90a45f2473c5df047da3c6828baea040485d98e50a1b563d457cd9088
+        checksum/config: 4b685bb298c3de62c802e617fac44e4d4e3dbdcdcfb4126592805beb4b150051
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -105,6 +105,10 @@ spec:
         - name: sfx-forwarder
           containerPort: 9080
           hostPort: 9080
+          protocol: TCP
+        - name: signalfx
+          containerPort: 9943
+          hostPort: 9943
           protocol: TCP
         - name: zipkin
           containerPort: 9411

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 9918e4cc7db91c4681ce7a018344f29b68d8ebfdc5d7aebe5a630536ed5348f9
+        checksum/config: f7bda3b90a45f2473c5df047da3c6828baea040485d98e50a1b563d457cd9088
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -116,10 +116,8 @@ data:
         receivers:
           prometheus_simple:
             config:
-              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
-                : 9090`'
-              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
-                : "/metrics"`'
+              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
             rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
         watch_observers:
         - k8s_observer

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -116,13 +116,17 @@ data:
         receivers:
           prometheus_simple:
             config:
-              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
-              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                : 9090`'
+              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                : "/metrics"`'
             rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
         watch_observers:
         - k8s_observer
       sapm:
         endpoint: 0.0.0.0:7276
+      signalfx:
+        endpoint: 0.0.0.0:9943
       smartagent/signalfx-forwarder:
         listenAddress: 0.0.0.0:9080
         type: signalfx-forwarder
@@ -146,6 +150,7 @@ data:
           - hostmetrics
           - kubeletstats
           - receiver_creator
+          - signalfx
         metrics/agent:
           exporters:
           - signalfx

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 83bf66991fd6134b0a90371c11ea3925af32f9162ffd53ff746c38978ba7163a
+        checksum/config: e1818655d603bf7a50e707fd6bbf75290a990cfe1c63010015f65d87094549e9
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -58,6 +58,10 @@ spec:
         - name: sfx-forwarder
           containerPort: 9080
           hostPort: 9080
+          protocol: TCP
+        - name: signalfx
+          containerPort: 9943
+          hostPort: 9943
           protocol: TCP
         - name: zipkin
           containerPort: 9411

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 235b5273c7070e1a1a5fba301f67cf9e58296ca1ed34d3568b653758f3313e90
+        checksum/config: 83bf66991fd6134b0a90371c11ea3925af32f9162ffd53ff746c38978ba7163a
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -116,10 +116,8 @@ data:
         receivers:
           prometheus_simple:
             config:
-              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
-                : 9090`'
-              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
-                : "/metrics"`'
+              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
             rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
         watch_observers:
         - k8s_observer

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -116,13 +116,17 @@ data:
         receivers:
           prometheus_simple:
             config:
-              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
-              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"]
+                : 9090`'
+              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"]
+                : "/metrics"`'
             rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
         watch_observers:
         - k8s_observer
       sapm:
         endpoint: 0.0.0.0:7276
+      signalfx:
+        endpoint: 0.0.0.0:9943
       smartagent/signalfx-forwarder:
         listenAddress: 0.0.0.0:9080
         type: signalfx-forwarder
@@ -146,6 +150,7 @@ data:
           - hostmetrics
           - kubeletstats
           - receiver_creator
+          - signalfx
         metrics/agent:
           exporters:
           - signalfx

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 83bf66991fd6134b0a90371c11ea3925af32f9162ffd53ff746c38978ba7163a
+        checksum/config: e1818655d603bf7a50e707fd6bbf75290a990cfe1c63010015f65d87094549e9
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -58,6 +58,10 @@ spec:
         - name: sfx-forwarder
           containerPort: 9080
           hostPort: 9080
+          protocol: TCP
+        - name: signalfx
+          containerPort: 9943
+          hostPort: 9943
           protocol: TCP
         - name: zipkin
           containerPort: 9411

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 235b5273c7070e1a1a5fba301f67cf9e58296ca1ed34d3568b653758f3313e90
+        checksum/config: 83bf66991fd6134b0a90371c11ea3925af32f9162ffd53ff746c38978ba7163a
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
[splunk-otel-java](https://github.com/signalfx/splunk-otel-java) now exports metrics in the signalfx format, the otel agent should be able to pick them up out of the box. This change adds the `signalfx` receiver to the default agent metrics pipeline.