### PR TITLE
Remove resourcedetection processor from logs/events pipeline

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -118,7 +118,6 @@ service:
         - memory_limiter
         - batch
         - resource
-        - resourcedetection
       exporters: [signalfx]
     {{- end }}
 {{- end }}


### PR DESCRIPTION
This processor is adding wrong metadata from a random host to cluster-wide events. The events already come with necessary k8s metadata.