### PR TITLE
Fix Values configuration references in comments

### DIFF
--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -221,7 +221,7 @@ otelAgent:
   extraVolumeMounts: []
 
   # OpenTelemetry Collector configuration for otel-agent daemonset can be overriden in this field.
-  # Default configuration defined in config/otel-agent-config.yaml
+  # Default configuration defined in templates/config/_otel-agent.tpl
   # Any additional fields will be merged into the defaults,
   # existing fields can be disabled by setting them to null value.
   config: {}
@@ -274,7 +274,7 @@ otelK8sClusterReceiver:
   extraVolumeMounts: []
 
   # OpenTelemetry Collector configuration for K8s Cluster Receiver deployment can be overriden in this field.
-  # Defaul configuration defined in config/otel-k8s-cluster-receiver-config.yaml
+  # Default configuration defined in templates/config/_otel-k8s-cluster-receiver-config.tpl
   # Any additional fields will be merged into the defaults,
   # existing fields can be disabled by setting them to null value.
   config: {}


### PR DESCRIPTION
I assume these where old/broken references to the templates/config/*.tpl files. If I'm wrong, I think the comments should be clearer about what files they are referring to.