### PR TITLE
Enable container metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add recommended Kubernetes labels (#217)
 - Add an option to skip RBAC resources creation (#231)
+- Enable container metadata. This gives all collected logs new attributes:
+  `container.image.name` and `container.image.tag`. Also the native OTel logs
+  collection gets `container.id` attribute that allows container level
+  correlation in Splunk Observability Cloud closing a feature parity gap with
+  fluentd (#238)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -262,9 +262,6 @@ logsCollection:
 
 There are following known limitations of native OTel logs collection:
 
-- Container attributes `container.id` and `container.image.name` are missed.
-  This means that correlation between Splunk Log Observer and Splunk Infrastructure will not work
-  on container level, but only on kubernetes pod level.
 - `service.name` attribute will not be automatically constructed in istio environment.
   This means that correlation between logs and traces will not work in Splunk Observability.
   Logs collection with fluentd is still recommended if chart deployed with `autodetect.istio=true`.

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -261,6 +261,9 @@ processors:
         - k8s.node.name
         - k8s.pod.name
         - k8s.pod.uid
+        - container.id
+        - container.image.name
+        - container.image.tag
       annotations:
         - key: splunk.com/sourcetype
           from: pod

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -74,6 +74,9 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7046b15271336873e77b7dae353d9bd71ab4dec553a460d440913ca294d30c5b
+        checksum/config: 20c4d8e2e7bc9a2924dba5bfe36640c2ec2fa0f32c01d2026be3a69f0fa06a15
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -71,6 +71,9 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: a6fb3caee40d3d0a7a2c7726a0f2f621e9f270c6d56b956bcae8d1ceb8421064
+        checksum/config: e95c74111b5c110623844b7e316bf9a93598f684b2cb787c4ed250ba1c528d24
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -68,6 +68,9 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: a8c33a8554a33b955562ff9e1e7a2a7c7409c179b04bff5728e9ec1741577d23
+        checksum/config: 6cc02bfff24ad61ac0294515e7506e75cf2dc7b07d3274b5cf5432453f6c427d
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -71,6 +71,9 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e18ad46f2914367f00f5da0655f349445f251296a846a9e749368a87aa9809b7
+        checksum/config: 90bba67d61912a1cbc230c7708a54d9bf38fb33e53dab8f02e38bf08fddbdbf2
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
This gives all collected logs new attributes: `container.image.name` and `container.image.tag`. Also the native OTel logs collection gets `container.id` attribute that allows container level correlation in Splunk Observability Cloud closing a feature parity gap with fluentd.

Depends on https://github.com/signalfx/splunk-otel-collector-chart/pull/237