### PR TITLE
Move `system` detector to the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- BREAKING CHANGE: Reorder resource detectors, moving the `system` detector
+  to the end of the list. Applying this change in an EC2 or Azure environment
+  may change the `host.name` dimension and the resource ID dimension
+  on some MTSes, possibly causing detectors to fire.
+
 ## [0.36.2] - 2021-10-08
 
 ### Fixed

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -51,7 +51,6 @@ Common config for resourcedetection processor
 # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
 resourcedetection:
   detectors:
-    - system
     # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
     # before it gets set later by the cloud provider detector.
     - env
@@ -69,6 +68,9 @@ resourcedetection:
     {{- else if eq .Values.provider "azure" }}
     - azure
     {{- end }}
+    # The `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
+    # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering
+    - system
   # Don't override existing resource attributes to maintain identification of data sources
   override: false
   timeout: 10s

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -114,8 +114,8 @@ data:
           key: splunk.com/exclude
       resourcedetection:
         detectors:
-        - system
         - env
+        - system
         override: false
         timeout: 10s
     receivers:

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -53,8 +53,8 @@ data:
           value: ${K8S_NAMESPACE}
       resourcedetection:
         detectors:
-        - system
         - env
+        - system
         override: false
         timeout: 10s
     receivers:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 1b9fc8f5610c4295df51650286633d18dad3235c0531e77546966148e2241768
+        checksum/config: 51921f8718ecd04b0b4460ae64f90a96e656feceace1262cf3a137423b12aaaa
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b7199de83a2d9e392d9fca87a4502647fff91685b985be232843e56f8bb5b8a7
+        checksum/config: d1121e7fcacdcd3fd90468b9aa670939aeb3676e07725e88a78b4763e40dbea9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -99,8 +99,8 @@ data:
           key: splunk.com/exclude
       resourcedetection:
         detectors:
-        - system
         - env
+        - system
         override: false
         timeout: 10s
     receivers:

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: fc3497f69b0f6cb8c248d3b438dc0d7866cc8b72e3bd2e5fde0a3222b4070e6b
+        checksum/config: 3217fdd65d970829babbacd162049ad76cf1f3c5a48a183edf4f1961a5912467
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -111,8 +111,8 @@ data:
           key: splunk.com/exclude
       resourcedetection:
         detectors:
-        - system
         - env
+        - system
         override: false
         timeout: 10s
     receivers:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e43d78c5c08a0e4d23f5b929832c7344bab202f206006992f1bcdc25ad04adf9
+        checksum/config: 778f27dfec219b4e13f09cafa850f51b3772ab5c07852da710f99f9bd3e7f485
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -108,8 +108,8 @@ data:
           key: splunk.com/exclude
       resourcedetection:
         detectors:
-        - system
         - env
+        - system
         override: false
         timeout: 10s
     receivers:

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -53,8 +53,8 @@ data:
           value: ${K8S_NAMESPACE}
       resourcedetection:
         detectors:
-        - system
         - env
+        - system
         override: false
         timeout: 10s
     receivers:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e5f1faa5cd4269416852648f77811b7fcbaae22fa021537eb71e8c7d122c2061
+        checksum/config: e2e2b7c254278fdf9c8a9db509098560a2f318a70e5d2c2201ed7d611161b978
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -24,7 +24,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b7199de83a2d9e392d9fca87a4502647fff91685b985be232843e56f8bb5b8a7
+        checksum/config: d1121e7fcacdcd3fd90468b9aa670939aeb3676e07725e88a78b4763e40dbea9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -111,8 +111,8 @@ data:
           key: splunk.com/exclude
       resourcedetection:
         detectors:
-        - system
         - env
+        - system
         override: false
         timeout: 10s
     receivers:

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 8efc2aa37febcc0986bf74b5cb73a80372393844c42cda20548e42a80dcc03eb
+        checksum/config: 16e127a372cceaa9f9d836ba5c046bedb7045b4ad9150443234137db58fd62b4
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
Move the `system` detector to the last position so it can't preclude cloud detectors from setting host/os info.