### PR TITLE
Change source of "service.name" log attribute value in istio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Change source label for "service.name" logs attribute if istio enabled (#175)
 - Change internal metrics port from 8888 to 8889 (#172)
 
 ## [0.28.2] - 2021-07-07

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -212,7 +212,7 @@ data:
 
           {{- if .Values.autodetect.istio }}
           # Automaically compose service.name attribute the same way as done in istio for traces
-          service.name ${record.dig("kubernetes","labels","app")}.${record.dig("kubernetes","namespace_name")}
+          service.name ${record.dig("kubernetes","labels","service.istio.io/canonical-name")}.${record.dig("kubernetes","namespace_name")}
           {{- end }}
 
           denylist ${record.dig("kubernetes", "annotations", "splunk.com/exclude") ? record.dig("kubernetes", "annotations", "splunk.com/exclude") : record.dig("kubernetes", "namespace_annotations", "splunk.com/exclude") ? (record["kubernetes"]["namespace_annotations"]["splunk.com/exclude"]) : ("false")}


### PR DESCRIPTION
Use "service.istio.io/canonical-name" to get "service.name" log attribute in istio environment. It's automatically populated from "app" label and falls back to deployment/replicaset/pod names.