### PR TITLE
Mark otel-collector as default container in otelAgent pod

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -33,6 +33,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ print (include (print $.Template.BasePath "/configmap-fluentd.yaml") .) (include (print $.Template.BasePath "/configmap-otel-agent.yaml") .) | sha256sum }}
+        kubectl.kubernetes.io/default-container: otel-collector
         {{- if .Values.otelAgent.podAnnotations }}
         {{- toYaml .Values.otelAgent.podAnnotations | nindent 8 }}
         {{- end }}

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -29,6 +29,7 @@ spec:
         release: default
       annotations:
         checksum/config: 20c4d8e2e7bc9a2924dba5bfe36640c2ec2fa0f32c01d2026be3a69f0fa06a15
+        kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -29,6 +29,7 @@ spec:
         release: default
       annotations:
         checksum/config: e95c74111b5c110623844b7e316bf9a93598f684b2cb787c4ed250ba1c528d24
+        kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -28,6 +28,7 @@ spec:
         release: default
       annotations:
         checksum/config: 6cc02bfff24ad61ac0294515e7506e75cf2dc7b07d3274b5cf5432453f6c427d
+        kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -28,6 +28,7 @@ spec:
         release: default
       annotations:
         checksum/config: 90bba67d61912a1cbc230c7708a54d9bf38fb33e53dab8f02e38bf08fddbdbf2
+        kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
To have quick access to otel-collector logs and shell