### PR TITLE
Template pod affinity settings from the correct value

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       {{- if .Values.otelCollector.affinity }}
       affinity:
-        {{ toYaml .Values.otelCollector.tolerations | nindent 8 }}
+        {{- toYaml .Values.otelCollector.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.otelCollector.securityContext }}
       securityContext:

--- a/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       {{- if .Values.otelK8sClusterReceiver.affinity }}
       affinity:
-        {{ toYaml .Values.otelK8sClusterReceiver.tolerations | nindent 8 }}
+        {{- toYaml .Values.otelK8sClusterReceiver.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.otelK8sClusterReceiver.securityContext }}
       securityContext:


### PR DESCRIPTION
Pod affinity settings were erroneously reading from the tolerations value rather than the affinity value for both the collector and cluster receiver deployments. As a result, setting the affinity value would result in an affinity key being templated but with the contents of the tolerations value.

This fix ensures the correct value is read, and also adds a leading dash to the template function to prevent an erroneous newline from being added.