### PR TITLE
Switch port for internal metrics from 8888 to 8889

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Change internal metrics port from 8888 to 8889 (#172)
+
 ## [0.28.2] - 2021-07-07
 
 ### Added

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -27,7 +27,7 @@ receivers:
         scrape_interval: 10s
         static_configs:
         - targets:
-          - "${K8S_POD_IP}:8888"
+          - "${K8S_POD_IP}:8889"
           # Fluend metrics collection disabled by default
           # - "${K8S_POD_IP}:24231"
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -21,7 +21,7 @@ receivers:
       - job_name: 'otel-collector'
         scrape_interval: 10s
         static_configs:
-        - targets: ["${K8S_POD_IP}:8888"]
+        - targets: ["${K8S_POD_IP}:8889"]
   signalfx:
     endpoint: 0.0.0.0:9943
     access_token_passthrough: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -14,7 +14,7 @@ receivers:
       - job_name: 'otel-k8s-cluster-receiver'
         scrape_interval: 10s
         static_configs:
-        - targets: ["${K8S_POD_IP}:8888"]
+        - targets: ["${K8S_POD_IP}:8889"]
   k8s_cluster:
     auth_type: serviceAccount
     metadata_exporters: [signalfx]

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         {{- range .Values.otelAgent.extraArgs }}
         - {{ . }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         {{- range .Values.otelCollector.extraArgs }}
         - {{ . }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
@@ -60,7 +60,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         {{- range .Values.otelK8sClusterReceiver.extraArgs }}
         - {{ . }}
         {{- end }}

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -113,7 +113,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8888
+              - ${K8S_POD_IP}:8889
       receiver_creator:
         receivers: null
         watch_observers:

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -55,7 +55,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8888
+              - ${K8S_POD_IP}:8889
     service:
       extensions:
       - health_check

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 163d24e194fdb37e664c8e6b5c52da012bc222a7b0f46a989e74aacf396fb997
+        checksum/config: 082df91116bf2b839a76c4f77051d9e642fa96c2407882936e5d6a567e16ca0c
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -107,7 +107,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         ports:
         - name: fluentforward
           containerPort: 8006

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9aa76e4a0195af8f49772eb3cf50bad809cb3b316a285e4bbcafbb52bd951194
+        checksum/config: 2b66c3f9e6bdc39bbca429096b3b6a56be8fa5c2d99bdc7d43df96213a871c78
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:
@@ -32,7 +32,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         image: quay.io/signalfx/splunk-otel-collector:0.28.1
         imagePullPolicy: IfNotPresent
         env:

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -66,7 +66,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8888
+              - ${K8S_POD_IP}:8889
       signalfx:
         access_token_passthrough: true
         endpoint: 0.0.0.0:9943

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: dda51a931806288b38073216eba2a1472c16f28279f4b8b7b8b9a98556ff3eea
+        checksum/config: 76ac441140e91c848290557e0b9db5b5cb3aa58e2c9062aadd4f407f49417b86
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:
@@ -32,7 +32,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         image: quay.io/signalfx/splunk-otel-collector:0.28.1
         imagePullPolicy: IfNotPresent
         env:

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -83,7 +83,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8888
+              - ${K8S_POD_IP}:8889
     service:
       extensions:
       - health_check

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: fe5a6b9570d81623b8890a819bb4cea087632880a0b5518d41bb4f147ed7d31c
+        checksum/config: 4e7580a9960f1908803f0b876094c8260d3fb12bab41e1cec41b2f797eff11cc
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -107,7 +107,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         ports:
         - name: fluentforward
           containerPort: 8006

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -99,7 +99,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8888
+              - ${K8S_POD_IP}:8889
       receiver_creator:
         receivers: null
         watch_observers:

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -55,7 +55,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8888
+              - ${K8S_POD_IP}:8889
     service:
       extensions:
       - health_check

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 2bf47a8a1f16ac2d7c8629c62f2c01a5b3274b69102377b05bef52789a659fae
+        checksum/config: 48271af374ef42b3f204848a7560fe2e2dfeb3af6a0c4846daefe64c42587bd4
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -36,7 +36,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         ports:
         - name: otlp
           containerPort: 4317

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9aa76e4a0195af8f49772eb3cf50bad809cb3b316a285e4bbcafbb52bd951194
+        checksum/config: 2b66c3f9e6bdc39bbca429096b3b6a56be8fa5c2d99bdc7d43df96213a871c78
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:
@@ -32,7 +32,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         image: quay.io/signalfx/splunk-otel-collector:0.28.1
         imagePullPolicy: IfNotPresent
         env:

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -87,7 +87,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8888
+              - ${K8S_POD_IP}:8889
       smartagent/signalfx-forwarder:
         listenAddress: 0.0.0.0:9080
         type: signalfx-forwarder

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5c9f829293fecaa315a656b6da361777818a29607e31fb6d02bc67db9a234b6e
+        checksum/config: a603fdc8a67dc462b424bcd6ff32f43d367ca79b88407e2edfde0479dce096e3
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -36,7 +36,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8888
+        - --metrics-addr=0.0.0.0:8889
         ports:
         - name: jaeger-grpc
           containerPort: 14250


### PR DESCRIPTION
GKE has their own otel-collector installed by default as agent with hostNetwork enabled and using the same default port "8888" for collector's metrics. We have to switch to another port to avoid conflicts in GKE.