### PR TITLE
Fix container runtime detection when metrics collection disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## [0.26.4] - 2021-06-09
+
+### Fixed
+
+- Fix container runtime detection when metrics pipeline disabled (#161)
+
 ## [0.26.3] - 2021-06-08
 
 - Add an option to add extra labels to pods (#158)

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.26.3
+version: 0.26.4
 description: Splunk OpenTelemetry Connector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/ci/logs-only-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/logs-only-values.yaml
@@ -1,0 +1,6 @@
+clusterName: fake-cluster
+splunkRealm: fake-realm
+splunkAccessToken: fake-token
+
+tracesEnabled: false
+metricsEnabled: false

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
           command: [ "sh", "-c"]
           args:
             - if [ -z "${LOG_FORMAT_TYPE}" ]; then
-                if [ "$(ls /hostfs/var/lib/docker/containers/*/*json.log 2>/dev/null | wc -l)" != "0" ]; then
+                if [ "$(ls {{ .Values.fluentd.config.containers.pathDest }}/*/*json.log 2>/dev/null | wc -l)" != "0" ]; then
                   export LOG_FORMAT_TYPE=json;
                 else
                   export LOG_FORMAT_TYPE=cri;
@@ -69,10 +69,9 @@ spec:
             - name: LOG_FORMAT_TYPE
               value: "{{ .Values.fluentd.config.containers.logFormatType }}"
           volumeMounts:
-            - mountPath: /hostfs
-              name: hostfs
+            - name: varlogdest
+              mountPath: {{ .Values.fluentd.config.containers.pathDest }}
               readOnly: true
-              mountPropagation: HostToContainer
             - name: fluentd-config
               mountPath: /fluentd/etc
             - name: fluentd-config-common

--- a/rendered/manifests/agent-only/clusterRole.yaml
+++ b/rendered/manifests/agent-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/agent-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/agent-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/agent-only/configmap-fluentd-cri.yaml
+++ b/rendered/manifests/agent-only/configmap-fluentd-cri.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd-cri
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-fluentd-json.yaml
+++ b/rendered/manifests/agent-only/configmap-fluentd-json.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-fluentd.yaml
+++ b/rendered/manifests/agent-only/configmap-fluentd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
     engine: fluentd
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: eb56739e0199ced217a14fcc02eada931f4d2adeabd2ef480c6ecbb4094446fa
+        checksum/config: 6ddcbb95554e7d324790a2c8084e833334368d2003d174f428a7cb492e4940b3
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -38,7 +38,7 @@ spec:
           command: [ "sh", "-c"]
           args:
             - if [ -z "${LOG_FORMAT_TYPE}" ]; then
-                if [ "$(ls /hostfs/var/lib/docker/containers/*/*json.log 2>/dev/null | wc -l)" != "0" ]; then
+                if [ "$(ls /var/lib/docker/containers/*/*json.log 2>/dev/null | wc -l)" != "0" ]; then
                   export LOG_FORMAT_TYPE=json;
                 else
                   export LOG_FORMAT_TYPE=cri;
@@ -49,10 +49,9 @@ spec:
             - name: LOG_FORMAT_TYPE
               value: ""
           volumeMounts:
-            - mountPath: /hostfs
-              name: hostfs
+            - name: varlogdest
+              mountPath: /var/lib/docker/containers
               readOnly: true
-              mountPropagation: HostToContainer
             - name: fluentd-config
               mountPath: /fluentd/etc
             - name: fluentd-config-common

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 spec:
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b5c932e6089b74c55906c15def7f2dfada67923661e8ec9bd4d072d4c15f6179
+        checksum/config: 720b87f36e82118d3038288a7cb906967b7f199f4f6bebe429fb6ec7311ed12f
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:

--- a/rendered/manifests/agent-only/secret.yaml
+++ b/rendered/manifests/agent-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/agent-only/serviceAccount.yaml
+++ b/rendered/manifests/agent-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm

--- a/rendered/manifests/gateway-only/clusterRole.yaml
+++ b/rendered/manifests/gateway-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/gateway-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/gateway-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 spec:
@@ -24,7 +24,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 1b6c4cefe0cfc709a06f7f57c4aa4bbc19af85fa9685645e3f6ec6be94f9aa2e
+        checksum/config: 684037bd096a49fffb5644b90d2160ad48d0773e6268dc856b1d2b6b4110c851
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:

--- a/rendered/manifests/gateway-only/secret.yaml
+++ b/rendered/manifests/gateway-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/gateway-only/service.yaml
+++ b/rendered/manifests/gateway-only/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 spec:

--- a/rendered/manifests/gateway-only/serviceAccount.yaml
+++ b/rendered/manifests/gateway-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm

--- a/rendered/manifests/logs-only/clusterRole.yaml
+++ b/rendered/manifests/logs-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/logs-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/logs-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd-cri
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd-json.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-json.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
     engine: fluentd
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d520f6aa9656afbcc9845cfdb59515beaf9b8d1f05611ce774f30e5c77d9bfaa
+        checksum/config: 21bc6edfc4ea6c41d9b45d4fd84293b8a5fe5f81c8eaa72fe2828380e374ef6d
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -38,7 +38,7 @@ spec:
           command: [ "sh", "-c"]
           args:
             - if [ -z "${LOG_FORMAT_TYPE}" ]; then
-                if [ "$(ls /hostfs/var/lib/docker/containers/*/*json.log 2>/dev/null | wc -l)" != "0" ]; then
+                if [ "$(ls /var/lib/docker/containers/*/*json.log 2>/dev/null | wc -l)" != "0" ]; then
                   export LOG_FORMAT_TYPE=json;
                 else
                   export LOG_FORMAT_TYPE=cri;
@@ -49,10 +49,9 @@ spec:
             - name: LOG_FORMAT_TYPE
               value: ""
           volumeMounts:
-            - mountPath: /hostfs
-              name: hostfs
+            - name: varlogdest
+              mountPath: /var/lib/docker/containers
               readOnly: true
-              mountPropagation: HostToContainer
             - name: fluentd-config
               mountPath: /fluentd/etc
             - name: fluentd-config-common

--- a/rendered/manifests/logs-only/secret.yaml
+++ b/rendered/manifests/logs-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/logs-only/serviceAccount.yaml
+++ b/rendered/manifests/logs-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm

--- a/rendered/manifests/metrics-only/clusterRole.yaml
+++ b/rendered/manifests/metrics-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/metrics-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/metrics-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 spec:
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6873a6aeb63939e2e1a8df02d525d9419658a3504515c9784f1fcae9df1c432e
+        checksum/config: fdb487762ae8e8896f01bcd8f616f2acf77b5d9cb391f89c957d46fc70d7b30b
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 spec:
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b5c932e6089b74c55906c15def7f2dfada67923661e8ec9bd4d072d4c15f6179
+        checksum/config: 720b87f36e82118d3038288a7cb906967b7f199f4f6bebe429fb6ec7311ed12f
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:

--- a/rendered/manifests/metrics-only/secret.yaml
+++ b/rendered/manifests/metrics-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/metrics-only/serviceAccount.yaml
+++ b/rendered/manifests/metrics-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm

--- a/rendered/manifests/traces-only/clusterRole.yaml
+++ b/rendered/manifests/traces-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/traces-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/traces-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 spec:
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7d5ee48216ed1eac14ff79ff33ba219af68a94b364a9e18136e7f8dc363afef3
+        checksum/config: ec997be5174ab3e23afa43cb2a343db5f58691b6eef481673c93ae14d74f7c6a
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/traces-only/secret.yaml
+++ b/rendered/manifests/traces-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/traces-only/serviceAccount.yaml
+++ b/rendered/manifests/traces-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.3
+    chart: splunk-otel-collector-0.26.4
     release: default
     heritage: Helm


### PR DESCRIPTION
Don't use hostfs volume for container runtime detection, since it's needed for logs only and hostfs volume not created for logs pipeline.