### PR TITLE
Set securityContext for native logs collection

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -157,9 +157,14 @@ spec:
         {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
-        {{- if .Values.otelAgent.securityContext }}
+        {{- if or .Values.otelAgent.securityContext (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") .Values.logsCollection.enabled) }}
         securityContext:
+          {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") .Values.logsCollection.enabled }}
+          runAsUser: 0
+          {{- end }}
+          {{- if .Values.otelAgent.securityContext }}
           {{ toYaml .Values.otelAgent.securityContext | nindent 10 }}
+          {{- end }}
         {{- end }}
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB


### PR DESCRIPTION
Since the image is not running under root user anymore by default, we need to set `runAsUser: 0` for native logs collection