### PR TITLE
ingest metrics to Splunk only when metrics index is given

### DIFF
--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1084,30 +1084,32 @@
     {
       "if": {
         "$comment": "if splunkPlatform.metricsEnabled is true and splunkPlatform.endpoint is provided",
+        "properties": {
+          "splunkPlatform": {
             "properties": {
-              "splunkPlatform": {
-                "properties": {
-                  "endpoint": {
-                    "minLength": 1
-                  }
-                }
+              "endpoint": {
+                "minLength": 1
               }
-            },
-              "splunkPlatform": {
-                "properties": {
-                  "metricsEnabled": {
-                    "const": true
-                  }
-                }
-              }
-            },
+            }
+          }
+        }
+      },
       "then": {
         "$comment": "then splunkPlatform.metrics_index must be provided",
         "properties": {
           "splunkPlatform": {
-            "properties": {
-              "metrics_index": {
-                "minLength": 1
+            "if" : {
+              "properties": {
+                "metricsEnabled": {
+                  "const": true
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "metrics_index": {
+                  "minLength": 1
+                }
               }
             }
           }

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1115,6 +1115,41 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "$comment": "if splunkPlatform.logsEnabled is true and splunkPlatform.endpoint is provided",
+        "properties": {
+          "splunkPlatform": {
+            "properties": {
+              "endpoint": {
+                "minLength": 1
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "$comment": "then splunkPlatform.index must be provided",
+        "properties": {
+          "splunkPlatform": {
+            "if" : {
+              "properties": {
+                "logsEnabled": {
+                  "const": true
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "index": {
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -992,89 +992,127 @@
       "deprecated": true
     }
   },
-  "anyOf": [
+  "allOf": [
     {
-      "properties": {
-        "splunkPlatform": {
-          "type": "object",
+      "anyOf": [
+        {
           "properties": {
-            "endpoint": {
-              "minLength": 1
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "splunkObservability": {
-          "type": "object",
-          "properties": {
-            "realm": {
-              "minLength": 1
-            }
-          }
-        }
-      }
-    },
-    {
-      "properties": {
-        "splunkRealm": {
-          "description": "[DEPRECATED] Splunk Observability Realm",
-          "type": "string",
-          "deprecated": true,
-          "minLength": 1
-        }
-      }
-    }
-  ],
-  "if": {
-    "$comment": "if k8s secret resource created by the chart (default behavior)",
-    "properties": {
-      "secret": {
-        "properties": {
-          "create": {
-            "const": true
-          }
-        }
-      }
-    }
-  },
-  "then": {
-    "$comment": "then require tokens to be provided for every enabled destination",
-    "properties": {
-      "splunkObservability": {
-        "if": {
-          "properties": {
-            "realm": {
-              "minLength": 1
+            "splunkPlatform": {
+              "type": "object",
+              "properties": {
+                "endpoint": {
+                  "minLength": 1
+                }
+              }
             }
           }
         },
-        "then": {
+        {
           "properties": {
-            "accessToken": {
+            "splunkObservability": {
+              "type": "object",
+              "properties": {
+                "realm": {
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        {
+          "properties": {
+            "splunkRealm": {
+              "description": "[DEPRECATED] Splunk Observability Realm",
+              "type": "string",
+              "deprecated": true,
               "minLength": 1
+            }
+          }
+        }
+      ]},
+    {
+      "if": {
+        "$comment": "if k8s secret resource created by the chart (default behavior)",
+        "properties": {
+          "secret": {
+            "properties": {
+              "create": {
+                "const": true
+              }
             }
           }
         }
       },
-      "splunkPlatform": {
-        "if": {
-          "properties": {
-            "endpoint": {
-              "minLength": 1
+      "then": {
+        "$comment": "then require tokens to be provided for every enabled destination",
+        "properties": {
+          "splunkObservability": {
+            "if": {
+              "properties": {
+                "realm": {
+                  "minLength": 1
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "accessToken": {
+                  "minLength": 1
+                }
+              }
+            }
+          },
+          "splunkPlatform": {
+            "if": {
+              "properties": {
+                "endpoint": {
+                  "minLength": 1
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "token": {
+                  "minLength": 1
+                }
+              }
             }
           }
-        },
-        "then": {
-          "properties": {
-            "token": {
-              "minLength": 1
+        }
+      }
+    },
+    {
+      "if": {
+        "$comment": "if splunkPlatform.metricsEnabled is true and splunkPlatform.endpoint is provided",
+            "properties": {
+              "splunkPlatform": {
+                "properties": {
+                  "endpoint": {
+                    "minLength": 1
+                  }
+                }
+              }
+            },
+              "splunkPlatform": {
+                "properties": {
+                  "metricsEnabled": {
+                    "const": true
+                  }
+                }
+              }
+            },
+      "then": {
+        "$comment": "then splunkPlatform.metrics_index must be provided",
+        "properties": {
+          "splunkPlatform": {
+            "properties": {
+              "metrics_index": {
+                "minLength": 1
+              }
             }
           }
         }
       }
     }
-  }
+  ]
 }

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -32,8 +32,9 @@ splunkPlatform:
   # HTTP Event Collector token.
   token: ""
 
-  # Optional. Name of the Splunk index targeted.
+  # Name of the Splunk event type index targeted. Required when ingesting logs to Splunk Platform.
   index: ""
+  # Name of the Splunk metric type index targeted. Required when ingesting metrics to Splunk Platform.
   metrics_index: ""
   # Optional. Default value for `source` field.
   source: "kubernetes"


### PR DESCRIPTION
when metrics are ingested to event type splunk index, client doesn't error out but it is not right. metrics should be sent to 
Splunk's metric type index. 
this prevents metrics data being sent when `metrics_index` is not specified. 