### PR TITLE
Rename cloud provider parameters according to Splunk GDI specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UP
 - Change secret names according to the GDI specification (#295)
 - Make `clusterName` configuration parameter generally required (#296)
 - Changed the default checkpoint path to `/var/addon/splunk/otel_pos` (#292)
+- Rename "provider" and "distro" parameters to "cloudProvider" and
+  "distribution" (#297)
 
 ### Fixed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,13 @@
 
 ## 0.37.1 to 0.38.0
 
+[#297 "provider" and "distro" parameters are renamed to "cloudProvider" and
+"distribution"](https://github.com/signalfx/splunk-otel-collector-chart/pull/297)
+
+Please rename the following parameters accordingly:
+- `provider` -> `cloudProvider`
+- `distro` -> `distribution`
+
 [#295 Secret names are changed according to the GDI
 specification](https://github.com/signalfx/splunk-otel-collector-chart/pull/295)
 

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -28,7 +28,8 @@ clusterName: my-k8s-cluster
 
 ## Cloud provider
 
-Use the `provider` parameter to provide information about the cloud provider, if any.
+Use the `cloudProvider` parameter to provide information about the cloud
+provider, if any.
 
 - `aws` - Amazon Web Services
 - `gcp` - Google Cloud
@@ -38,9 +39,9 @@ This value can be omitted if none of the values apply.
 
 ## Kubernetes distribution
 
-Use the `distro` parameter to provide information about underlying Kubernetes
-deployment. This parameter allows the connector to automatically scrape
-additional metadata. The supported options are:
+Use the `distribution` parameter to provide information about underlying
+Kubernetes deployment. This parameter allows the connector to automatically
+scrape additional metadata. The supported options are:
 
 - `eks` - Amazon EKS
 - `gke` - Google GKE

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -33,3 +33,11 @@ Splunk OpenTelemetry Connector is installed and configured to send data to Splun
 [WARNING] "logsEnabled" parameter is deprecated, please use "splunkObservability.logsEnabled" instead.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360
 {{ end }}
+{{- if not (eq (toString .Values.distro) "<nil>") }}
+[WARNING] "distro" parameter is deprecated, please use "distribution" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
+{{ end }}
+{{- if not (eq (toString .Values.provider) "<nil>") }}
+[WARNING] "provider" parameter is deprecated, please use "cloudProvider" instead.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
+{{ end }}

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -258,3 +258,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end -}}
+
+{{/*
+cloudProvider helper to support backward compatibility with the deprecated name.
+*/}}
+{{- define "splunk-otel-collector.cloudProvider" -}}
+{{- .Values.cloudProvider | default .Values.provider | default "" -}}
+{{- end -}}
+
+{{/*
+distribution helper to support backward compatibility with the deprecated name.
+*/}}
+{{- define "splunk-otel-collector.distribution" -}}
+{{- .Values.distribution | default .Values.distro | default "" -}}
+{{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -10,7 +10,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-{{- if eq .Values.distro "openshift" }}
+{{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
 - apiGroups:
   - quota.openshift.io
   resources:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -56,18 +56,18 @@ resourcedetection:
     # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
     # before it gets set later by the cloud provider detector.
     - env
-    {{- if eq .Values.distro "gke" }}
+    {{- if eq (include "splunk-otel-collector.distribution" .) "gke" }}
     - gke
-    {{- else if eq .Values.distro "eks" }}
+    {{- else if eq (include "splunk-otel-collector.distribution" .) "eks" }}
     - eks
-    {{- else if eq .Values.distro "aks" }}
+    {{- else if eq (include "splunk-otel-collector.distribution" .) "aks" }}
     - aks
     {{- end }}
-    {{- if eq .Values.provider "gcp" }}
+    {{- if eq (include "splunk-otel-collector.cloudProvider" .) "gcp" }}
     - gce
-    {{- else if eq .Values.provider "aws" }}
+    {{- else if eq (include "splunk-otel-collector.cloudProvider" .) "aws" }}
     - ec2
-    {{- else if eq .Values.provider "azure" }}
+    {{- else if eq (include "splunk-otel-collector.cloudProvider" .) "azure" }}
     - azure
     {{- end }}
     # The `system` detector goes last so it can't preclude cloud detectors from setting host/os info.

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -23,7 +23,7 @@ receivers:
     {{- if eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true" }}
     metadata_exporters: [signalfx]
     {{- end }}
-    {{- if eq .Values.distro "openshift" }}
+    {{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
     distribution: openshift
     {{- end }}
   {{- if .Values.otelK8sClusterReceiver.k8sEventsEnabled }}

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.distro "openshift" }}
+{{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -3,8 +3,8 @@
   "type": "object",
   "required": [
     "clusterName",
-    "provider",
-    "distro"
+    "cloudProvider",
+    "distribution"
   ],
   "title": "Values",
   "additionalProperties": false,
@@ -173,7 +173,7 @@
         "otel"
       ]
     },
-    "provider": {
+    "cloudProvider": {
       "description": "Cloud provider where the collector is running",
       "type": "string",
       "enum": [
@@ -184,7 +184,12 @@
         ""
       ]
     },
-    "distro": {
+    "provider": {
+      "description": "[DEPRECATED] Cloud provider where the collector is running",
+      "type": "string",
+      "deprecated": true
+    },
+    "distribution": {
       "description": "Kubernetes distribution where the collector is running",
       "type": "string",
       "enum": [
@@ -195,6 +200,11 @@
         " ",
         ""
       ]
+    },
+    "distro": {
+      "description": "[DEPRECATED] Kubernetes distribution where the collector is running",
+      "type": "string",
+      "deprecated": true
     },
     "environment": {
       "description": "Parameter that will be added to all the telemetry data (traces/logs/metrics) as an attribute.",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -120,7 +120,7 @@ logsEngine: fluentd
 # - "azure" (Microsoft Azure)
 ################################################################################
 
-provider: ""
+cloudProvider: ""
 
 ################################################################################
 # Kubernetes distribution being run. Leave empty for other.
@@ -130,7 +130,7 @@ provider: ""
 # - "openshift" (RedHat OpenShift)
 ################################################################################
 
-distro: ""
+distribution: ""
 
 ################################################################################
 # Optional "environment" parameter that will be added to all the telemetry


### PR DESCRIPTION
Rename the following parameters according to [GDI Specification](https://github.com/signalfx/gdi-specification/blob/main/specification/configuration.md#kubernetes-package-management-solutions):
- `provider` -> `cloudProvider`
- `distro` -> `distribution`