### PR TITLE
Remove host.name from resource processor

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -137,9 +137,6 @@ processors:
     # General resource attributes that apply to all telemetry passing through the agent.
     attributes:
       - action: insert
-        key: host.name
-        value: "${K8S_NODE_NAME}"
-      - action: insert
         key: k8s.node.name
         value: "${K8S_NODE_NAME}"
       - action: insert

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -45,9 +45,6 @@ data:
       resource:
         attributes:
         - action: insert
-          key: host.name
-          value: ${K8S_NODE_NAME}
-        - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
         - action: insert

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 4b685bb298c3de62c802e617fac44e4d4e3dbdcdcfb4126592805beb4b150051
+        checksum/config: d59f660e518e43acb6131f5a3ea32eab7407ce093d9f06f47c82a6782f4fa662
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -45,9 +45,6 @@ data:
       resource:
         attributes:
         - action: insert
-          key: host.name
-          value: ${K8S_NODE_NAME}
-        - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
         - action: insert

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e1818655d603bf7a50e707fd6bbf75290a990cfe1c63010015f65d87094549e9
+        checksum/config: 2e1a4082dddbe7755eb3d8b35d8f6e7b58cb06ef1b7d72344cf2df31d4a04cdd
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -45,9 +45,6 @@ data:
       resource:
         attributes:
         - action: insert
-          key: host.name
-          value: ${K8S_NODE_NAME}
-        - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
         - action: insert

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e1818655d603bf7a50e707fd6bbf75290a990cfe1c63010015f65d87094549e9
+        checksum/config: 2e1a4082dddbe7755eb3d8b35d8f6e7b58cb06ef1b7d72344cf2df31d4a04cdd
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
This is already set by the resourcedetection processor using the
system detection. No need to duplicate effort here.