### PR TITLE
Move k8s metadata enrichment from fluentd to otel-collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Move k8s metadata enrichment from fluentd to otel-collector (#191)
+- Move k8s metadata enrichment from fluentd to otel-collector (#192)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Move k8s metadata enrichment from fluentd to otel-collector (#191)
+
 ### Fixed
 
 - smartagent/kubernetes-events now works with `otelK8sClusterReceiver` deployment. (#187)

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -186,55 +186,35 @@ data:
       </match>
     </label>
     <label @SPLUNK>
-      # Enrich log with k8s metadata
+      # Extract k8s metadata from container logs source paths. Use original logs source
+      # "/var/log/containers/<k8s.pod.k8s>_<k8s.namespace.name>_<k8s.container.name>-<container.id>.log"
+      # first then check symlinks to the new k8s logs format
+      # "/var/log/pods/<k8s.namespace.name>_<k8s.pod.name>_<k8s.pod.uid>/<k8s.container.name>/<run_id>.log"
+      # to fetch "k8s.pod.uid" that will be used to get other k8s metadata by otel-collector from k8s API.
       <filter tail.containers.**>
-        @type kubernetes_metadata
-        annotation_match [ "^splunk\.com" ]
-        de_dot false
+        @type record_modifier
+        <record>
+          pods_source ${File.readlink(record['source'])}
+        </record>
       </filter>
       <filter tail.containers.**>
-        @type record_transformer
-        enable_ruby
-        <record>
-          # set the sourcetype from splunk.com/sourcetype pod annotation or set it to kube:container:CONTAINER_NAME
-          sourcetype ${record.dig("kubernetes", "annotations", "splunk.com/sourcetype") ? "kube:"+record.dig("kubernetes", "annotations", "splunk.com/sourcetype") : "kube:container:"+record.dig("kubernetes","container_name")}
-
-          k8s.container.name ${record.dig("kubernetes","container_name")}
-          k8s.namespace.name ${record.dig("kubernetes","namespace_name")}
-          k8s.pod.name ${record.dig("kubernetes","pod_name")}
-          container.id ${record.dig("docker","container_id")}
-          k8s.pod.uid ${record.dig("kubernetes","pod_id")}
-          container.image.name ${record.dig("kubernetes","container_image")}
-
-          {{- range .Values.extraAttributes.podLabels }}
-          k8s.pod.labels.{{ . }} ${record.dig("kubernetes","labels","{{ . }}")}
-          {{- end }}
-
-          denylist ${record.dig("kubernetes", "annotations", "splunk.com/exclude") ? record.dig("kubernetes", "annotations", "splunk.com/exclude") : record.dig("kubernetes", "namespace_annotations", "splunk.com/exclude") ? (record["kubernetes"]["namespace_annotations"]["splunk.com/exclude"]) : ("false")}
-        </record>
+        @type jq_transformer
+        jq '.record | . + (.source | capture("^/var/log/containers/(?<k8s.pod.name>[^_]+)_(?<k8s.namespace.name>[^_]+)_(?<k8s.container.name>[-0-9a-z]+)-(?<container.id>[^.]+).log$")) | . + (.pods_source | capture("^/var/log/pods/[^_]+_[^_]+_(?<k8s.pod.uid>[^/]+)/[^._]+/[0-9]+.log$") // {}) | .sourcetype = ("kube:container:" + .["k8s.container.name"])'
       </filter>
 
       {{- if .Values.autodetect.istio }}
-      # This filter adds "service.name" attribute, if it's not present, the same way as istio
-      # prepares service name for generated traces:
+      # This filter prepares a temporary "istio_service_name" attribute, the same way as istio service name is generated:
       # https://github.com/istio/istio/blob/77e00b47a61f0e995a29b33438c9dae7e8aace82/galley/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml#L110-L115
+      # The temporary "istio_service_name" attribute will be used to set "service.name" attribute in otel-collector
+      # if the pod doesn't have "app" label that should be used instead.
       # Name of the k8s deployment (or another object owning the pod, if any) is taken from "k8s.pod.name" attribute
       # using regex to filter out name suffix according to the k8s name generation rules:
       # https://github.com/kubernetes/apimachinery/blob/ff522ab81c745a9ac5f7eeb7852fac134194a3b6/pkg/util/rand/rand.go#L92-L127
       <filter tail.containers.**>
         @type jq_transformer
-        jq '.record["service.name"] = (.record["service.name"] // (.record.kubernetes.labels.app // (.record["k8s.pod.name"] // "istio-proxy" | (capture("^(?<owner_obj>.+?)-(?:(?:[0-9bcdf]+-)?[bcdfghjklmnpqrstvwxz2456789]{5}|[0-9]+)$") | .owner_obj) // .)) + "." + (.record["k8s.namespace.name"] // "default")) | .record'
+        jq '.record | . + (.istio_service_name = (.["k8s.pod.name"] // "istio-proxy" | (capture("^(?<owner_obj>.+?)-(?:(?:[0-9bcdf]+-)?[bcdfghjklmnpqrstvwxz2456789]{5}|[0-9]+)$") | .owner_obj) // .) + "." + (.["k8s.namespace.name"] // "default"))'
       </filter>
       {{- end }}
-
-      <filter tail.containers.**>
-        # Exclude all logs that are denylisted
-        @type grep
-        <exclude>
-          key denylist
-          pattern /^true$/
-        </exclude>
-      </filter>
 
       @include output.transform.conf
 
@@ -274,7 +254,7 @@ data:
           com.splunk.sourcetype ${record.dig("sourcetype") ? record.dig("sourcetype") : ""}
           com.splunk.source ${record.dig("source") ? record.dig("source") : ""}
         </record>
-        remove_keys denylist,docker,kubernetes,source,sourcetype
+        remove_keys pods_source,source,sourcetype
       </filter>
 
       # = output =

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -87,8 +87,8 @@ extraAttributes:
   # Labels that will be collected from k8s pods (in case they are set)
   # and added  as extra attributes to the telemetry in the following format:
   # k8s.pod.labels.<label_name>: <label_value>
-  podLabels: []
-    # - app
+  podLabels:
+    - app
     # - k8s-app
     # - release
 
@@ -519,7 +519,7 @@ image:
     # The registry and name of the fluentd image to pull
     repository: splunk/fluentd-hec
     # The tag of the fluentd image to pull
-    tag: 1.2.4
+    tag: 1.2.7
     # The policy that specifies when the user wants the fluentd images to be pulled
     pullPolicy: IfNotPresent
 
@@ -531,9 +531,9 @@ image:
 
   otelcol:
     # The registry and name of the opentelemetry collector image to pull
-    repository: quay.io/signalfx/splunk-otel-collector
+    repository: quay.io/signalfx/splunk-otel-collector-dev
     # The tag of the opentelemetry collector image to pull
-    tag: 0.31.0
+    tag: ab0055ef9f87e9c6df40bc4bae4cad32f0f911f2
     # The policy that specifies when the user wants the opentelemetry collector images to be pulled
     pullPolicy: IfNotPresent
 

--- a/rendered/manifests/agent-only/configmap-fluentd.yaml
+++ b/rendered/manifests/agent-only/configmap-fluentd.yaml
@@ -245,37 +245,20 @@ data:
       </match>
     </label>
     <label @SPLUNK>
-      # Enrich log with k8s metadata
+      # Extract k8s metadata from container logs source paths. Use original logs source
+      # "/var/log/containers/<k8s.pod.k8s>_<k8s.namespace.name>_<k8s.container.name>-<container.id>.log"
+      # first then check symlinks to the new k8s logs format
+      # "/var/log/pods/<k8s.namespace.name>_<k8s.pod.name>_<k8s.pod.uid>/<k8s.container.name>/<run_id>.log"
+      # to fetch "k8s.pod.uid" that will be used to get other k8s metadata by otel-collector from k8s API.
       <filter tail.containers.**>
-        @type kubernetes_metadata
-        annotation_match [ "^splunk\.com" ]
-        de_dot false
-      </filter>
-      <filter tail.containers.**>
-        @type record_transformer
-        enable_ruby
+        @type record_modifier
         <record>
-          # set the sourcetype from splunk.com/sourcetype pod annotation or set it to kube:container:CONTAINER_NAME
-          sourcetype ${record.dig("kubernetes", "annotations", "splunk.com/sourcetype") ? "kube:"+record.dig("kubernetes", "annotations", "splunk.com/sourcetype") : "kube:container:"+record.dig("kubernetes","container_name")}
-
-          k8s.container.name ${record.dig("kubernetes","container_name")}
-          k8s.namespace.name ${record.dig("kubernetes","namespace_name")}
-          k8s.pod.name ${record.dig("kubernetes","pod_name")}
-          container.id ${record.dig("docker","container_id")}
-          k8s.pod.uid ${record.dig("kubernetes","pod_id")}
-          container.image.name ${record.dig("kubernetes","container_image")}
-
-          denylist ${record.dig("kubernetes", "annotations", "splunk.com/exclude") ? record.dig("kubernetes", "annotations", "splunk.com/exclude") : record.dig("kubernetes", "namespace_annotations", "splunk.com/exclude") ? (record["kubernetes"]["namespace_annotations"]["splunk.com/exclude"]) : ("false")}
+          pods_source ${File.readlink(record['source'])}
         </record>
       </filter>
-
       <filter tail.containers.**>
-        # Exclude all logs that are denylisted
-        @type grep
-        <exclude>
-          key denylist
-          pattern /^true$/
-        </exclude>
+        @type jq_transformer
+        jq '.record | . + (.source | capture("^/var/log/containers/(?<k8s.pod.name>[^_]+)_(?<k8s.namespace.name>[^_]+)_(?<k8s.container.name>[-0-9a-z]+)-(?<container.id>[^.]+).log$")) | . + (.pods_source | capture("^/var/log/pods/[^_]+_[^_]+_(?<k8s.pod.uid>[^/]+)/[^._]+/[0-9]+.log$") // {}) | .sourcetype = ("kube:container:" + .["k8s.container.name"])'
       </filter>
 
       @include output.transform.conf
@@ -302,7 +285,7 @@ data:
           com.splunk.sourcetype ${record.dig("sourcetype") ? record.dig("sourcetype") : ""}
           com.splunk.source ${record.dig("source") ? record.dig("source") : ""}
         </record>
-        remove_keys denylist,docker,kubernetes,source,sourcetype
+        remove_keys pods_source,source,sourcetype
       </filter>
 
       # = output =

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -32,8 +32,35 @@ data:
       zpages: null
     processors:
       batch: null
+      filter/logs:
+        logs:
+          resource_attributes:
+          - key: splunk.com/exclude
+            value: "true"
+      groupbyattrs/logs:
+        keys:
+        - com.splunk.source
+        - com.splunk.sourcetype
+        - container.id
+        - fluent.tag
+        - istio_service_name
+        - k8s.container.name
+        - k8s.namespace.name
+        - k8s.pod.name
+        - k8s.pod.uid
       k8s_tagger:
         extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          labels:
+          - key: app
           metadata:
           - k8s.namespace.name
           - k8s.node.name
@@ -41,6 +68,16 @@ data:
           - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - from: resource_attribute
+          name: k8s.pod.uid
+        - from: resource_attribute
+          name: k8s.pod.ip
+        - from: resource_attribute
+          name: ip
+        - from: connection
+        - from: resource_attribute
+          name: host.name
       memory_limiter:
         ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
         check_interval: 2s
@@ -64,6 +101,15 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
       resourcedetection:
         detectors:
         - system
@@ -136,7 +182,11 @@ data:
           - splunk_hec
           processors:
           - memory_limiter
+          - groupbyattrs/logs
+          - k8s_tagger
           - batch
+          - filter/logs
+          - resource/logs
           - resource
           - resourcedetection
           receivers:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 136e3a2253756802f5bbdb948ee847d8f0269d08e5213e03a3cd04b305784a08
+        checksum/config: 44017cd17c55bc93ddc37a0070db072711792c3f8396c160eded08c5b5b1aab5
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -63,7 +63,7 @@ spec:
               mountPath: /fluentd/etc/cri
       containers:
       - name: fluentd
-        image: splunk/fluentd-hec:1.2.4
+        image: splunk/fluentd-hec:1.2.7
         imagePullPolicy: IfNotPresent
         securityContext:
           
@@ -138,7 +138,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.31.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:ab0055ef9f87e9c6df40bc4bae4cad32f0f911f2
         imagePullPolicy: IfNotPresent
         env:
           - name: K8S_NODE_NAME

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector:0.31.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:ab0055ef9f87e9c6df40bc4bae4cad32f0f911f2
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -30,13 +30,39 @@ data:
       zpages: null
     processors:
       batch: null
+      filter/logs:
+        logs:
+          resource_attributes:
+          - key: splunk.com/exclude
+            value: "true"
       k8s_tagger:
         extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          labels:
+          - key: app
           metadata:
           - k8s.namespace.name
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+        pod_association:
+        - from: resource_attribute
+          name: k8s.pod.uid
+        - from: resource_attribute
+          name: k8s.pod.ip
+        - from: resource_attribute
+          name: ip
+        - from: connection
+        - from: resource_attribute
+          name: host.name
       memory_limiter:
         ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
         check_interval: 2s
@@ -60,6 +86,15 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
       resourcedetection:
         detectors:
         - system
@@ -103,7 +138,10 @@ data:
           - splunk_hec
           processors:
           - memory_limiter
+          - k8s_tagger
           - batch
+          - filter/logs
+          - resource/logs
           receivers:
           - otlp
         logs/signalfx-events:

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: c1b66be0095af72537e126ddc51a08f0049545a71f362444a48f678e8b864a92
+        checksum/config: 647f9057c466bf31093989d26de55d5be9c23ebde3ac426f5281a04d09fe2869
     spec:
       serviceAccountName: default-splunk-otel-collector
       containers:
@@ -33,7 +33,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector:0.31.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:ab0055ef9f87e9c6df40bc4bae4cad32f0f911f2
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/logs-only/configmap-fluentd.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd.yaml
@@ -245,37 +245,20 @@ data:
       </match>
     </label>
     <label @SPLUNK>
-      # Enrich log with k8s metadata
+      # Extract k8s metadata from container logs source paths. Use original logs source
+      # "/var/log/containers/<k8s.pod.k8s>_<k8s.namespace.name>_<k8s.container.name>-<container.id>.log"
+      # first then check symlinks to the new k8s logs format
+      # "/var/log/pods/<k8s.namespace.name>_<k8s.pod.name>_<k8s.pod.uid>/<k8s.container.name>/<run_id>.log"
+      # to fetch "k8s.pod.uid" that will be used to get other k8s metadata by otel-collector from k8s API.
       <filter tail.containers.**>
-        @type kubernetes_metadata
-        annotation_match [ "^splunk\.com" ]
-        de_dot false
-      </filter>
-      <filter tail.containers.**>
-        @type record_transformer
-        enable_ruby
+        @type record_modifier
         <record>
-          # set the sourcetype from splunk.com/sourcetype pod annotation or set it to kube:container:CONTAINER_NAME
-          sourcetype ${record.dig("kubernetes", "annotations", "splunk.com/sourcetype") ? "kube:"+record.dig("kubernetes", "annotations", "splunk.com/sourcetype") : "kube:container:"+record.dig("kubernetes","container_name")}
-
-          k8s.container.name ${record.dig("kubernetes","container_name")}
-          k8s.namespace.name ${record.dig("kubernetes","namespace_name")}
-          k8s.pod.name ${record.dig("kubernetes","pod_name")}
-          container.id ${record.dig("docker","container_id")}
-          k8s.pod.uid ${record.dig("kubernetes","pod_id")}
-          container.image.name ${record.dig("kubernetes","container_image")}
-
-          denylist ${record.dig("kubernetes", "annotations", "splunk.com/exclude") ? record.dig("kubernetes", "annotations", "splunk.com/exclude") : record.dig("kubernetes", "namespace_annotations", "splunk.com/exclude") ? (record["kubernetes"]["namespace_annotations"]["splunk.com/exclude"]) : ("false")}
+          pods_source ${File.readlink(record['source'])}
         </record>
       </filter>
-
       <filter tail.containers.**>
-        # Exclude all logs that are denylisted
-        @type grep
-        <exclude>
-          key denylist
-          pattern /^true$/
-        </exclude>
+        @type jq_transformer
+        jq '.record | . + (.source | capture("^/var/log/containers/(?<k8s.pod.name>[^_]+)_(?<k8s.namespace.name>[^_]+)_(?<k8s.container.name>[-0-9a-z]+)-(?<container.id>[^.]+).log$")) | . + (.pods_source | capture("^/var/log/pods/[^_]+_[^_]+_(?<k8s.pod.uid>[^/]+)/[^._]+/[0-9]+.log$") // {}) | .sourcetype = ("kube:container:" + .["k8s.container.name"])'
       </filter>
 
       @include output.transform.conf
@@ -302,7 +285,7 @@ data:
           com.splunk.sourcetype ${record.dig("sourcetype") ? record.dig("sourcetype") : ""}
           com.splunk.source ${record.dig("source") ? record.dig("source") : ""}
         </record>
-        remove_keys denylist,docker,kubernetes,source,sourcetype
+        remove_keys pods_source,source,sourcetype
       </filter>
 
       # = output =

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -29,8 +29,35 @@ data:
       zpages: null
     processors:
       batch: null
+      filter/logs:
+        logs:
+          resource_attributes:
+          - key: splunk.com/exclude
+            value: "true"
+      groupbyattrs/logs:
+        keys:
+        - com.splunk.source
+        - com.splunk.sourcetype
+        - container.id
+        - fluent.tag
+        - istio_service_name
+        - k8s.container.name
+        - k8s.namespace.name
+        - k8s.pod.name
+        - k8s.pod.uid
       k8s_tagger:
         extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          labels:
+          - key: app
           metadata:
           - k8s.namespace.name
           - k8s.node.name
@@ -38,6 +65,16 @@ data:
           - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - from: resource_attribute
+          name: k8s.pod.uid
+        - from: resource_attribute
+          name: k8s.pod.ip
+        - from: resource_attribute
+          name: ip
+        - from: connection
+        - from: resource_attribute
+          name: host.name
       memory_limiter:
         ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
         check_interval: 2s
@@ -61,6 +98,15 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
       resourcedetection:
         detectors:
         - system
@@ -95,7 +141,11 @@ data:
           - splunk_hec
           processors:
           - memory_limiter
+          - groupbyattrs/logs
+          - k8s_tagger
           - batch
+          - filter/logs
+          - resource/logs
           - resource
           - resourcedetection
           receivers:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 40df2bf484514dc55491c57ef1c8e8c37d725d3b4880ef969a9c6e9383106597
+        checksum/config: 290be290cbafe715fc8eae30ab642321349aa40a996a93bbdfb5342fb8f845e6
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -63,7 +63,7 @@ spec:
               mountPath: /fluentd/etc/cri
       containers:
       - name: fluentd
-        image: splunk/fluentd-hec:1.2.4
+        image: splunk/fluentd-hec:1.2.7
         imagePullPolicy: IfNotPresent
         securityContext:
           
@@ -118,7 +118,7 @@ spec:
           containerPort: 4317
           hostPort: 4317
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.31.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:ab0055ef9f87e9c6df40bc4bae4cad32f0f911f2
         imagePullPolicy: IfNotPresent
         env:
           - name: K8S_NODE_NAME

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -26,8 +26,35 @@ data:
       zpages: null
     processors:
       batch: null
+      filter/logs:
+        logs:
+          resource_attributes:
+          - key: splunk.com/exclude
+            value: "true"
+      groupbyattrs/logs:
+        keys:
+        - com.splunk.source
+        - com.splunk.sourcetype
+        - container.id
+        - fluent.tag
+        - istio_service_name
+        - k8s.container.name
+        - k8s.namespace.name
+        - k8s.pod.name
+        - k8s.pod.uid
       k8s_tagger:
         extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          labels:
+          - key: app
           metadata:
           - k8s.namespace.name
           - k8s.node.name
@@ -35,6 +62,16 @@ data:
           - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - from: resource_attribute
+          name: k8s.pod.uid
+        - from: resource_attribute
+          name: k8s.pod.ip
+        - from: resource_attribute
+          name: ip
+        - from: connection
+        - from: resource_attribute
+          name: host.name
       memory_limiter:
         ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
         check_interval: 2s
@@ -58,6 +95,15 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
       resourcedetection:
         detectors:
         - system

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 641a9ff44743a5f86f273a917f7ff83458f0d03fee3ef6829c2bc458c660dc72
+        checksum/config: c30967ada50acefcd403fbb77f96e28ffaf8283dd2d8e6d0b735c68682bb164b
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -46,7 +46,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.31.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:ab0055ef9f87e9c6df40bc4bae4cad32f0f911f2
         imagePullPolicy: IfNotPresent
         env:
           - name: K8S_NODE_NAME

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector:0.31.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:ab0055ef9f87e9c6df40bc4bae4cad32f0f911f2
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -29,8 +29,35 @@ data:
       zpages: null
     processors:
       batch: null
+      filter/logs:
+        logs:
+          resource_attributes:
+          - key: splunk.com/exclude
+            value: "true"
+      groupbyattrs/logs:
+        keys:
+        - com.splunk.source
+        - com.splunk.sourcetype
+        - container.id
+        - fluent.tag
+        - istio_service_name
+        - k8s.container.name
+        - k8s.namespace.name
+        - k8s.pod.name
+        - k8s.pod.uid
       k8s_tagger:
         extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          labels:
+          - key: app
           metadata:
           - k8s.namespace.name
           - k8s.node.name
@@ -38,6 +65,16 @@ data:
           - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - from: resource_attribute
+          name: k8s.pod.uid
+        - from: resource_attribute
+          name: k8s.pod.ip
+        - from: resource_attribute
+          name: ip
+        - from: connection
+        - from: resource_attribute
+          name: host.name
       memory_limiter:
         ballast_size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
         check_interval: 2s
@@ -61,6 +98,15 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
       resourcedetection:
         detectors:
         - system

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 4db8ca0f95cd078629000ee4aee534f92a489bf9e7f3d6cde5a731dd844a3ac4
+        checksum/config: 0ffe58ec34693c4e3c6bafecb69f1c7dcf38b4dcfd6bbc90174513b447ffcb99
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -58,7 +58,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.31.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:ab0055ef9f87e9c6df40bc4bae4cad32f0f911f2
         imagePullPolicy: IfNotPresent
         env:
           - name: K8S_NODE_NAME


### PR DESCRIPTION
This change is the first step towards moving away from fluentd logs collection.

Fluentd "kubernetes_metadata_filter" plugin is known as a performance bottleneck in k8s logs collection with fluentd. So moving away from it already gives performance benefits. Also it mitigates issues when fluentd ends up hammering k8s API. 

This change is compatible with otel gateway, if `otelCollector.enabled=true` all logs are forwarded through the gateway and logs enrichment is happening there reducing load on k8s API.

Drawbacks:

- `container.image.name` logs attribute cannot be provided at the moment until this issue is resolved: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5235

Additional changes:

- Extra attribute added by default `k8s.pod.labels.app`. Value for this attribute is taken from pod's "app" label if it's set. The change is needed to support istio use case. We also want to enable more of these attributes going forward https://github.com/signalfx/splunk-otel-collector-chart/issues/189.