### PR TITLE
Add missing attributes to self-scraping prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- All missing attributes are added to prometheus metrics reported
+  by gateway and k8s-cluster-receiver collector deployments (#170)
+
 ## [0.29.1] - 2021-07-08
 
 ### Fixed

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -44,3 +44,34 @@ zipkin:
   endpoint: 0.0.0.0:9411
 {{- end }}
 {{- end }}
+
+{{/*
+Common config for resourcedetection processor
+*/}}
+{{- define "splunk-otel-collector.resourceDetectionProcessor" -}}
+# Resource detection processor picks attributes from host environment.
+# https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+resourcedetection:
+  detectors:
+    - system
+    # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
+    # before it gets set later by the cloud provider detector.
+    - env
+    {{- if eq .Values.distro "gke" }}
+    - gke
+    {{- else if eq .Values.distro "eks" }}
+    - eks
+    {{- else if eq .Values.distro "aks" }}
+    - aks
+    {{- end }}
+    {{- if eq .Values.provider "gcp" }}
+    - gce
+    {{- else if eq .Values.provider "aws" }}
+    - ec2
+    {{- else if eq .Values.provider "azure" }}
+    - azure
+    {{- end }}
+  # Don't override existing resource attributes to maintain identification of data sources
+  override: false
+  timeout: 10s
+{{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -119,35 +119,11 @@ processors:
         {{- end }}
       {{- end }}
 
-  # Resource detection processor picks attributes from host environment.
-  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
-  resourcedetection:
-    detectors:
-      - system
-      # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
-      # before it gets set later by the cloud provider detector.
-      - env
-      {{- if eq .Values.distro "gke" }}
-      - gke
-      {{- else if eq .Values.distro "eks" }}
-      - eks
-      {{- else if eq .Values.distro "aks" }}
-      - aks
-      {{- end }}
-      {{- if eq .Values.provider "gcp" }}
-      - gce
-      {{- else if eq .Values.provider "aws" }}
-      - ec2
-      {{- else if eq .Values.provider "azure" }}
-      - azure
-      {{- end }}
-    # Don't override existing resource attributes to maintain identification of data sources
-    override: false
-    timeout: 10s
-
   {{- include "splunk-otel-collector.otelMemoryLimiterConfig" .Values.otelAgent | nindent 2 }}
 
   batch:
+
+  {{- include "splunk-otel-collector.resourceDetectionProcessor" . | nindent 2 }}
 
   resource:
     # General resource attributes that apply to all telemetry passing through the agent.

--- a/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
@@ -78,6 +78,18 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SPLUNK_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
@@ -78,6 +78,18 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SPLUNK_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -21,13 +21,6 @@ data:
       health_check: null
     processors:
       batch: null
-      k8s_tagger:
-        filter:
-          labels:
-            key: component
-            op: equals
-            value: otel-k8s-cluster-receiver
-          node_from_env_var: K8S_NODE_NAME
       memory_limiter:
         ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
         check_interval: 5s
@@ -43,12 +36,32 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_collector_k8s:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resourcedetection:
+        detectors:
+        - system
+        - env
+        override: false
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-      prometheus:
+      prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
           - job_name: otel-k8s-cluster-receiver
@@ -67,6 +80,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_collector_k8s
+          - resourcedetection
           receivers:
-          - prometheus
-          - k8s_cluster
+          - prometheus/k8s_cluster_receiver

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9be884aefa99593fd91546948340bf6a039d0b9bd4e5389da31226179262af90
+        checksum/config: 2d65a1fc80af6a7020e35ebf6390a981f99ea87c066848845da721513ab4784b
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:
@@ -47,6 +47,18 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SPLUNK_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -46,6 +46,26 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_collector_k8s:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resourcedetection:
+        detectors:
+        - system
+        - env
+        override: false
+        timeout: 10s
     receivers:
       jaeger:
         protocols:
@@ -59,7 +79,7 @@ data:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:55681
-      prometheus:
+      prometheus/collector:
         config:
           scrape_configs:
           - job_name: otel-collector
@@ -103,8 +123,18 @@ data:
           - resource/add_cluster_name
           receivers:
           - otlp
-          - prometheus
           - signalfx
+        metrics/collector:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_cluster_name
+          - resource/add_collector_k8s
+          - resourcedetection
+          receivers:
+          - prometheus/collector
         traces:
           exporters:
           - sapm

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: c62bfb843e168c5ae848390a1f6de78823d8ea4259dc5817cd16c50b305267cf
+        checksum/config: 23fb8e3ca7ae878920c7c82e5c4d451b22614848a3f65293747c77ac46127c1e
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:
@@ -47,6 +47,18 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SPLUNK_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -21,13 +21,6 @@ data:
       health_check: null
     processors:
       batch: null
-      k8s_tagger:
-        filter:
-          labels:
-            key: component
-            op: equals
-            value: otel-k8s-cluster-receiver
-          node_from_env_var: K8S_NODE_NAME
       memory_limiter:
         ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
         check_interval: 5s
@@ -43,12 +36,32 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_collector_k8s:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resourcedetection:
+        detectors:
+        - system
+        - env
+        override: false
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-      prometheus:
+      prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
           - job_name: otel-k8s-cluster-receiver
@@ -67,6 +80,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_collector_k8s
+          - resourcedetection
           receivers:
-          - prometheus
-          - k8s_cluster
+          - prometheus/k8s_cluster_receiver

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9be884aefa99593fd91546948340bf6a039d0b9bd4e5389da31226179262af90
+        checksum/config: 2d65a1fc80af6a7020e35ebf6390a981f99ea87c066848845da721513ab4784b
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:
@@ -47,6 +47,18 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SPLUNK_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Prometheus metrics reported by gateway and k8s-cluster-receiver collector deployments are missing k8s and host related attributes. This commit is to make sure that all the self-scraping prometheus metrics have all the required attributes.