### PR TITLE
Simplify logic identifying which destination is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   may change the `host.name` dimension and the resource ID dimension
   on some MTSes, possibly causing detectors to fire.
 - Change `run_id` log resource attribute to `k8s.container.restart_count` (#226)
+- Use only `splunkPlatform.endpoint` and `splunkObservability.realm` parameters
+  to identify which destination is enabled, remove default value for
+  `splunkObservability.realm` (#230)
 
 ## [0.36.2] - 2021-10-08
 

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -136,7 +136,7 @@ Create the name of the service account to use
 Get Splunk Observability Realm.
 */}}
 {{- define "splunk-otel-collector.o11yRealm" -}}
-{{- .Values.splunkObservability.realm | default .Values.splunkRealm | default "us0" }}
+{{- .Values.splunkObservability.realm | default .Values.splunkRealm }}
 {{- end -}}
 
 

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -27,9 +27,12 @@
       "type": "object",
       "properties": {
         "endpoint": {
+          "description": "Splunk Platform Endpoint",
+          "example": "http://localhost:8088/services/collector",
           "type": "string"
         },
         "token": {
+          "description": "Splunk Platform HEC Token",
           "type": "string"
         },
         "logsEnabled": {
@@ -56,16 +59,36 @@
             }
           }
         }
-      ]
+      ],
+      "if": {
+        "properties": {
+          "endpoint": {
+            "minLength": 1
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "endpoint": {
+            "format": "uri"
+          },
+          "token": {
+            "minLength": 1
+          }
+        }
+      }
     },
     "splunkObservability": {
       "description": "Splunk Observability configuration",
       "type": "object",
       "properties": {
         "realm": {
+          "description": "Splunk Observability Realm",
+          "example": "us0",
           "type": "string"
         },
         "accessToken": {
+          "description": "Splunk Observability Access Token",
           "type": "string"
         },
         "ingestUrl": {
@@ -109,7 +132,21 @@
             }
           }
         }
-      ]
+      ],
+      "if": {
+        "properties": {
+          "realm": {
+            "minLength": 1
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "accessToken": {
+            "minLength": 1
+          }
+        }
+      }
     }
   },
   "anyOf": [
@@ -119,21 +156,9 @@
           "type": "object",
           "properties": {
             "endpoint": {
-              "description": "Splunk Platform Endpoint",
-              "type": "string",
-              "format": "uri"
-            },
-            "token": {
-              "description": "Splunk Platform HEC Token",
-              "type": "string",
-              "minLength": 36,
-              "maxLength": 36
+              "minLength": 1
             }
-          },
-          "required": [
-            "endpoint",
-            "token"
-          ]
+          }
         }
       }
     },
@@ -143,20 +168,9 @@
           "type": "object",
           "properties": {
             "realm": {
-              "description": "Splunk Observability Realm",
-              "type": "string",
-              "minLength": 3
-            },
-            "accessToken": {
-              "description": "Splunk Observability Access Token",
-              "type": "string",
               "minLength": 1
             }
-          },
-          "required": [
-            "realm",
-            "accessToken"
-          ]
+          }
         }
       }
     },
@@ -166,19 +180,9 @@
           "description": "[DEPRECATED] Splunk Observability Realm",
           "type": "string",
           "deprecated": true,
-          "minLength": 3
-        },
-        "splunkAccessToken": {
-          "description": "[DEPRECATED] Splunk Observability Access Token",
-          "type": "string",
-          "deprecated": true,
           "minLength": 1
         }
-      },
-      "required": [
-        "splunkRealm",
-        "splunkAccessToken"
-      ]
+      }
     }
   ]
 }

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -24,10 +24,12 @@ clusterName: ""
 # Specify `endpoint` and `token` in order to send data to Splunk Cloud or Splunk
 # Enterprise.
 splunkPlatform:
-  # Required for Splunk Enterprise/Cloud. URL to a Splunk instance to send data to.
-  # e.g. "http://X.X.X.X:8088/services/collector"
+  # Required for Splunk Enterprise/Cloud. URL to a Splunk instance to send data
+  # to. e.g. "http://X.X.X.X:8088/services/collector". Setting this parameter
+  # enables Splunk Platform as a destination.
   endpoint: ""
-  # Required for Splunk Enterprise/Cloud. Splunk HTTP Event Collector token.
+  # Required for Splunk Enterprise/Cloud (if `endpoint` is specified). Splunk
+  # HTTP Event Collector token.
   token: ""
 
   # Optional. Name of the Splunk index targeted.
@@ -73,9 +75,11 @@ splunkPlatform:
 # Cloud.
 splunkObservability:
   # Required for Splunk Observability. Splunk Observability realm to send
-  # telemetry data to.
+  # telemetry data to. Setting this parameter enables Splunk Observability as a
+  # destination.
   realm: ""
-  # Required for Splunk Observability. Splunk Observability org access token.
+  # Required for Splunk Observability (if `realm` is specified). Splunk
+  # Observability org access token.
   accessToken: ""
 
   # Optional. Splunk Observability ingest URL, default:


### PR DESCRIPTION
Use only `splunkPlatform.endpoint` and `splunkObservability.realm` parameters to identify which destination is enabled, remove default value for `splunkObservability.realm`