### PR TITLE
Send k8s events additionally to Splunk HEC endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Send k8s events additionally to Splunk HEC endpoint (#202)
+
 ## [0.35.1] - 2021-09-23
 
 ### Added

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -91,6 +91,14 @@ exporters:
     access_token: ${SPLUNK_ACCESS_TOKEN}
     timeout: 10s
 
+  {{- if and .Values.logsEnabled .Values.otelK8sClusterReceiver.k8sEventsEnabled }}
+  splunk_hec:
+    endpoint: {{ include "splunk-otel-collector.ingestUrl" . }}/v1/log
+    token: "${SPLUNK_ACCESS_TOKEN}"
+    sourcetype: kube:events
+    source: kubelet
+  {{- end }}
+
 service:
   extensions: [health_check]
   pipelines:
@@ -119,6 +127,10 @@ service:
         - batch
         - resource
         - resourcedetection
-      exporters: [signalfx]
+      exporters:
+        - signalfx
+        {{- if .Values.logsEnabled }}
+        - splunk_hec
+        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
We want k8s events to be available in Splunk Log Observer additionally to IMM