### PR TITLE
updated sourcetype precedence order

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -173,7 +173,6 @@ splunk_hec/platform_logs:
   token: "${SPLUNK_PLATFORM_HEC_TOKEN}"
   index: {{ .Values.splunkPlatform.index | quote }}
   source: {{ .Values.splunkPlatform.source | quote }}
-  sourcetype: {{ .Values.splunkPlatform.sourcetype | quote }}
   max_connections: {{ .Values.splunkPlatform.max_connections }}
   disable_compression: {{ .Values.splunkPlatform.disable_compression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
@@ -201,7 +200,6 @@ splunk_hec/platform_metrics:
   token: "${SPLUNK_PLATFORM_HEC_TOKEN}"
   index: {{ .Values.splunkPlatform.metrics_index | quote }}
   source: {{ .Values.splunkPlatform.source | quote }}
-  sourcetype: {{ .Values.splunkPlatform.sourcetype | quote }}
   max_connections: {{ .Values.splunkPlatform.max_connections }}
   disable_compression: {{ .Values.splunkPlatform.disable_compression }}
   timeout: {{ .Values.splunkPlatform.timeout }}

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -84,6 +84,11 @@ Resource processor for logs manipulations
 {{- define "splunk-otel-collector.resourceLogsProcessor" -}}
 resource/logs:
   attributes:
+    {{- if .Values.splunkPlatform.sourcetype }}
+    - key: com.splunk.sourcetype
+      value: "{{.Values.splunkPlatform.sourcetype }}"
+      action: upsert
+    {{- end }}
     - key: com.splunk.sourcetype
       from_attribute: k8s.pod.annotations.splunk.com/sourcetype
       action: upsert


### PR DESCRIPTION
updated sourcetype precedence order: 

- Sourcetype defined via Pod annotation [1]
- Sourcetype defined via optional config param in helm chart values [2]
- K8s metadata: “kube:container:<CONTAINER_NAME>” for container logs [3]
- Sourcetype for non-container logs/ extrafiles: "defined by the user in the config" [4]
