### PR TITLE
Reduce scope of host mounted volumes on linux systems

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -242,10 +242,30 @@ spec:
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: otel-configmap
         {{- if eq (include "splunk-otel-collector.metricsEnabled" $) "true" }}
-        - mountPath: {{ .Values.isWindows | ternary "C:\\hostfs" "/hostfs" }}
+        {{- if .Values.isWindows }}
+        - mountPath: "C:\\hostfs"
           name: hostfs
           readOnly: true
-          mountPropagation: HostToContainer
+        {{- else }}
+        - mountPath: /hostfs/dev
+          name: host-dev
+          readOnly: true
+        - mountPath: /hostfs/etc
+          name: host-etc
+          readOnly: true
+        - mountPath: /hostfs/proc
+          name: host-proc
+          readOnly: true
+        - mountPath: /hostfs/run/udev/data
+          name: host-run-udev-data
+          readOnly: true
+        - mountPath: /hostfs/sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /hostfs/var/run/utmp
+          name: host-var-run-utmp
+          readOnly: true
+        {{- end }}
         {{- end }}
         {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") .Values.logsCollection.enabled }}
         - name: varlog
@@ -302,9 +322,30 @@ spec:
       {{- end}}
       {{- end}}
       {{- if eq (include "splunk-otel-collector.metricsEnabled" $) "true" }}
+      {{- if .Values.isWindows }}
       - name: hostfs
         hostPath:
-          path: {{ .Values.isWindows | ternary "C:\\" "/" }}
+          path: "C:\\"
+      {{- else }}
+      - name: host-dev
+        hostPath:
+          path: /dev
+      - name: host-etc
+        hostPath:
+          path: /etc
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-var-run-utmp
+        hostPath:
+          path: /var/run/utmp
+      {{- end }}
       {{- end }}
       - name: otel-configmap
         configMap:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -208,10 +208,24 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs
-          name: hostfs
+        - mountPath: /hostfs/dev
+          name: host-dev
           readOnly: true
-          mountPropagation: HostToContainer
+        - mountPath: /hostfs/etc
+          name: host-etc
+          readOnly: true
+        - mountPath: /hostfs/proc
+          name: host-proc
+          readOnly: true
+        - mountPath: /hostfs/run/udev/data
+          name: host-run-udev-data
+          readOnly: true
+        - mountPath: /hostfs/sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /hostfs/var/run/utmp
+          name: host-var-run-utmp
+          readOnly: true
       terminationGracePeriodSeconds: 600
       volumes:
       - name: varlog
@@ -237,9 +251,24 @@ spec:
       - name: fluentd-config-json
         configMap:
           name: default-splunk-otel-collector-fluentd-json
-      - name: hostfs
+      - name: host-dev
         hostPath:
-          path: /
+          path: /dev
+      - name: host-etc
+        hostPath:
+          path: /etc
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-var-run-utmp
+        hostPath:
+          path: /var/run/utmp
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -116,15 +116,44 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs
-          name: hostfs
+        - mountPath: /hostfs/dev
+          name: host-dev
           readOnly: true
-          mountPropagation: HostToContainer
+        - mountPath: /hostfs/etc
+          name: host-etc
+          readOnly: true
+        - mountPath: /hostfs/proc
+          name: host-proc
+          readOnly: true
+        - mountPath: /hostfs/run/udev/data
+          name: host-run-udev-data
+          readOnly: true
+        - mountPath: /hostfs/sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /hostfs/var/run/utmp
+          name: host-var-run-utmp
+          readOnly: true
       terminationGracePeriodSeconds: 600
       volumes:
-      - name: hostfs
+      - name: host-dev
         hostPath:
-          path: /
+          path: /dev
+      - name: host-etc
+        hostPath:
+          path: /etc
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-var-run-utmp
+        hostPath:
+          path: /var/run/utmp
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent


### PR DESCRIPTION
Reduce scope of host paths for mounted volumes to the minimum required by hostmetrics receiver - gopsutil library.

This change allows us to run the Splunk OTel Collector in k8s environments where mounting to host "/" path is prohibited.