### PR TITLE
Remove SAPM receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- BREAKING: Remove SAPM receiver from default config (#168)
+
 ## [0.28.1] - 2021-06-18
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -34,8 +34,6 @@ otlp:
       endpoint: 0.0.0.0:55681
 
 {{- if .Values.tracesEnabled }}
-sapm:
-  endpoint: 0.0.0.0:7276
 jaeger:
   protocols:
     thrift_http:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -86,7 +86,7 @@ service:
     {{- if .Values.tracesEnabled }}
     # default traces pipeline
     traces:
-      receivers: [otlp, jaeger, zipkin, sapm]
+      receivers: [otlp, jaeger, zipkin]
       processors:
         - memory_limiter
         - batch

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -613,10 +613,6 @@ otelCollector:
       containerPort: 9411
       protocol: TCP
       enabled_for: [traces]
-    sapm:
-      containerPort: 7276
-      protocol: TCP
-      enabled_for: [traces]
     signalfx:
       containerPort: 9943
       protocol: TCP

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -118,8 +118,6 @@ data:
         receivers: null
         watch_observers:
         - k8s_observer
-      sapm:
-        endpoint: 0.0.0.0:7276
       signalfx:
         endpoint: 0.0.0.0:9943
       smartagent/signalfx-forwarder:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7f0040fa217f3a2bec3ec9550abfd54f12978286dc3fd2aa62e9eed6e8afd87e
+        checksum/config: 56f38e3159a073143bf6ba9c93602ce9716b0c58a17f157a325770221cdb4b4d
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -67,8 +67,6 @@ data:
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8888
-      sapm:
-        endpoint: 0.0.0.0:7276
       signalfx:
         access_token_passthrough: true
         endpoint: 0.0.0.0:9943
@@ -119,4 +117,3 @@ data:
           - otlp
           - jaeger
           - zipkin
-          - sapm

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: cca2d7d060704d5d299a98e7576b24eef7a2d42be4e90fd8245e65158c150d82
+        checksum/config: 734c3b038fdc99927b69659708c156d506652fc2b450bfb93378ef20555c2f18
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:
@@ -64,9 +64,6 @@ spec:
           protocol: TCP
         - name: otlp
           containerPort: 4317
-          protocol: TCP
-        - name: sapm
-          containerPort: 7276
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/rendered/manifests/gateway-only/service.yaml
+++ b/rendered/manifests/gateway-only/service.yaml
@@ -29,10 +29,6 @@ spec:
     port: 4317
     targetPort: otlp
     protocol: TCP
-  - name: sapm
-    port: 7276
-    targetPort: sapm
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -88,8 +88,6 @@ data:
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8888
-      sapm:
-        endpoint: 0.0.0.0:7276
       smartagent/signalfx-forwarder:
         listenAddress: 0.0.0.0:9080
         type: signalfx-forwarder

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d283f5402c37424e6cf4e8ea9f86b43d393541e8905fd547292a1f6ea00a2fbc
+        checksum/config: 119df5d65873e60ea936fde1c9a83e4fc7eb7126f4922cc1e04b2d0900fa2318
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
This is a complimenting change to splunk-otel-collector repo. SAPM
receiver is not used by anything today so remove it.