### PR TITLE
Extract `container.image.tag` attribute from `container.image.name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Field name compatibility for SCK (#258)
 
+### Changed
+
+- Extract `container.image.tag` attribute from `container.image.name` (#285)
+
 ### Removed
 
 - Busybox image dependency (#275)

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -94,6 +94,21 @@ processors:
         key: {{ .name }}
         value: {{ .value }}
       {{- end }}
+      # Extract "container.image.tag" attribute from "container.image.name" here until k8scluster
+      # receiver does it natively.
+      - key: container.image.name
+        pattern: ^(?P<container_image_name>[^\:]+)(?:\:(?P<container_image_tag>.*))?
+        action: extract
+      - key: container.image.name
+        from_attribute: container_image_name
+        action: upsert
+      - key: container_image_name
+        action: delete
+      - key: container.image.tag
+        from_attribute: container_image_tag
+        action: upsert
+      - key: container_image_tag
+        action: delete
 
 exporters:
   {{- if eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true" }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -97,17 +97,17 @@ processors:
       # Extract "container.image.tag" attribute from "container.image.name" here until k8scluster
       # receiver does it natively.
       - key: container.image.name
-        pattern: ^(?P<container_image_name>[^\:]+)(?:\:(?P<container_image_tag>.*))?
+        pattern: ^(?P<temp_container_image_name>[^\:]+)(?:\:(?P<temp_container_image_tag>.*))?
         action: extract
       - key: container.image.name
-        from_attribute: container_image_name
+        from_attribute: temp_container_image_name
         action: upsert
-      - key: container_image_name
+      - key: temp_container_image_name
         action: delete
       - key: container.image.tag
-        from_attribute: container_image_tag
+        from_attribute: temp_container_image_tag
         action: upsert
-      - key: container_image_tag
+      - key: temp_container_image_tag
         action: delete
 
 exporters:

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -44,17 +44,17 @@ data:
           value: CHANGEME
         - action: extract
           key: container.image.name
-          pattern: ^(?P<container_image_name>[^\:]+)(?:\:(?P<container_image_tag>.*))?
+          pattern: ^(?P<temp_container_image_name>[^\:]+)(?:\:(?P<temp_container_image_tag>.*))?
         - action: upsert
-          from_attribute: container_image_name
+          from_attribute: temp_container_image_name
           key: container.image.name
         - action: delete
-          key: container_image_name
+          key: temp_container_image_name
         - action: upsert
-          from_attribute: container_image_tag
+          from_attribute: temp_container_image_tag
           key: container.image.tag
         - action: delete
-          key: container_image_tag
+          key: temp_container_image_tag
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -42,6 +42,19 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+        - action: extract
+          key: container.image.name
+          pattern: ^(?P<container_image_name>[^\:]+)(?:\:(?P<container_image_tag>.*))?
+        - action: upsert
+          from_attribute: container_image_name
+          key: container.image.name
+        - action: delete
+          key: container_image_name
+        - action: upsert
+          from_attribute: container_image_tag
+          key: container.image.tag
+        - action: delete
+          key: container_image_tag
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0482b5c8dc6f8b2b65eaca8979490e13ddffaa7ef323cf330677deee0e635b5e
+        checksum/config: c77ad0b36c4dd8182418b2149d996143bac0dc03f2036aad1410acef22c75eec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c77ad0b36c4dd8182418b2149d996143bac0dc03f2036aad1410acef22c75eec
+        checksum/config: 1f01ab0ce60e050a9b9214ed9d89548557c428e16b1006d83182f5f4cd534a03
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -44,17 +44,17 @@ data:
           value: CHANGEME
         - action: extract
           key: container.image.name
-          pattern: ^(?P<container_image_name>[^\:]+)(?:\:(?P<container_image_tag>.*))?
+          pattern: ^(?P<temp_container_image_name>[^\:]+)(?:\:(?P<temp_container_image_tag>.*))?
         - action: upsert
-          from_attribute: container_image_name
+          from_attribute: temp_container_image_name
           key: container.image.name
         - action: delete
-          key: container_image_name
+          key: temp_container_image_name
         - action: upsert
-          from_attribute: container_image_tag
+          from_attribute: temp_container_image_tag
           key: container.image.tag
         - action: delete
-          key: container_image_tag
+          key: temp_container_image_tag
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -42,6 +42,19 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+        - action: extract
+          key: container.image.name
+          pattern: ^(?P<container_image_name>[^\:]+)(?:\:(?P<container_image_tag>.*))?
+        - action: upsert
+          from_attribute: container_image_name
+          key: container.image.name
+        - action: delete
+          key: container_image_name
+        - action: upsert
+          from_attribute: container_image_tag
+          key: container.image.tag
+        - action: delete
+          key: container_image_tag
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0482b5c8dc6f8b2b65eaca8979490e13ddffaa7ef323cf330677deee0e635b5e
+        checksum/config: c77ad0b36c4dd8182418b2149d996143bac0dc03f2036aad1410acef22c75eec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c77ad0b36c4dd8182418b2149d996143bac0dc03f2036aad1410acef22c75eec
+        checksum/config: 1f01ab0ce60e050a9b9214ed9d89548557c428e16b1006d83182f5f4cd534a03
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
Update k8sClusterReceiver component to export `container.image.tag` attribute from `container.image.name` according to OpenTelemetry semantic conventions https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/resource/semantic_conventions/container.md

This can be removed once this issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6314 is resolved