### PR TITLE
Adding create, list and watch configmap-permissions

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -23,6 +23,9 @@ rules:
   - get
   - update
   - patch
+  - create
+  - list
+  - watch
 {{- end }}
 - apiGroups:
   - ""


### PR DESCRIPTION
Description:
Adding create, list, and watch configmap-permissions
Ticket : [OTL-951](https://signalfuse.atlassian.net/browse/OTL-951)
During testing of kubernetes-events monitor, we found that configmaps required create, list, and watch permission.