### PR TITLE
Enable OTLP HTTP ports in otelAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix setting of SPLUNK_MEMORY_TOTAL_MIB env var in otelAgent daemonset (#240)
+- Enable OTLP HTTP ports (4318 and 55681) in otelAgent daemonset (#243)
 
 ## [0.36.2] - 2021-10-08
 

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -23,13 +23,15 @@ sapm:
 {{/*
 Common config for the otel-collector traces receivers
 */}}
-{{- define "splunk-otel-collector.otelTraceReceivers" -}}
+{{- define "splunk-otel-collector.otelReceivers" -}}
 otlp:
   protocols:
     grpc:
       endpoint: 0.0.0.0:4317
     http:
-      endpoint: 0.0.0.0:55681
+      # Deprecated 55681 port is also open by default:
+      # https://github.com/open-telemetry/opentelemetry-collector/blob/9d3a8a4608a7dbd9f787867226a78356ace9b5e4/receiver/otlpreceiver/otlp.go#L140-L152
+      endpoint: 0.0.0.0:4318
 
 {{- if (eq (include "splunk-otel-collector.tracesEnabled" .) "true") }}
 jaeger:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -21,7 +21,7 @@ extensions:
   zpages:
 
 receivers:
-  {{- include "splunk-otel-collector.otelTraceReceivers" . | nindent 2 }}
+  {{- include "splunk-otel-collector.otelReceivers" . | nindent 2 }}
   {{- if (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   fluentforward:
     endpoint: 0.0.0.0:8006
@@ -475,7 +475,7 @@ service:
     {{- if (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
     # Default metrics pipeline.
     metrics:
-      receivers: [hostmetrics, kubeletstats, receiver_creator, signalfx]
+      receivers: [hostmetrics, kubeletstats, otlp, receiver_creator, signalfx]
       processors:
         - memory_limiter
         - batch

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -18,7 +18,7 @@ extensions:
   zpages:
 
 receivers:
-  {{- include "splunk-otel-collector.otelTraceReceivers" . | nindent 2 }}
+  {{- include "splunk-otel-collector.otelReceivers" . | nindent 2 }}
   # Prometheus receiver scraping metrics from the pod itself
   prometheus/collector:
     config:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -176,6 +176,14 @@ otelAgent:
       hostPort: 4317
       protocol: TCP
       enabled_for: [traces, metrics, logs]
+    otlp-http:
+      containerPort: 4318
+      protocol: TCP
+      enabled_for: [metrics, traces, logs]
+    otlp-http-old:
+      containerPort: 55681
+      protocol: TCP
+      enabled_for: [metrics, traces, logs]
     sfx-forwarder:
       containerPort: 9080
       hostPort: 9080
@@ -742,6 +750,14 @@ otelCollector:
   ports:
     otlp:
       containerPort: 4317
+      protocol: TCP
+      enabled_for: [metrics, traces, logs]
+    otlp-http:
+      containerPort: 4318
+      protocol: TCP
+      enabled_for: [metrics, traces, logs]
+    otlp-http-old:
+      containerPort: 55681
       protocol: TCP
       enabled_for: [metrics, traces, logs]
     jaeger-thrift:

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -161,7 +161,7 @@ data:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
-            endpoint: 0.0.0.0:55681
+            endpoint: 0.0.0.0:4318
       prometheus/agent:
         config:
           scrape_configs:
@@ -214,6 +214,7 @@ data:
           receivers:
           - hostmetrics
           - kubeletstats
+          - otlp
           - receiver_creator
           - signalfx
         metrics/agent:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 20c4d8e2e7bc9a2924dba5bfe36640c2ec2fa0f32c01d2026be3a69f0fa06a15
+        checksum/config: b6365fda63714975a0357475d78ca2b29d611d88ed423a6904ab6907c2479f0e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -131,6 +131,12 @@ spec:
         - name: otlp
           containerPort: 4317
           hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
           protocol: TCP
         - name: sfx-forwarder
           containerPort: 9080

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -120,7 +120,7 @@ data:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
-            endpoint: 0.0.0.0:55681
+            endpoint: 0.0.0.0:4318
       prometheus/collector:
         config:
           scrape_configs:

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 68815a7328d29288d3a9c09989ae0a9d1023732c67463b76ad3356f8cf04c8e1
+        checksum/config: 3fc26f2c3706b45f1bf56a11ef643d9772828fb83fb1c93684ad2598e98cf195
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -84,6 +84,12 @@ spec:
           protocol: TCP
         - name: otlp
           containerPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/rendered/manifests/gateway-only/service.yaml
+++ b/rendered/manifests/gateway-only/service.yaml
@@ -35,6 +35,14 @@ spec:
     port: 4317
     targetPort: otlp
     protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: otlp-http-old
+    port: 55681
+    targetPort: otlp-http-old
+    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -131,7 +131,7 @@ data:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
-            endpoint: 0.0.0.0:55681
+            endpoint: 0.0.0.0:4318
       prometheus/agent:
         config:
           scrape_configs:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e95c74111b5c110623844b7e316bf9a93598f684b2cb787c4ed250ba1c528d24
+        checksum/config: 6b6d963c9f9d26928b86591169ecbb81988e113867bb59367c653ee8e171d94f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -123,6 +123,12 @@ spec:
         - name: otlp
           containerPort: 4317
           hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
           protocol: TCP
         image: quay.io/signalfx/splunk-otel-collector:0.37.0
         imagePullPolicy: IfNotPresent

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -147,7 +147,7 @@ data:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
-            endpoint: 0.0.0.0:55681
+            endpoint: 0.0.0.0:4318
       prometheus/agent:
         config:
           scrape_configs:
@@ -180,6 +180,7 @@ data:
           receivers:
           - hostmetrics
           - kubeletstats
+          - otlp
           - receiver_creator
           - signalfx
         metrics/agent:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6cc02bfff24ad61ac0294515e7506e75cf2dc7b07d3274b5cf5432453f6c427d
+        checksum/config: 4993cc0f3f69a3a7930aa2ca7b2cbf9febc75305fa65f95492e654348ef9c524
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -49,6 +49,12 @@ spec:
         - name: otlp
           containerPort: 4317
           hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -135,7 +135,7 @@ data:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
-            endpoint: 0.0.0.0:55681
+            endpoint: 0.0.0.0:4318
       prometheus/agent:
         config:
           scrape_configs:

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 90bba67d61912a1cbc230c7708a54d9bf38fb33e53dab8f02e38bf08fddbdbf2
+        checksum/config: 0683086ff0397d4b836c79a60a7590fba44e0821a8c7c561d7f3a7bd663c3286
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -57,6 +57,12 @@ spec:
         - name: otlp
           containerPort: 4317
           hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
           protocol: TCP
         - name: sfx-forwarder
           containerPort: 9080


### PR DESCRIPTION
Enable the new OTLP HTTP 4318 port and open it along with the deprecated 55681 port as host ports in the OTel agent daemonset for all telemetry types.

Resolves: https://github.com/signalfx/splunk-otel-collector-chart/issues/243