### PR TITLE
Change interface to be able to send data to Splunk Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Change configuration interface to be able to send data to Splunk
+  Enterprise/Cloud and to Splunk Observability (#209)
 - Improve multiline logs configuration for native logs collection (#208)
 
 ## [0.35.3] - 2021-09-29

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ render:
 		helm template \
 			--namespace default \
 			--values rendered/values.yaml \
-			--set metricsEnabled=false,tracesEnabled=false,logsEnabled=false,$${i}Enabled=true \
+			--set splunkObservability.metricsEnabled=false,splunkObservability.tracesEnabled=false,splunkObservability.logsEnabled=false,splunkObservability.$${i}Enabled=true \
 			--output-dir "$$dir" \
 			default helm-charts/splunk-otel-collector; \
 		mv "$$dir"/splunk-otel-collector/templates/* "$$dir"; \

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,10 +11,22 @@ helm install my-splunk-otel-collector --values my-values.yaml splunk-otel-collec
 ```
 
 All of the provided examples must also include the required parameters:
+
 ```yaml
+# Splunk Platform required parameters
+splunkPlatform:
+  token: xxxxxx
+  endpoint: http://localhost:8088/services/collector
+```
+
+or
+
+```yaml
+# Splunk Observability required parameters
 clusterName: my-cluster
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 ```
 
 ## Deploy for k8s cluster with windows worker node.

--- a/examples/add-sampler-values.yaml
+++ b/examples/add-sampler-values.yaml
@@ -1,6 +1,7 @@
 clusterName: my-cluster
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 
 otelAgent:
   config:

--- a/examples/crio-logging-values.yaml
+++ b/examples/crio-logging-values.yaml
@@ -1,6 +1,7 @@
 clusterName: my-cluster
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 
 fluentd:
   config:

--- a/examples/enable-gateway-values.yaml
+++ b/examples/enable-gateway-values.yaml
@@ -1,6 +1,7 @@
 clusterName: my-cluster
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 
 otelCollector:
   enabled: true

--- a/examples/gateway-only-values.yaml
+++ b/examples/gateway-only-values.yaml
@@ -1,6 +1,7 @@
 clusterName: my-cluster
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 
 otelCollector:
   enabled: true

--- a/examples/parse-java-stacktrace-values.yaml
+++ b/examples/parse-java-stacktrace-values.yaml
@@ -1,6 +1,7 @@
 clusterName: my-cluster
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 
 fluentd:
   config:

--- a/examples/use-custom-gateway-values.yaml
+++ b/examples/use-custom-gateway-values.yaml
@@ -1,6 +1,7 @@
 clusterName: my-cluster
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 
 otelAgent:
   config:

--- a/examples/use-proxy-values.yaml
+++ b/examples/use-proxy-values.yaml
@@ -1,6 +1,7 @@
 clusterName: my-cluster
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 
 otelAgent:
   extraEnvs:

--- a/helm-charts/splunk-otel-collector/ci/basic-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/basic-values.yaml
@@ -1,6 +1,7 @@
 clusterName: fake-cluster
-splunkRealm: fake-realm
-splunkAccessToken: fake-token
+splunkObservability:
+  realm: fake-realm
+  accessToken: fake-token
 
 # Logs collection config for Kind cluster
 fluentd:

--- a/helm-charts/splunk-otel-collector/ci/logs-only-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/logs-only-values.yaml
@@ -1,6 +1,7 @@
 clusterName: fake-cluster
-splunkRealm: fake-realm
-splunkAccessToken: fake-token
+splunkObservability:
+  realm: fake-realm
+  accessToken: fake-token
 
 tracesEnabled: false
 metricsEnabled: false

--- a/helm-charts/splunk-otel-collector/ci/sampler-gateway-env-vars-java-logs-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/sampler-gateway-env-vars-java-logs-values.yaml
@@ -1,6 +1,7 @@
 clusterName: fake-cluster
-splunkRealm: fake-realm
-splunkAccessToken: fake-token
+splunkObservability:
+  realm: fake-realm
+  accessToken: fake-token
 
 otelAgent:
   config:

--- a/helm-charts/splunk-otel-collector/ci/use-custom-gateway-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/use-custom-gateway-values.yaml
@@ -1,4 +1,5 @@
 clusterName: my-cluster
+# Validate backward compatible parameters
 splunkRealm: us0
 splunkAccessToken: my-access-token
 

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -1,0 +1,35 @@
+{{- if eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true" }}
+Splunk OpenTelemetry Connector is installed and configured to send data to Splunk Platform endpoint "{{ .Values.splunkPlatform.endpoint }}".
+{{ end }}
+{{- if eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true" }}
+Splunk OpenTelemetry Connector is installed and configured to send data to Splunk Observability realm {{ include "splunk-otel-collector.o11yRealm" . }}.
+{{ end }}
+
+{{- if .Values.splunkRealm }}
+[WARNING] "splunkRealm" parameter is deprecated, please use "splunkObservability.realm" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart#0353-to-0360
+{{ end }}
+{{- if .Values.splunkAccessToken }}
+[WARNING] "splunkAccessToken" parameter is deprecated, please use "splunkObservability.accessToken" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart#0353-to-0360
+{{ end }}
+{{- if .Values.ingestUrl }}
+[WARNING] "ingestUrl" parameter is deprecated, please use "splunkObservability.ingestUrl" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart#0353-to-0360
+{{ end }}
+{{- if .Values.apiUrl }}
+[WARNING] "apiUrl" parameter is deprecated, please use "splunkObservability.apiUrl" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart#0353-to-0360
+{{ end }}
+{{- if not (empty .Values.metricsEnabled) }}
+[WARNING] "metricsEnabled" parameter is deprecated, please use "splunkObservability.metricsEnabled" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart#0353-to-0360
+{{ end }}
+{{- if not (empty .Values.tracesEnabled) }}
+[WARNING] "tracesEnabled" parameter is deprecated, please use "splunkObservability.tracesEnabled" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart#0353-to-0360
+{{ end }}
+{{- if not (empty .Values.logsEnabled) }}
+[WARNING] "logsEnabled" parameter is deprecated, please use "splunkObservability.logsEnabled" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart#0353-to-0360
+{{ end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -15,10 +15,10 @@ memory_limiter:
 Common config for the otel-collector sapm exporter
 */}}
 {{- define "splunk-otel-collector.otelSapmExporter" -}}
-{{- if .Values.tracesEnabled }}
+{{- if (eq (include "splunk-otel-collector.tracesEnabled" .) "true") }}
 sapm:
-  endpoint: {{ include "splunk-otel-collector.ingestUrl" . }}/v2/trace
-  access_token: ${SPLUNK_ACCESS_TOKEN}
+  endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v2/trace
+  access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
 {{- end }}
 {{- end }}
 
@@ -33,7 +33,7 @@ otlp:
     http:
       endpoint: 0.0.0.0:55681
 
-{{- if .Values.tracesEnabled }}
+{{- if (eq (include "splunk-otel-collector.tracesEnabled" .) "true") }}
 jaeger:
   protocols:
     thrift_http:
@@ -113,4 +113,60 @@ filter/logs:
     resource_attributes:
       - key: splunk.com/exclude
         value: "true"
+{{- end }}
+
+{{/*
+Splunk Platform Logs exporter
+*/}}
+{{- define "splunk-otel-collector.splunkPlatformLogsExporter" -}}
+splunk_hec/platform_logs:
+  endpoint: {{ .Values.splunkPlatform.endpoint | quote }}
+  token: "${SPLUNK_PLATFORM_HEC_TOKEN}"
+  index: {{ .Values.splunkPlatform.index | quote }}
+  source: {{ .Values.splunkPlatform.source | quote }}
+  sourcetype: {{ .Values.splunkPlatform.sourcetype | quote }}
+  max_connections: {{ .Values.splunkPlatform.max_connections }}
+  disable_compression: {{ .Values.splunkPlatform.disable_compression }}
+  timeout: {{ .Values.splunkPlatform.timeout }}
+  insecure: {{ .Values.splunkPlatform.insecure }}
+  insecure_skip_verify: {{ .Values.splunkPlatform.insecure_skip_verify }}
+  splunk_app_name: {{ .Chart.Name }}
+  splunk_app_version: {{ .Chart.Version }}
+  {{- if .Values.splunkPlatform.clientCert }}
+  cert_file: /otel/etc/hec_client_cert
+  {{- end }}
+  {{- if .Values.splunkPlatform.clientKey  }}
+  key_file: /otel/etc/hec_client_key
+  {{- end }}
+  {{- if .Values.splunkPlatform.caFile }}
+  ca_file: /otel/etc/hec_ca_file
+  {{- end }}
+{{- end }}
+
+{{/*
+Splunk Platform Logs exporter
+*/}}
+{{- define "splunk-otel-collector.splunkPlatformMetricsExporter" -}}
+splunk_hec/platform_metrics:
+  endpoint: {{ .Values.splunkPlatform.endpoint | quote }}
+  token: "${SPLUNK_PLATFORM_HEC_TOKEN}"
+  index: {{ .Values.splunkPlatform.metrics_index | quote }}
+  source: {{ .Values.splunkPlatform.source | quote }}
+  sourcetype: {{ .Values.splunkPlatform.sourcetype | quote }}
+  max_connections: {{ .Values.splunkPlatform.max_connections }}
+  disable_compression: {{ .Values.splunkPlatform.disable_compression }}
+  timeout: {{ .Values.splunkPlatform.timeout }}
+  insecure: {{ .Values.splunkPlatform.insecure }}
+  insecure_skip_verify: {{ .Values.splunkPlatform.insecure_skip_verify }}
+  splunk_app_name: {{ .Chart.Name }}
+  splunk_app_version: {{ .Chart.Version }}
+  {{- if .Values.splunkPlatform.clientCert }}
+  cert_file: /otel/etc/hec_client_cert
+  {{- end }}
+  {{- if .Values.splunkPlatform.clientKey  }}
+  key_file: /otel/etc/hec_client_key
+  {{- end }}
+  {{- if .Values.splunkPlatform.caFile }}
+  ca_file: /otel/etc/hec_ca_file
+  {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -479,7 +479,7 @@ service:
         {{- if (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") }}
         - signalfx
         {{- end }}
-        {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
+        {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" .) "true") }}
         - splunk_hec/platform_metrics
         {{- end }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-cri.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-cri.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.logsEnabled .Values.otelAgent.enabled .Values.fluentd.enabled }}
+{{ if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.otelAgent.enabled .Values.fluentd.enabled }}
 {{/*
 Fluentd config parts applied only to clusters with containerd/cri-o runtime.
 */}}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.logsEnabled .Values.otelAgent.enabled .Values.fluentd.enabled }}
+{{ if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.otelAgent.enabled .Values.fluentd.enabled }}
 {{/*
 Fluentd config parts applied only to clusters with docker runtime.
 */}}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.logsEnabled .Values.otelAgent.enabled .Values.fluentd.enabled }}
+{{ if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.otelAgent.enabled .Values.fluentd.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/configmap-otel-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-otel-k8s-cluster-receiver.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.otelK8sClusterReceiver.enabled .Values.metricsEnabled }}
+{{ if and .Values.otelK8sClusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ template "splunk-otel-collector.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if and .Values.logsEnabled .Values.fluentd.enabled }}
+    {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.fluentd.enabled }}
     engine: fluentd
     {{- end }}
   {{- if .Values.otelAgent.annotations }}
@@ -58,7 +58,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.logsEnabled .Values.fluentd.enabled }}
+      {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.fluentd.enabled }}
       initContainers:
         - name: prepare-fluentd-config
           image: {{ .Values.image.fluentd.initContainer.image }}
@@ -90,7 +90,7 @@ spec:
               mountPath: /fluentd/etc/cri
       {{- end }}
       containers:
-      {{- if and .Values.logsEnabled .Values.fluentd.enabled }}
+      {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.fluentd.enabled }}
       - name: fluentd
         image: {{ template "splunk-otel-collector.image.fluentd" . }}
         imagePullPolicy: {{ .Values.image.fluentd.pullPolicy }}
@@ -150,7 +150,7 @@ spec:
         {{- end }}
         ports:
         {{- range $key, $port := .Values.otelAgent.ports }}
-        {{- if eq true (and $.Values.metricsEnabled (has "metrics" $port.enabled_for)) (and $.Values.tracesEnabled (has "traces" $port.enabled_for)) (and $.Values.logsEnabled (has "logs" $port.enabled_for)) }}
+        {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.o11yTracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) }}
         - name: {{ $key }}
           {{- omit $port "enabled_for" | toYaml | trim | nindent 10 }}
         {{- end }}
@@ -188,12 +188,21 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "splunk-otel-collector.secret" . }}
-                key: splunk_access_token
-          {{- if .Values.metricsEnabled }}
+                key: splunk_o11y_access_token
+          {{- end }}
+          {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
+          - name: SPLUNK_PLATFORM_HEC_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "splunk-otel-collector.secret" . }}
+                key: splunk_platform_hec_token
+          {{- end }}
+          {{- if eq (include "splunk-otel-collector.metricsEnabled" .) "true" }}
           # Env variables for host metrics receiver
           - name: HOST_PROC
             value: {{ .Values.isWindows | ternary "C:\\hostfs\\proc" "/hostfs/proc" }}
@@ -231,13 +240,13 @@ spec:
         volumeMounts:
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: otel-configmap
-        {{- if .Values.metricsEnabled }}
+        {{- if eq (include "splunk-otel-collector.metricsEnabled" $) "true" }}
         - mountPath: {{ .Values.isWindows | ternary "C:\\hostfs" "/hostfs" }}
           name: hostfs
           readOnly: true
           mountPropagation: HostToContainer
         {{- end }}
-        {{- if and .Values.logsEnabled .Values.logsCollection.enabled }}
+        {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") .Values.logsCollection.enabled }}
         - name: varlog
           mountPath: /var/log
           readOnly: true
@@ -252,7 +261,7 @@ spec:
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
-      {{- if .Values.logsEnabled }}
+      {{- if (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
       {{- if .Values.fluentd.enabled }}
       - name: varlog
         hostPath:
@@ -291,7 +300,7 @@ spec:
           type: DirectoryOrCreate
       {{- end}}
       {{- end}}
-      {{- if .Values.metricsEnabled }}
+      {{- if eq (include "splunk-otel-collector.metricsEnabled" $) "true" }}
       - name: hostfs
         hostPath:
           path: {{ .Values.isWindows | ternary "C:\\" "/" }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
@@ -99,17 +99,26 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "splunk-otel-collector.secret" . }}
-                key: splunk_access_token
+                key: splunk_o11y_access_token
+          {{- end }}
+          {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
+          - name: SPLUNK_PLATFORM_HEC_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "splunk-otel-collector.secret" . }}
+                key: splunk_platform_hec_token
+          {{- end }}
           {{- with .Values.otelCollector.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}
         ports:
         {{- range $key, $port := .Values.otelCollector.ports }}
-        {{- if eq true (and $.Values.metricsEnabled (has "metrics" $port.enabled_for)) (and $.Values.tracesEnabled (has "traces" $port.enabled_for)) (and $.Values.logsEnabled (has "logs" $port.enabled_for)) }}
+        {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) }}
         - name: {{ $key }}
           {{- omit $port "enabled_for" | toYaml | trim | nindent 10 }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.otelK8sClusterReceiver.enabled .Values.metricsEnabled }}
+{{ if and .Values.otelK8sClusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -99,11 +99,20 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "splunk-otel-collector.secret" . }}
-                key: splunk_access_token
+                key: splunk_o11y_access_token
+          {{- end }}
+          {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
+          - name: SPLUNK_PLATFORM_HEC_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "splunk-otel-collector.secret" . }}
+                key: splunk_platform_hec_token
+          {{- end }}
           {{- with .Values.otelK8sClusterReceiver.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/pdb-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-k8s-cluster-receiver.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.otelK8sClusterReceiver.enabled .Values.metricsEnabled) .Values.podDisruptionBudget }}
+{{- if and (and .Values.otelK8sClusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" $) "true")) .Values.podDisruptionBudget }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/secret.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret.yaml
@@ -10,5 +10,19 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  splunk_access_token: {{ include "splunk-otel-collector.accessToken" . | b64enc }}
+  {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
+  splunk_o11y_access_token: {{ include "splunk-otel-collector.o11yAccessToken" . | b64enc }}
+  {{- end }}
+  {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
+  splunk_platform_hec_token: {{ .Values.splunkPlatform.token | b64enc }}
+  {{- end }}
+  {{- with .Values.splunkPlatform.clientCert }}
+  hec_client_cert: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.splunkPlatform.clientKey }}
+  hec_client_key: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.splunkPlatform.caFile }}
+  hec_ca_file: {{ . | b64enc }}
+  {{- end }}
 {{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   {{- range $key, $port := .Values.otelCollector.ports }}
-  {{- if eq true (and $.Values.metricsEnabled (has "metrics" $port.enabled_for)) (and $.Values.tracesEnabled (has "traces" $port.enabled_for)) (and $.Values.logsEnabled (has "logs" $port.enabled_for)) }}
+  {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) }}
   - name: {{ $key }}
     port: {{ $port.containerPort }}
     targetPort: {{ $key }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -4,16 +4,12 @@
   "required": [
     "clusterName",
     "provider",
-    "distro",
-    "tracesEnabled",
-    "metricsEnabled",
-    "logsEnabled"
+    "distro"
   ],
   "title": "Values",
   "properties": {
     "clusterName": {
       "description": "Cluster name that will be used as metadata attributes for all telemetry data",
-      "minLength": 1,
       "type": "string"
     },
     "provider": {
@@ -26,22 +22,35 @@
       "type": "string",
       "enum": ["eks", "gke", "aks", "openshift", " ", ""]
     },
-    "metricsEnabled": {
-      "description": "Metrics telemetry enabled",
-      "type": "boolean"
+    "splunkPlatform": {
+      "description": "Splunk Data-to-Everything Platform configuration",
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      }
     },
-    "tracesEnabled": {
-      "description": "Traces telemetry enabled",
-      "type": "boolean"
-    },
-    "logsEnabled": {
-      "description": "Logs telemetry enabled",
-      "type": "boolean"
+    "splunkObservability": {
+      "description": "Splunk Observability configuration",
+      "type": "object",
+      "properties": {
+        "realm": {
+          "type": "string"
+        },
+        "accessToken": {
+          "type": "string"
+        },
+        "ingestUrl": {
+          "type": "string"
+        },
+        "apiUrl": {
+          "type": "string"
+        }
+      }
     }
-  },
-  "anyOf": [
-    {"properties": {"metricsEnabled": {"const": true}}},
-    {"properties": {"tracesEnabled": {"const": true}}},
-    {"properties": {"logsEnabled": {"const": true}}}
-  ]
+  }
 }

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -3,31 +3,86 @@
 # Declared variables will be passed into templates.
 
 ################################################################################
-# clusterName is a REQUIRED field. It can be set to an arbitrary value
-# that identifies this K8s cluster in SignalFx. The value will be associated
-# with every trace, metric and log as "k8s.cluster.name" metadata attribute.
+# clusterName is a REQUIRED field for Spunk Observability. It can be set to an
+# arbitrary value that identifies this K8s cluster in SignalFx. The value will
+# be associated with every trace, metric and log as "k8s.cluster.name" metadata
+# attribute.
 ################################################################################
 
-clusterName: k8s-cluster
-
+clusterName: ""
 
 ################################################################################
-# Splunk SignalFx backend configuration
+# Splunk Data-to-Everything Platform configuration.
 ################################################################################
 
-# The SignalFx realm to send telemetry data to. If set, the values of `ingestUrl`
-# and `apiUrl` will be automatically set based on this
-# realm value. If not set, it defaults to the original "us0" realm.
-splunkRealm: us0
+# Specify `endpoint` and `token` in order to send data to Splunk Cloud or Splunk
+# Enterprise.
+splunkPlatform:
+  # Required for Splunk Enterprise/Cloud. URL to a Splunk instance to send data to.
+  # e.g. "http://X.X.X.X:8088/services/collector"
+  endpoint: ""
+  # Required for Splunk Enterprise/Cloud. Splunk HTTP Event Collector token.
+  token: ""
 
-# (REQUIRED) SignalFx org access token.
-splunkAccessToken:
+  # Optional. Name of the Splunk index targeted.
+  index: ""
+  metrics_index:
+  # Optional. Default value for `source` field.
+  source: "kubernetes"
+  # Optional. Default value for `sourcetype` field. For container logs, it will
+  # be container name.
+  sourcetype:
+  # Maximum HTTP connections to use simultaneously when sending data.
+  max_connections: 200
+  # Whether to disable gzip compression over HTTP. Defaults to true.
+  disable_compression: true
+  # HTTP timeout when sending data. Defaults to 10s.
+  timeout: 10s
+  # Whether to skip checking the certificate of the HEC endpoint when sending
+  # data over HTTPS.
+  insecure_skip_verify: false
+  # The PEM-format CA certificate for this client.
+  # NOTE: The content of the certificate itself should be used here, not the
+  #       file path. The certificate will be stored as a secret in kubernetes.
+  clientCert: ""
+  # The private key for this client.
+  # NOTE: The content of the key itself should be used here, not the file path.
+  #       The key will be stored as a secret in kubernetes.
+  clientKey: ""
+  # The PEM-format CA certificate file.
+  # NOTE: The content of the file itself should be used here, not the file path.
+  #       The file will be stored as a secret in kubernetes.
+  caFile: ""
 
-# SignalFx ingest URL, default: "https://ingest.<realm>.signalfx.com".
-ingestUrl:
+  # Options to disable particular telemetry data types that will be sent to
+  # Splunk Platform.
+  logsEnabled: true
+  metricsEnabled: true
 
-# The SignalFx API URL, default: "https://api.<realm>.signalfx.com".
-apiUrl:
+################################################################################
+# Splunk Observability configuration
+################################################################################
+
+# Specify `realm` and `accessToken` to telemetry data to Splunk Observability
+# Cloud.
+splunkObservability:
+  # Required for Splunk Observability. Splunk Observability realm to send
+  # telemetry data to.
+  realm: us0
+  # Required for Splunk Observability. Splunk Observability org access token.
+  accessToken: ""
+
+  # Optional. Splunk Observability ingest URL, default:
+  # "https://ingest.<realm>.signalfx.com".
+  ingestUrl: ""
+  # Optional. Splunk Observability API URL, default:
+  # "https://api.<realm>.signalfx.com".
+  apiUrl: ""
+
+  # Options to disable particular telemetry data types.
+  logsEnabled: true
+  metricsEnabled: true
+  tracesEnabled: true
 
 ################################################################################
 # Cloud provider, if any, the collector is running on. Leave empty for none/other.
@@ -47,16 +102,6 @@ provider: ""
 ################################################################################
 
 distro: ""
-
-################################################################################
-# Telemetry configuration.
-# By default metrics, traces and logs are collected from the k8s cluster.
-# It's possible to disable any kind of telemetry, if it's not needed.
-################################################################################
-
-metricsEnabled: true
-tracesEnabled: true
-logsEnabled: true
 
 ################################################################################
 # Optional "environment" parameter that will be added to all the telemetry

--- a/rendered/README.md
+++ b/rendered/README.md
@@ -1,6 +1,8 @@
 # Manifests
 
-The [manifests](manifests) directory contains pre-rendered Kubernetes resource manifests that can be applied with `kubectl create`. Different sets contain different features enabled
+The [manifests](manifests) directory contains pre-rendered Kubernetes resource
+manifests that can be applied with `kubectl create`. Different sets contain
+different features enabled. For now, configured for Slunk Observability only.
 
 - [metrics-only](manifests/metrics-only)
 - [traces-only](manifests/traces-only)

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -13,17 +13,17 @@ data:
   relay: |
     exporters:
       sapm:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
-      splunk_hec:
+      splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
-        token: ${SPLUNK_ACCESS_TOKEN}
+        token: ${SPLUNK_O11Y_ACCESS_TOKEN}
     extensions:
       health_check: null
       k8s_observer:
@@ -179,7 +179,7 @@ data:
       pipelines:
         logs:
           exporters:
-          - splunk_hec
+          - splunk_hec/o11y
           processors:
           - memory_limiter
           - groupbyattrs/logs

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -13,7 +13,7 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 910a4b62c349010272d79c8b9df01763dbade96e38c112b6a42fe6c104065890
+        checksum/config: 4a9f02f0872404f1a79b3f6137576e3ecea9f7f5c6f20f43f2472eea92e9e0e7
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -169,11 +169,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_access_token
+                key: splunk_o11y_access_token
           # Env variables for host metrics receiver
           - name: HOST_PROC
             value: /hostfs/proc

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c0e85821c399d8b353982b0dbcf705f5ff08eed03210be69cd797db3d0ff22e
+        checksum/config: 74f886c0736a63c325ac5012c547ccfcd7ecddffea5cd7e6160a0cc18182a511
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -61,11 +61,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_access_token
+                key: splunk_o11y_access_token
         readinessProbe:
           httpGet:
             path: /

--- a/rendered/manifests/agent-only/secret.yaml
+++ b/rendered/manifests/agent-only/secret.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_access_token: Q0hBTkdFTUU=
+  splunk_o11y_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -13,15 +13,15 @@ data:
   relay: |
     exporters:
       sapm:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
-      splunk_hec:
+      splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
-        token: ${SPLUNK_ACCESS_TOKEN}
+        token: ${SPLUNK_O11Y_ACCESS_TOKEN}
     extensions:
       health_check: null
       http_forwarder:
@@ -130,12 +130,12 @@ data:
     service:
       extensions:
       - health_check
-      - http_forwarder
       - zpages
+      - http_forwarder
       pipelines:
         logs:
           exporters:
-          - splunk_hec
+          - splunk_hec/o11y
           processors:
           - memory_limiter
           - k8s_tagger

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6f482deaa97d3232e16bb8fa2888efec76f517190162c60f74ff5a591c049fc8
+        checksum/config: cff3eef80b7da9ff873290a5a6350a2d602d720126f92722ed2528ad4a96c3a9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -61,11 +61,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_access_token
+                key: splunk_o11y_access_token
         ports:
         - name: http-forwarder
           containerPort: 6060

--- a/rendered/manifests/gateway-only/secret.yaml
+++ b/rendered/manifests/gateway-only/secret.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_access_token: Q0hBTkdFTUU=
+  splunk_o11y_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -13,14 +13,14 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
-      splunk_hec:
+      splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
-        token: ${SPLUNK_ACCESS_TOKEN}
+        token: ${SPLUNK_O11Y_ACCESS_TOKEN}
     extensions:
       health_check: null
       k8s_observer:
@@ -138,7 +138,7 @@ data:
       pipelines:
         logs:
           exporters:
-          - splunk_hec
+          - splunk_hec/o11y
           processors:
           - memory_limiter
           - groupbyattrs/logs

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: abb4c1d1d9eb516027b34d18561a5b776a5d26213a4a727f2b5f53b8988d6eb7
+        checksum/config: 9a69db1310eaff3ec03d7c616908a71c5f17396b58c2caaf2d9a1f66b42ac523
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -149,11 +149,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_access_token
+                key: splunk_o11y_access_token
 
         readinessProbe:
           httpGet:

--- a/rendered/manifests/logs-only/secret.yaml
+++ b/rendered/manifests/logs-only/secret.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_access_token: Q0hBTkdFTUU=
+  splunk_o11y_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -13,7 +13,7 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -13,7 +13,7 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: a8071b9a5ed466ddb2ceb9f015757c475782b354b1893d305041fac6d6702e8e
+        checksum/config: d23f5d85b5c0e22c609f91dc94cb609922a915eace0cae5b01b7dbfa5bdc1b3d
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -77,11 +77,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_access_token
+                key: splunk_o11y_access_token
           # Env variables for host metrics receiver
           - name: HOST_PROC
             value: /hostfs/proc

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c0e85821c399d8b353982b0dbcf705f5ff08eed03210be69cd797db3d0ff22e
+        checksum/config: 74f886c0736a63c325ac5012c547ccfcd7ecddffea5cd7e6160a0cc18182a511
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -61,11 +61,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_access_token
+                key: splunk_o11y_access_token
         readinessProbe:
           httpGet:
             path: /

--- a/rendered/manifests/metrics-only/secret.yaml
+++ b/rendered/manifests/metrics-only/secret.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_access_token: Q0hBTkdFTUU=
+  splunk_o11y_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -13,10 +13,10 @@ data:
   relay: |
     exporters:
       sapm:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
-        access_token: ${SPLUNK_ACCESS_TOKEN}
+        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5ebfd3a9e3bd58b56030678100bcd499c3a13fce4c3c32ca5818a0cce4dc6e38
+        checksum/config: e7a1934bf7cfbef91ee17d642032bf88a269b4886b1bdbf956161728f846f759
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
@@ -89,11 +89,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_ACCESS_TOKEN
+          - name: SPLUNK_O11Y_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_access_token
+                key: splunk_o11y_access_token
 
         readinessProbe:
           httpGet:

--- a/rendered/manifests/traces-only/secret.yaml
+++ b/rendered/manifests/traces-only/secret.yaml
@@ -11,4 +11,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_access_token: Q0hBTkdFTUU=
+  splunk_o11y_access_token: Q0hBTkdFTUU=

--- a/rendered/values.yaml
+++ b/rendered/values.yaml
@@ -1,4 +1,5 @@
 # These values are used in the pre-rendered helm templates.
-splunkAccessToken: CHANGEME
 clusterName: CHANGEME
-splunkRealm: CHANGEME
+splunkObservability:
+  realm: CHANGEME
+  accessToken: CHANGEME


### PR DESCRIPTION
This change introduces ability to send data to Splunk Enterprise/Cloud and to Splunk Observability. Most of the documentation and configurations are updated but the change set as kept to minimal required changed.

Resolves: https://github.com/signalfx/splunk-otel-collector-chart/issues/204