### PR TITLE
Add include logs functionality

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -270,11 +270,11 @@ processors:
       annotations:
         - key: splunk.com/sourcetype
           from: pod
-        - key: splunk.com/exclude
-          tag_name: splunk.com/exclude
+        - key: {{ include "splunk-otel-collector.filterAttr" . }}
+          tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
           from: namespace
-        - key: splunk.com/exclude
-          tag_name: splunk.com/exclude
+        - key: {{ include "splunk-otel-collector.filterAttr" . }}
+          tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
           from: pod
         - key: splunk.com/index
           tag_name: com.splunk.index

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -53,11 +53,11 @@ processors:
       annotations:
         - key: splunk.com/sourcetype
           from: pod
-        - key: splunk.com/exclude
-          tag_name: splunk.com/exclude
+        - key: {{ include "splunk-otel-collector.filterAttr" . }}
+          tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
           from: namespace
-        - key: splunk.com/exclude
-          tag_name: splunk.com/exclude
+        - key: {{ include "splunk-otel-collector.filterAttr" . }}
+          tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
           from: pod
         - key: splunk.com/index
           tag_name: com.splunk.index

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -482,6 +482,9 @@
                 "type": "string"
               }
             },
+            "useSplunkIncludeAnnotation": {
+              "type": "boolean"
+            },
             "multilineConfigs": {
               "type": "array",
               "items": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -348,8 +348,6 @@ logsCollection:
     # By the time of reconstructing a multiline log the following information is available to
     # identify source of the logs: namespace, pod and container names. At least one source
     # identifier has to be specified in for each multiline config.
-    multilineConfigs: []
-
     # The following example shows how to setup multiline log processing for logs having subsequent
     # log lines written with an offset. Let's say a k8s deployment called "buttercup-app" is
     # scheduled to run in "default" namespace with a java container called "server", and the
@@ -372,7 +370,8 @@ logsCollection:
     #     containerName:
     #       value: server
     #     firstEntryRegex: ^[^\s].*
-    # Set this flag to `true` to collect logs from pods with `splunk.com/include: true` annotation and ignore others.
+    multilineConfigs: []
+    # Set useSplunkIncludeAnnotation flag to `true` to collect logs from pods with `splunk.com/include: true` annotation and ignore others.
     # All other logs will be ignored.
     useSplunkIncludeAnnotation: false
 

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -349,6 +349,7 @@ logsCollection:
     # identify source of the logs: namespace, pod and container names. At least one source
     # identifier has to be specified in for each multiline config.
     multilineConfigs: []
+
     # The following example shows how to setup multiline log processing for logs having subsequent
     # log lines written with an offset. Let's say a k8s deployment called "buttercup-app" is
     # scheduled to run in "default" namespace with a java container called "server", and the
@@ -371,6 +372,9 @@ logsCollection:
     #     containerName:
     #       value: server
     #     firstEntryRegex: ^[^\s].*
+    # Set this flag to `true` to collect logs from pods with `splunk.com/include: true` annotation and ignore others.
+    # All other logs will be ignored.
+    useSplunkIncludeAnnotation: false
 
   checkpointPath: "/var/addon/splunk/otel_pos"
 


### PR DESCRIPTION
Set splunk.com/include annotation to true on pod and .Values.logsCollection.containers.useSplunkIncludeAnnotation flag to true to include its logs from ingested to your Splunk platform deployment. 
All other logs will be ignored. 