### PR TITLE
Make namespace default in rendered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ render:
 		dir=rendered/manifests/"$$i-only"; \
 		mkdir -p "$$dir"; \
 		helm template \
+			--namespace default \
 			--values rendered/values.yaml \
 			--set metricsEnabled=false,tracesEnabled=false,logsEnabled=false,$${i}Enabled=true \
 			--output-dir "$$dir" default helm-charts/splunk-otel-collector; \
@@ -16,7 +17,7 @@ render:
 	# All telemetry types but no gateway, only agent.
 	dir=rendered/manifests/agent-only; \
 	mkdir -p "$$dir"; \
-	helm template --values rendered/values.yaml --output-dir "$$dir" \
+	helm template --namespace default --values rendered/values.yaml --output-dir "$$dir" \
 		default helm-charts/splunk-otel-collector; \
 	mv "$$dir"/splunk-otel-collector/templates/* "$$dir"; \
 	rm -rf "$$dir"/splunk-otel-collector
@@ -24,7 +25,7 @@ render:
 	# XXX: Disable for now, reenable on otel-logs branch.
 	# # All telemetry types but no agent, only gateway.
 	# mkdir -p rendered/manifests/gateway-only
-	# helm template --values rendered/values.yaml --output-dir rendered/manifests/gateway-only \
+	# helm template --namespace default --values rendered/values.yaml --output-dir rendered/manifests/gateway-only \
 	# 	--set otelAgent.enabled=false,otelCollector.enabled=true,otelK8sClusterReceiver.enabled=false,fluentd.enabled=false \
 	# 	default helm-charts/splunk-otel-collector
 	# mv rendered/manifests/gateway-only/splunk-otel-collector/templates/* rendered/manifests/gateway-only


### PR DESCRIPTION
The namespace might otherwise be picked up from current kubectl context.
