### PR TITLE
Fix helpers according to the new way of identifying enabled destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change `run_id` log resource attribute to `k8s.container.restart_count` (#226)
 - Use only `splunkPlatform.endpoint` and `splunkObservability.realm` parameters
   to identify which destination is enabled, remove default value for
-  `splunkObservability.realm` (#230)
+  `splunkObservability.realm` (#230, #233)
 
 ## [0.36.2] - 2021-10-08
 

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -36,14 +36,14 @@ Create chart name and version as used by the chart label.
 Whether to send data to Splunk Platform endpoint
 */}}
 {{- define "splunk-otel-collector.splunkPlatformEnabled" -}}
-{{- and (not (eq .Values.splunkPlatform.token "")) (not (eq .Values.splunkPlatform.endpoint "")) }}
+{{- not (eq .Values.splunkPlatform.endpoint "") }}
 {{- end -}}
 
 {{/*
 Whether to send data to Splunk Observability endpoint
 */}}
 {{- define "splunk-otel-collector.splunkO11yEnabled" -}}
-{{- not (eq (include "splunk-otel-collector.o11yAccessToken" .) "") }}
+{{- not (eq (include "splunk-otel-collector.o11yRealm" .) "") }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Enabled destination is now identified only based on `realm` and `endpoint` sub-properties: https://github.com/signalfx/splunk-otel-collector-chart/pull/230. This change updates missed helpers according to the new behavior.