### PR TITLE
Add validation of required parameters

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.5.4
+          version: v3.6.3
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -31,8 +31,32 @@
         },
         "token": {
           "type": "string"
+        },
+        "logsEnabled": {
+          "description": "Send Logs to Splunk Platform",
+          "type": "boolean"
+        },
+        "metricsEnabled": {
+          "description": "Send Metrics to Splunk Platform",
+          "type": "boolean"
         }
-      }
+      },
+      "anyOf": [
+        {
+          "properties": {
+            "logsEnabled": {
+              "const": true
+            }
+          }
+        },
+        {
+          "properties": {
+            "metricsEnabled": {
+              "const": true
+            }
+          }
+        }
+      ]
     },
     "splunkObservability": {
       "description": "Splunk Observability configuration",
@@ -49,8 +73,112 @@
         },
         "apiUrl": {
           "type": "string"
+        },
+        "metricsEnabled": {
+          "description": "Send Metrics to Splunk Observability",
+          "type": "boolean"
+        },
+        "tracesEnabled": {
+          "description": "Send Traces to Splunk Observability",
+          "type": "boolean"
+        },
+        "logsEnabled": {
+          "description": "Send Logs to Splunk Observability",
+          "type": "boolean"
+        }
+      },
+      "anyOf": [
+        {
+          "properties": {
+            "metricsEnabled": {
+              "const": true
+            }
+          }
+        },
+        {
+          "properties": {
+            "tracesEnabled": {
+              "const": true
+            }
+          }
+        },
+        {
+          "properties": {
+            "logsEnabled": {
+              "const": true
+            }
+          }
+        }
+      ]
+    }
+  },
+  "anyOf": [
+    {
+      "properties": {
+        "splunkPlatform": {
+          "type": "object",
+          "properties": {
+            "endpoint": {
+              "description": "Splunk Platform Endpoint",
+              "type": "string",
+              "format": "uri"
+            },
+            "token": {
+              "description": "Splunk Platform HEC Token",
+              "type": "string",
+              "minLength": 36,
+              "maxLength": 36
+            }
+          },
+          "required": [
+            "endpoint",
+            "token"
+          ]
         }
       }
+    },
+    {
+      "properties": {
+        "splunkObservability": {
+          "type": "object",
+          "properties": {
+            "realm": {
+              "description": "Splunk Observability Realm",
+              "type": "string",
+              "minLength": 3
+            },
+            "accessToken": {
+              "description": "Splunk Observability Access Token",
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "realm",
+            "accessToken"
+          ]
+        }
+      }
+    },
+    {
+      "properties": {
+        "splunkRealm": {
+          "description": "[DEPRECATED] Splunk Observability Realm",
+          "type": "string",
+          "deprecated": true,
+          "minLength": 3
+        },
+        "splunkAccessToken": {
+          "description": "[DEPRECATED] Splunk Observability Access Token",
+          "type": "string",
+          "deprecated": true,
+          "minLength": 1
+        }
+      },
+      "required": [
+        "splunkRealm",
+        "splunkAccessToken"
+      ]
     }
-  }
+  ]
 }


### PR DESCRIPTION
Add the following JSON Schema rules:
- Required fields of any of the destinations must be filled
- All destinations (`splunkPlatform` and `splunkObservability`) must have at least one of the telemetry types enabled

TODO in the following PR: rely only on `splunkPlatform.endpoint` and `splunkObservability.realm` to determine which destination is _enabled_, and require `splunkPlatform.token` and `splunkObservability.accessToken` for any _enabled_ destination.