### PR TITLE
Adjust configuration for istio environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - BREAKING: Remove SAPM receiver from default config (#168)
 
+### Added
+
+- Add Istio specific configurations (#171)
+
 ## [0.28.1] - 2021-06-18
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -52,10 +52,15 @@ receivers:
   receiver_creator:
     watch_observers: [k8s_observer]
     receivers:
-      {{- if .Values.autodetect.prometheus }}
+      {{- if or .Values.autodetect.prometheus .Values.autodetect.istio }}
       prometheus_simple:
+        {{- if .Values.autodetect.prometheus }}
         # Enable prometheus scraping for pods with standard prometheus annotations
         rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+        {{- else }}
+        # Enable prometheus scraping for istio pods only
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && "istio.io/rev" in labels
+        {{- end }}
         config:
           metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
           endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -210,6 +210,11 @@ data:
           k8s.pod.labels.{{ . }} ${record.dig("kubernetes","labels","{{ . }}")}
           {{- end }}
 
+          {{- if .Values.autodetect.istio }}
+          # Automaically compose service.name attribute the same way as done in istio for traces
+          service.name ${record.dig("kubernetes","labels","app")}.${record.dig("kubernetes","namespace_name")}
+          {{- end }}
+
           denylist ${record.dig("kubernetes", "annotations", "splunk.com/exclude") ? record.dig("kubernetes", "annotations", "splunk.com/exclude") : record.dig("kubernetes", "namespace_annotations", "splunk.com/exclude") ? (record["kubernetes"]["namespace_annotations"]["splunk.com/exclude"]) : ("false")}
         </record>
       </filter>

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -35,6 +35,9 @@ spec:
         {{- if .Values.otelAgent.podAnnotations }}
         {{- toYaml .Values.otelAgent.podAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.autodetect.istio }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
@@ -34,6 +34,9 @@ spec:
         {{- if .Values.otelCollector.podAnnotations }}
         {{- toYaml .Values.otelCollector.podAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.autodetect.istio }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
     spec:
       serviceAccountName: {{ template "splunk-otel-collector.serviceAccountName" . }}
       {{- if .Values.otelCollector.nodeSelector }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
@@ -34,6 +34,9 @@ spec:
         {{- if .Values.otelK8sClusterReceiver.podAnnotations }}
         {{- toYaml .Values.otelK8sClusterReceiver.podAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.autodetect.istio }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
     spec:
       serviceAccountName: {{ template "splunk-otel-collector.serviceAccountName" . }}
       {{- if .Values.otelK8sClusterReceiver.nodeSelector }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -69,11 +69,13 @@ logsEnabled: true
 # Optional: Automatic detection of additional metric sources.
 # Set autodetect.prometheus=true if you want the otel-collector agent to scrape
 # prometheus metrics from pods that have prometheus-style annotations like
-# "prometheus.io/scrape"
+# "prometheus.io/scrape".
+# Set autodetect.istio=true in istio environment.
 ################################################################################
 
 autodetect:
   prometheus: false
+  istio: false
 
 ################################################################################
 # Optional: Configuration for additional metadata that will be added to all the


### PR DESCRIPTION
Add new config option autodetect.istio, which, if enabled, adds few things to the default configuration:
- Add `service.name` attribute to logs that are composed the same way as done for traces in istio. This enables APM <-> Log Observer correlation OOTB.
- Add automatic istio metrics scraping that are exposed via prometheus endpoints.
- Add `sidecar.istio.io/inject: "false"` annotation to the otel-collector pods to avoid infinite self-tracing.