### PR TITLE
Fix k8s cluster receiver collector pipelines

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -85,7 +85,7 @@ service:
       exporters: [signalfx]
 
     # Pipeline for metrics collected about the collector pod itself.
-    metrics:
+    metrics/collector:
       receivers: [prometheus/k8s_cluster_receiver]
       processors:
         - memory_limiter

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -80,6 +80,15 @@ data:
           - memory_limiter
           - batch
           - resource
+          receivers:
+          - k8s_cluster
+        metrics/collector:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource
           - resource/add_collector_k8s
           - resourcedetection
           receivers:

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 92d7b33eb5df88128edbeb08989ac25b5bcc8ab8e0b376a6ee39789d211ea6cb
+        checksum/config: d7577c54dd69d75271908dd6dc8de17918edd2bfe4bce10afcde8186edc73a43
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -80,6 +80,15 @@ data:
           - memory_limiter
           - batch
           - resource
+          receivers:
+          - k8s_cluster
+        metrics/collector:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource
           - resource/add_collector_k8s
           - resourcedetection
           receivers:

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 92d7b33eb5df88128edbeb08989ac25b5bcc8ab8e0b376a6ee39789d211ea6cb
+        checksum/config: d7577c54dd69d75271908dd6dc8de17918edd2bfe4bce10afcde8186edc73a43
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:


### PR DESCRIPTION
Bug: pipeline names for k8s metrics and internal metrics are the same, which causes one of them disappear