### PR TITLE
Make auto-detection of prometheus metrics disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## [0.27.0] - 2021-06-15
+
+### Changed
+
+- BREAKING CHANGE: Auto-detection of prometheus metrics is disabled by default (#163). See
+  [Upgrade guideline](https://github.com/signalfx/splunk-otel-collector-chart#0264-to-0270)
+
 ## [0.26.4] - 2021-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ $ helm install my-splunk-otel-collector \
 
 The [rendered directory](rendered) contains pre-rendered Kubernetes resource manifests.
 
+## Upgrade guidelines
+
+### 0.26.4 to 0.27.0
+
+[#163 Auto-detection of prometheus metrics is disabled by default](https://github.com/signalfx/splunk-otel-collector-chart/pull/163):
+If you rely on automatic prometheus endpoints detection to scrape prometheus
+metrics from pods in your k8s cluster, make sure to add this configuration to
+your values.yaml:
+
+```
+autodetect:
+  prometheus: true
+```
+
 ## License
 
 [Apache Software License version 2.0](LICENSE).

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.26.4
+version: 0.27.0
 description: Splunk OpenTelemetry Connector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -65,8 +65,21 @@ logsEnabled: true
 
 # environment: production
 
-# Configuration for additional metadata that will be added to all the telemetry
-# as extra attributes.
+################################################################################
+# Optional: Automatic detection of additional metric sources.
+# Set autodetect.prometheus=true if you want the otel-collector agent to scrape
+# prometheus metrics from pods that have prometheus-style annotations like
+# "prometheus.io/scrape"
+################################################################################
+
+autodetect:
+  prometheus: false
+
+################################################################################
+# Optional: Configuration for additional metadata that will be added to all the
+# telemetry as extra attributes.
+################################################################################
+
 extraAttributes:
 
   # Labels that will be collected from k8s pods (in case they are set)

--- a/rendered/manifests/agent-only/clusterRole.yaml
+++ b/rendered/manifests/agent-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/agent-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/agent-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/agent-only/configmap-fluentd-cri.yaml
+++ b/rendered/manifests/agent-only/configmap-fluentd-cri.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd-cri
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-fluentd-json.yaml
+++ b/rendered/manifests/agent-only/configmap-fluentd-json.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-fluentd.yaml
+++ b/rendered/manifests/agent-only/configmap-fluentd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -26,6 +26,9 @@ data:
         token: ${SPLUNK_ACCESS_TOKEN}
     extensions:
       health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
       zpages: null
     processors:
       batch: null
@@ -111,6 +114,10 @@ data:
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8888
+      receiver_creator:
+        receivers: null
+        watch_observers:
+        - k8s_observer
       sapm:
         endpoint: 0.0.0.0:7276
       signalfx:
@@ -123,6 +130,7 @@ data:
     service:
       extensions:
       - health_check
+      - k8s_observer
       - zpages
       pipelines:
         logs:
@@ -146,6 +154,7 @@ data:
           receivers:
           - hostmetrics
           - kubeletstats
+          - receiver_creator
           - signalfx
         metrics/agent:
           exporters:

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:
@@ -26,9 +26,6 @@ data:
         token: ${SPLUNK_ACCESS_TOKEN}
     extensions:
       health_check: null
-      k8s_observer:
-        auth_type: serviceAccount
-        node: ${K8S_NODE_NAME}
       zpages: null
     processors:
       batch: null
@@ -114,15 +111,6 @@ data:
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8888
-      receiver_creator:
-        receivers:
-          prometheus_simple:
-            config:
-              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
-              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
-            rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
-        watch_observers:
-        - k8s_observer
       sapm:
         endpoint: 0.0.0.0:7276
       signalfx:
@@ -135,7 +123,6 @@ data:
     service:
       extensions:
       - health_check
-      - k8s_observer
       - zpages
       pipelines:
         logs:
@@ -159,7 +146,6 @@ data:
           receivers:
           - hostmetrics
           - kubeletstats
-          - receiver_creator
           - signalfx
         metrics/agent:
           exporters:

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6ddcbb95554e7d324790a2c8084e833334368d2003d174f428a7cb492e4940b3
+        checksum/config: 6d19d8fd42cc37704e164b01dc5cb01cc64188617772879310051eb6476b43ff
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6d19d8fd42cc37704e164b01dc5cb01cc64188617772879310051eb6476b43ff
+        checksum/config: 31d234b57a23c70a286e04dc535276afc4e1bc1d41e99778d1d5ff16d1584800
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 spec:
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 720b87f36e82118d3038288a7cb906967b7f199f4f6bebe429fb6ec7311ed12f
+        checksum/config: aae6f77ea8e569efa22900b2d41320d11939ff70ab1abab0b9e347f25aedcfbc
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:

--- a/rendered/manifests/agent-only/secret.yaml
+++ b/rendered/manifests/agent-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/agent-only/serviceAccount.yaml
+++ b/rendered/manifests/agent-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm

--- a/rendered/manifests/gateway-only/clusterRole.yaml
+++ b/rendered/manifests/gateway-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/gateway-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/gateway-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 spec:
@@ -24,7 +24,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 684037bd096a49fffb5644b90d2160ad48d0773e6268dc856b1d2b6b4110c851
+        checksum/config: 7cb28f7b6e64bfefab003794453d1f67813eb81e6eb4dfe88be170bf14c6b100
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:

--- a/rendered/manifests/gateway-only/secret.yaml
+++ b/rendered/manifests/gateway-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/gateway-only/service.yaml
+++ b/rendered/manifests/gateway-only/service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 spec:

--- a/rendered/manifests/gateway-only/serviceAccount.yaml
+++ b/rendered/manifests/gateway-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm

--- a/rendered/manifests/logs-only/clusterRole.yaml
+++ b/rendered/manifests/logs-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/logs-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/logs-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd-cri
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd-json.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-json.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:
@@ -23,9 +23,6 @@ data:
         token: ${SPLUNK_ACCESS_TOKEN}
     extensions:
       health_check: null
-      k8s_observer:
-        auth_type: serviceAccount
-        node: ${K8S_NODE_NAME}
       zpages: null
     processors:
       batch: null
@@ -87,7 +84,6 @@ data:
     service:
       extensions:
       - health_check
-      - k8s_observer
       - zpages
       pipelines:
         logs:

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -23,6 +23,9 @@ data:
         token: ${SPLUNK_ACCESS_TOKEN}
     extensions:
       health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
       zpages: null
     processors:
       batch: null
@@ -84,6 +87,7 @@ data:
     service:
       extensions:
       - health_check
+      - k8s_observer
       - zpages
       pipelines:
         logs:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 24960c4b0b6581b99304342552af05a89cbdbe6e52e7cf5ef8d02cf524b7b86e
+        checksum/config: 6822bfb810b0bf9d3bbe193397181b3564e866e47ed03e1f2bcfb6f3ec058df5
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 21bc6edfc4ea6c41d9b45d4fd84293b8a5fe5f81c8eaa72fe2828380e374ef6d
+        checksum/config: 24960c4b0b6581b99304342552af05a89cbdbe6e52e7cf5ef8d02cf524b7b86e
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/logs-only/secret.yaml
+++ b/rendered/manifests/logs-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/logs-only/serviceAccount.yaml
+++ b/rendered/manifests/logs-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm

--- a/rendered/manifests/metrics-only/clusterRole.yaml
+++ b/rendered/manifests/metrics-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/metrics-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/metrics-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:
@@ -20,9 +20,6 @@ data:
         sync_host_metadata: true
     extensions:
       health_check: null
-      k8s_observer:
-        auth_type: serviceAccount
-        node: ${K8S_NODE_NAME}
       zpages: null
     processors:
       batch: null
@@ -100,21 +97,11 @@ data:
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8888
-      receiver_creator:
-        receivers:
-          prometheus_simple:
-            config:
-              endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
-              metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
-            rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
-        watch_observers:
-        - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
     service:
       extensions:
       - health_check
-      - k8s_observer
       - zpages
       pipelines:
         metrics:
@@ -128,7 +115,6 @@ data:
           receivers:
           - hostmetrics
           - kubeletstats
-          - receiver_creator
           - signalfx
         metrics/agent:
           exporters:

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -20,6 +20,9 @@ data:
         sync_host_metadata: true
     extensions:
       health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
       zpages: null
     processors:
       batch: null
@@ -97,11 +100,16 @@ data:
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8888
+      receiver_creator:
+        receivers: null
+        watch_observers:
+        - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
     service:
       extensions:
       - health_check
+      - k8s_observer
       - zpages
       pipelines:
         metrics:
@@ -115,6 +123,7 @@ data:
           receivers:
           - hostmetrics
           - kubeletstats
+          - receiver_creator
           - signalfx
         metrics/agent:
           exporters:

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 spec:
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: fdb487762ae8e8896f01bcd8f616f2acf77b5d9cb391f89c957d46fc70d7b30b
+        checksum/config: bc1db25de9a252b6c733d462f587db1f4b1e49632f89f133f8ba446b8ab45eaf
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: bc1db25de9a252b6c733d462f587db1f4b1e49632f89f133f8ba446b8ab45eaf
+        checksum/config: 7cfef6f3f744f02aa3f20cf6e238fd47f5609843a7dcceeb3c1be06709f5d482
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 spec:
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 720b87f36e82118d3038288a7cb906967b7f199f4f6bebe429fb6ec7311ed12f
+        checksum/config: aae6f77ea8e569efa22900b2d41320d11939ff70ab1abab0b9e347f25aedcfbc
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:

--- a/rendered/manifests/metrics-only/secret.yaml
+++ b/rendered/manifests/metrics-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/metrics-only/serviceAccount.yaml
+++ b/rendered/manifests/metrics-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm

--- a/rendered/manifests/traces-only/clusterRole.yaml
+++ b/rendered/manifests/traces-only/clusterRole.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/traces-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/traces-only/clusterRoleBinding.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 data:
@@ -23,9 +23,6 @@ data:
         sync_host_metadata: true
     extensions:
       health_check: null
-      k8s_observer:
-        auth_type: serviceAccount
-        node: ${K8S_NODE_NAME}
       zpages: null
     processors:
       batch: null
@@ -98,7 +95,6 @@ data:
     service:
       extensions:
       - health_check
-      - k8s_observer
       - zpages
       pipelines:
         metrics/agent:

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -23,6 +23,9 @@ data:
         sync_host_metadata: true
     extensions:
       health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
       zpages: null
     processors:
       batch: null
@@ -95,6 +98,7 @@ data:
     service:
       extensions:
       - health_check
+      - k8s_observer
       - zpages
       pipelines:
         metrics/agent:

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 spec:
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ec997be5174ab3e23afa43cb2a343db5f58691b6eef481673c93ae14d74f7c6a
+        checksum/config: 25d166bb762475d70e0b0564ac4d01a0ff4c0ebf7a1b5f42e538035fc925270a
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 25d166bb762475d70e0b0564ac4d01a0ff4c0ebf7a1b5f42e538035fc925270a
+        checksum/config: 18a377754654e0b1a32795d76240ece59f2515e0a798521230b8e8dd2325882c
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/traces-only/secret.yaml
+++ b/rendered/manifests/traces-only/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/traces-only/serviceAccount.yaml
+++ b/rendered/manifests/traces-only/serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.26.4
+    chart: splunk-otel-collector-0.27.0
     release: default
     heritage: Helm


### PR DESCRIPTION
Add an additional "autodetect.prometheus" flag to enable automatic prometheus endpoint detection and make it disabled by default.