### PR TITLE
Disable unnecessary leader election for smartagent/kubernetes-events

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -18,19 +18,6 @@ rules:
   - list
   - watch
 {{- end }}
-{{- if .Values.otelK8sClusterReceiver.k8sEventsEnabled }}
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - patch
-  - create
-  - list
-  - watch
-{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -24,6 +24,7 @@ receivers:
   {{- if .Values.otelK8sClusterReceiver.k8sEventsEnabled }}
   smartagent/kubernetes-events:
     type: kubernetes-events
+    alwaysClusterReporter: true
     whitelistedEvents:
     - reason: Created
       involvedObjectKind: Pod

--- a/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
@@ -90,16 +90,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          {{- if .Values.otelK8sClusterReceiver.k8sEventsEnabled }}
-          - name: MY_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          {{- end }}
           - name: SPLUNK_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
smartagent/kubernetes-events receiver is running on 1-replica deployment, so leader election can be disabled and all relevant configurations can be removed