### PR TITLE
Change secret names according to the GDI specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+[Upgrade
+guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380)
+
 ### Added
 
 - Field name compatibility for SCK (#258)
@@ -12,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Extract `container.image.tag` attribute from `container.image.name` (#285)
 - Upgrade splunk-otel-collector image to 0.38.1 (#284)
+- Change secret names according to the GDI specification (#295)
 
 ### Fixed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,14 @@
 # Upgrade guidelines
 
+## 0.37.1 to 0.38.0
+
+[#295 Secret names are changed according to the GDI
+specification](https://github.com/signalfx/splunk-otel-collector-chart/pull/295)
+
+If you provide access token for Splunk Observability using a custom Kubernetes
+secret (secter.create=false), please update the secret name from
+`splunk_o11y_access_token` to `splunk_observability_access_token`
+
 ## 0.36.2 to 0.37.0
 
 [#232 Access to underlying node's filesystem was reduced to the minimum scope

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -16,7 +16,7 @@ Common config for the otel-collector sapm exporter
 {{- if (eq (include "splunk-otel-collector.tracesEnabled" .) "true") }}
 sapm:
   endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v2/trace
-  access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+  access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
 {{- end }}
 {{- end }}
 
@@ -181,13 +181,13 @@ splunk_hec/platform_logs:
   tls:
     insecure_skip_verify: {{ .Values.splunkPlatform.insecure_skip_verify }}
     {{- if .Values.splunkPlatform.clientCert }}
-    cert_file: /otel/etc/hec_client_cert
+    cert_file: /otel/etc/splunk_platform_hec_client_cert
     {{- end }}
     {{- if .Values.splunkPlatform.clientKey  }}
-    key_file: /otel/etc/hec_client_key
+    key_file: /otel/etc/splunk_platform_hec_client_key
     {{- end }}
     {{- if .Values.splunkPlatform.caFile }}
-    ca_file: /otel/etc/hec_ca_file
+    ca_file: /otel/etc/splunk_platform_hec_ca_file
     {{- end }}
 {{- end }}
 
@@ -208,12 +208,12 @@ splunk_hec/platform_metrics:
   tls:
     insecure_skip_verify: {{ .Values.splunkPlatform.insecure_skip_verify }}
     {{- if .Values.splunkPlatform.clientCert }}
-    cert_file: /otel/etc/hec_client_cert
+    cert_file: /otel/etc/splunk_platform_hec_client_cert
     {{- end }}
     {{- if .Values.splunkPlatform.clientKey  }}
-    key_file: /otel/etc/hec_client_key
+    key_file: /otel/etc/splunk_platform_hec_client_key
     {{- end }}
     {{- if .Values.splunkPlatform.caFile }}
-    ca_file: /otel/etc/hec_ca_file
+    ca_file: /otel/etc/splunk_platform_hec_ca_file
     {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -380,7 +380,7 @@ exporters:
   {{- if (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") }}
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
-    token: "${SPLUNK_O11Y_ACCESS_TOKEN}"
+    token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
   {{- end }}
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
   {{- include "splunk-otel-collector.splunkPlatformLogsExporter" . | nindent 2 }}
@@ -400,7 +400,7 @@ exporters:
     ingest_url: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
     {{- end }}
-    access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+    access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     sync_host_metadata: true
   {{- end }}
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -128,7 +128,7 @@ exporters:
   signalfx:
     ingest_url: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
-    access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+    access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
@@ -138,7 +138,7 @@ exporters:
   {{- if (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") }}
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
-    token: "${SPLUNK_O11Y_ACCESS_TOKEN}"
+    token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -120,14 +120,14 @@ exporters:
     ingest_url: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
     {{- end }}
-    access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+    access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     timeout: 10s
   {{- end }}
 
   {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") .Values.otelK8sClusterReceiver.k8sEventsEnabled }}
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
-    token: "${SPLUNK_O11Y_ACCESS_TOKEN}"
+    token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
     sourcetype: kube:events
     source: kubelet
   {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -231,11 +231,11 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "splunk-otel-collector.secret" . }}
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
           {{- end }}
           {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
           - name: SPLUNK_PLATFORM_HEC_TOKEN

--- a/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-collector.yaml
@@ -102,11 +102,11 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "splunk-otel-collector.secret" . }}
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
           {{- end }}
           {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
           - name: SPLUNK_PLATFORM_HEC_TOKEN

--- a/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
@@ -102,11 +102,11 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "splunk-otel-collector.secret" . }}
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
           {{- end }}
           {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
           - name: SPLUNK_PLATFORM_HEC_TOKEN

--- a/helm-charts/splunk-otel-collector/templates/secret.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret.yaml
@@ -12,18 +12,18 @@ metadata:
 type: Opaque
 data:
   {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
-  splunk_o11y_access_token: {{ include "splunk-otel-collector.o11yAccessToken" . | b64enc }}
+  splunk_observability_access_token: {{ include "splunk-otel-collector.o11yAccessToken" . | b64enc }}
   {{- end }}
   {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
   splunk_platform_hec_token: {{ .Values.splunkPlatform.token | b64enc }}
   {{- end }}
   {{- with .Values.splunkPlatform.clientCert }}
-  hec_client_cert: {{ . | b64enc }}
+  splunk_platform_hec_client_cert: {{ . | b64enc }}
   {{- end }}
   {{- with .Values.splunkPlatform.clientKey }}
-  hec_client_key: {{ . | b64enc }}
+  splunk_platform_hec_client_key: {{ . | b64enc }}
   {{- end }}
   {{- with .Values.splunkPlatform.caFile }}
-  hec_ca_file: {{ . | b64enc }}
+  splunk_platform_hec_ca_file: {{ . | b64enc }}
   {{- end }}
 {{- end -}}

--- a/rendered/manifests/agent-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-agent.yaml
@@ -18,17 +18,17 @@ data:
   relay: |
     exporters:
       sapm:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
-        token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null
       k8s_observer:

--- a/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 4eeca5afdb8456588b3f21440b9833d2f723f657ae167126f7f5182eea44bf30
+        checksum/config: 13ebf1992ec4b891314554315d658530379d3449244854d3d8abe4deb4a2e2c1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -183,11 +183,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
           # Env variables for host metrics receiver
           - name: HOST_PROC
             value: /hostfs/proc

--- a/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-k8s-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7a0c93778a90faf607f84f182e959a2fa0a5086f8e085c2e7a5b1205ed9c9085
+        checksum/config: 59f9ce25501546034c03ac1afe9b8df53bc190f57d388290ad7c67ad2088a048
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -67,11 +67,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
         readinessProbe:
           httpGet:
             path: /

--- a/rendered/manifests/agent-only/secret.yaml
+++ b/rendered/manifests/agent-only/secret.yaml
@@ -16,4 +16,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_o11y_access_token: Q0hBTkdFTUU=
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/gateway-only/configmap-otel-collector.yaml
+++ b/rendered/manifests/gateway-only/configmap-otel-collector.yaml
@@ -18,15 +18,15 @@ data:
   relay: |
     exporters:
       sapm:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
-        token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null
       http_forwarder:

--- a/rendered/manifests/gateway-only/deployment-collector.yaml
+++ b/rendered/manifests/gateway-only/deployment-collector.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 82f5a99ec5d7b25a404a23c6a3cb486b28037b729f073fc101230c04b610904d
+        checksum/config: 2bd79e3573ec78f7208ea22d30e1c47dea3a2b18028bcbaed4280cb16f1825f4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -67,11 +67,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
         ports:
         - name: http-forwarder
           containerPort: 6060

--- a/rendered/manifests/gateway-only/secret.yaml
+++ b/rendered/manifests/gateway-only/secret.yaml
@@ -16,4 +16,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_o11y_access_token: Q0hBTkdFTUU=
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/logs-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-otel-agent.yaml
@@ -18,14 +18,14 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
-        token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null
       k8s_observer:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: a31970065aabdf55dec4f5397d2d338f6b988f1599e0dca4ecf168fd294eb945
+        checksum/config: 2707d59b2e0bb73579a56c15fcd55255c8b419b2cb391ac2347fdcdbd4d08071
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -163,11 +163,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
 
         readinessProbe:
           httpGet:

--- a/rendered/manifests/logs-only/secret.yaml
+++ b/rendered/manifests/logs-only/secret.yaml
@@ -16,4 +16,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_o11y_access_token: Q0hBTkdFTUU=
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/metrics-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com

--- a/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-otel-k8s-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e7d1ec302095a1cfdf06114064eb7e01edcf9dce8b2bf6028ae922ba1ac653a6
+        checksum/config: 767afdeffa0130189e91f88f541efe348dea9752cd67fe4273399fd39469346d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -91,11 +91,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
           # Env variables for host metrics receiver
           - name: HOST_PROC
             value: /hostfs/proc

--- a/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-k8s-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7a0c93778a90faf607f84f182e959a2fa0a5086f8e085c2e7a5b1205ed9c9085
+        checksum/config: 59f9ce25501546034c03ac1afe9b8df53bc190f57d388290ad7c67ad2088a048
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -67,11 +67,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
         readinessProbe:
           httpGet:
             path: /

--- a/rendered/manifests/metrics-only/secret.yaml
+++ b/rendered/manifests/metrics-only/secret.yaml
@@ -16,4 +16,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_o11y_access_token: Q0hBTkdFTUU=
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/otel-logs/configmap-otel-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-otel-agent.yaml
@@ -18,17 +18,17 @@ data:
   relay: |
     exporters:
       sapm:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
-        token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       file_storage:
         directory: /var/lib/otel_pos

--- a/rendered/manifests/otel-logs/configmap-otel-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-otel-k8s-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 79fbef3ed17c5716a0d28f36d47d1f28fa123718a75dd9865dec2160707b0b47
+        checksum/config: b0e737e212b52be61476ca135fde715597ec9789743b5c2f2f1078356000613b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -144,11 +144,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
           # Env variables for host metrics receiver
           - name: HOST_PROC
             value: /hostfs/proc

--- a/rendered/manifests/otel-logs/deployment-k8s-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-k8s-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7a0c93778a90faf607f84f182e959a2fa0a5086f8e085c2e7a5b1205ed9c9085
+        checksum/config: 59f9ce25501546034c03ac1afe9b8df53bc190f57d388290ad7c67ad2088a048
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -67,11 +67,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
         readinessProbe:
           httpGet:
             path: /

--- a/rendered/manifests/otel-logs/secret.yaml
+++ b/rendered/manifests/otel-logs/secret.yaml
@@ -16,4 +16,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_o11y_access_token: Q0hBTkdFTUU=
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/traces-only/configmap-otel-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-otel-agent.yaml
@@ -18,10 +18,10 @@ data:
   relay: |
     exporters:
       sapm:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
-        access_token: ${SPLUNK_O11Y_ACCESS_TOKEN}
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: fb37eb794d74f55669e7e8804627a61e5e6090f26c4f78457e3a606cde8f6b81
+        checksum/config: ab0039eb8569a5206eb2b1c230530729d4e2443653653ba4ec6b1deff4011d77
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -103,11 +103,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SPLUNK_O11Y_ACCESS_TOKEN
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: splunk-otel-collector
-                key: splunk_o11y_access_token
+                key: splunk_observability_access_token
 
         readinessProbe:
           httpGet:

--- a/rendered/manifests/traces-only/secret.yaml
+++ b/rendered/manifests/traces-only/secret.yaml
@@ -16,4 +16,4 @@ metadata:
     heritage: Helm
 type: Opaque
 data:
-  splunk_o11y_access_token: Q0hBTkdFTUU=
+  splunk_observability_access_token: Q0hBTkdFTUU=


### PR DESCRIPTION
Update secret names according to [Splunk GDI Specification](https://github.com/signalfx/gdi-specification/blob/main/specification/configuration.md#kubernetes-package-management-solutions).
The following fields are renamed:
- `splunk_o11y_access_token` -> `splunk_observability_access_token`
- `hec_client_cert` -> `splunk_platform_hec_client_cert`
- `hec_client_key` -> `splunk_platform_hec_client_key`
- `hec_ca_file` -> `splunk_platform_hec_ca_file`