### PR TITLE
Upgrade helm/kind-action

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -33,7 +33,7 @@ jobs:
         run: ct lint --config=ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         # Only build a kind cluster if there are chart changes to test.
         if: steps.list-changed.outputs.changed == 'true'
 


### PR DESCRIPTION
Old version of kind started timing out on cluster creation. The new one should be good.