### PR TITLE
Rename parameter groups for Splunk OTel Collector components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UP
 - Changed the default checkpoint path to `/var/addon/splunk/otel_pos` (#292)
 - Rename "provider" and "distro" parameters to "cloudProvider" and
   "distribution" (#297)
+- Rename parameter groups for Splunk OTel Collector components (#301):
+  - `otelAgent` -> `agent`
+  - `otelCollector` -> `gateway`
+  - `otelK8sClusterReceiver` -> `clusterReceiver`
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ render:
 		--namespace default \
 		--values rendered/values.yaml \
 		--output-dir "$$dir" \
-		--set otelAgent.enabled=false,otelCollector.enabled=true,otelK8sClusterReceiver.enabled=false \
+		--set agent.enabled=false,gateway.enabled=true,clusterReceiver.enabled=false \
 		default helm-charts/splunk-otel-collector; \
 	mv "$$dir"/splunk-otel-collector/templates/* "$$dir"; \
 	rm -rf "$$dir"/splunk-otel-collector

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,7 +42,7 @@ For example, if you have the following `smartagent/docker-container-stats`
 receiver added to your configuration:
 
 ```yaml
-otelAgent:
+agent:
   config:
     receivers:
       smartagent/docker-container-stats:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,12 +2,18 @@
 
 ## 0.37.1 to 0.38.0
 
-[#297 "provider" and "distro" parameters are renamed to "cloudProvider" and
-"distribution"](https://github.com/signalfx/splunk-otel-collector-chart/pull/297)
+[297](https://github.com/signalfx/splunk-otel-collector-chart/pull/297),
+[301](https://github.com/signalfx/splunk-otel-collector-chart/pull/301) Several
+parameters in values.yaml configuration were renamed according to [Splunk GDI
+Specification](https://github.com/signalfx/gdi-specification/blob/main/specification/configuration.md#kubernetes-package-management-solutions)
 
-Please rename the following parameters accordingly:
+If you use the following parameters in your custom values.yaml, please rename
+them accordingly:
 - `provider` -> `cloudProvider`
 - `distro` -> `distribution`
+- `otelAgent` -> `agent`
+- `otelCollector` -> `gateway`
+- `otelK8sClusterReceiver` -> `clusterReceiver`
 
 [#295 Secret names are changed according to the GDI
 specification](https://github.com/signalfx/splunk-otel-collector-chart/pull/295)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,19 +51,19 @@ guidelines](https://github.com/signalfx/splunk-otel-collector/blob/main/docs/siz
 Use the following configuration to bump resource limits for the agent:
 
 ```yaml
-otelAgent:
+agent:
   resources:
     limits:
       cpu: 500m
       memory: 1Gi
 ```
 
-Resources allocated to Kubernetes cluster receiver deployment should be based on
-the cluster size. For a cluster with 100 nodes you would need the following
+Resources allocated to cluster receiver deployment should be based on the
+cluster size. For a cluster with 100 nodes you would need the following
 resources:
 
 ```yaml
-otelK8sClusterReceiver:
+clusterReceiver:
   resources:
     limits:
       cpu: 1
@@ -92,7 +92,7 @@ sending queue of the failing exporter, e.g. to reduce `sending_queue` for the
 `sapm` exporter (tracing):
 
 ```
-otelAgent:
+agent:
   config:
     exporters:
       sapm:

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ Final OTel config will be created by merging the custom config provided in
 [default configuration of agent-mode collector](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl).
 
 ```yaml
-otelAgent:
+agent:
   config:
     processors:
       probabilistic_sampler:
@@ -87,11 +87,11 @@ This configuration installs collector as a gateway deployment along with
 regular components. All the telemetry will be routed through this collector.
 By default, the gateway-mode collector deployed with 3 replicas with 4 CPU
 cores and 8Gb of memory each, but this can be easily changed as in this example.
-`resources` can be adjusted for other components as well: `otelAgent`,
-`otelK8sClusterReceiver`, `fluentd`.
+`resources` can be adjusted for other components as well: `agent`,
+`clusterReceiver`, `fluentd`.
 
 ```yaml
-otelCollector:
+gateway:
   enabled: true
   replicaCount: 1
   resources:
@@ -107,9 +107,9 @@ No metrics or logs will be collector, the gateway can be used to forward
 telemetry data through it for aggregation, enrichment purposes.
 
 ```yaml
-otelCollector:
+gateway:
   enabled: true
-otelAgent:
+agent:
   enabled: false
 logsEnabled: false
 ```
@@ -120,7 +120,7 @@ The following configuration can be used to forward telemetry through an OTel
 collector gateway deployed separately.
 
 ```yaml
-otelAgent:
+agent:
   config:
     exporters:
       otlp:
@@ -137,7 +137,7 @@ otelAgent:
         metrics:
           exporters: [otlp]
 
-otelK8sClusterReceiver:
+clusterReceiver:
   config:
     exporters:
       signalfx:
@@ -157,11 +157,11 @@ Collector containers to send the traffic through a proxy server from
 both components that are enabled by default.
 
 ```yaml
-otelAgent:
+agent:
   extraEnvs:
     - name: HTTPS_PROXY
       value: "192.168.0.10"
-otelK8sClusterReceiver:
+clusterReceiver:
   extraEnvs:
     - name: HTTPS_PROXY
       value: "192.168.0.10"

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,8 +55,8 @@ This example shows how to change default OTel Collector configuration to add
 [Probabilistic Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/probabilisticsamplerprocessor).
 This approach can be used for any other OTel Collector re-configuration as well.
 Final OTel config will be created by merging the custom config provided in
-`otelAgent.config` into
-[default configuration of agent-mode collector](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl).
+`agent.config` into [default configuration of agent-mode
+collector](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl).
 
 ```yaml
 agent:

--- a/examples/add-sampler-values.yaml
+++ b/examples/add-sampler-values.yaml
@@ -3,7 +3,7 @@ splunkObservability:
   realm: us0
   accessToken: my-access-token
 
-otelAgent:
+agent:
   config:
     processors:
       probabilistic_sampler:

--- a/examples/enable-gateway-values.yaml
+++ b/examples/enable-gateway-values.yaml
@@ -3,7 +3,7 @@ splunkObservability:
   realm: us0
   accessToken: my-access-token
 
-otelCollector:
+gateway:
   enabled: true
   replicaCount: 1
   resources:

--- a/examples/gateway-only-values.yaml
+++ b/examples/gateway-only-values.yaml
@@ -3,8 +3,8 @@ splunkObservability:
   realm: us0
   accessToken: my-access-token
 
-otelCollector:
+gateway:
   enabled: true
-otelAgent:
+agent:
   enabled: false
 logsEnabled: false

--- a/examples/use-custom-gateway-values.yaml
+++ b/examples/use-custom-gateway-values.yaml
@@ -3,7 +3,7 @@ splunkObservability:
   realm: us0
   accessToken: my-access-token
 
-otelAgent:
+agent:
   config:
     exporters:
       otlp:
@@ -19,7 +19,7 @@ otelAgent:
         metrics:
           exporters: [otlp]
 
-otelK8sClusterReceiver:
+clusterReceiver:
   config:
     exporters:
       signalfx:

--- a/examples/use-proxy-values.yaml
+++ b/examples/use-proxy-values.yaml
@@ -3,11 +3,11 @@ splunkObservability:
   realm: us0
   accessToken: my-access-token
 
-otelAgent:
+agent:
   extraEnvs:
     - name: HTTPS_PROXY
       value: "192.168.0.10"
-otelK8sClusterReceiver:
+clusterReceiver:
   extraEnvs:
     - name: HTTPS_PROXY
       value: "192.168.0.10"

--- a/helm-charts/splunk-otel-collector/ci/sampler-gateway-env-vars-java-logs-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/sampler-gateway-env-vars-java-logs-values.yaml
@@ -3,7 +3,7 @@ splunkObservability:
   realm: fake-realm
   accessToken: fake-token
 
-otelAgent:
+agent:
   config:
     processors:
       probabilistic_sampler:
@@ -23,12 +23,12 @@ otelAgent:
     - name: HTTPS_PROXY
       value: "192.168.0.10"
 
-otelK8sClusterReceiver:
+clusterReceiver:
   extraEnvs:
     - name: HTTPS_PROXY
       value: "192.168.0.10"
 
-otelCollector:
+gateway:
   enabled: true
   replicaCount: 1
   resources:

--- a/helm-charts/splunk-otel-collector/ci/use-custom-gateway-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/use-custom-gateway-values.yaml
@@ -5,7 +5,7 @@ splunkAccessToken: my-access-token
 
 logsEnabled: false
 
-otelAgent:
+agent:
   config:
     exporters:
       otlp:
@@ -21,7 +21,7 @@ otelAgent:
         metrics:
           exporters: [otlp]
 
-otelK8sClusterReceiver:
+clusterReceiver:
   config:
     exporters:
       signalfx:

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -45,3 +45,15 @@ Splunk OpenTelemetry Connector is installed and configured to send data to Splun
 [WARNING] ".Values.extraAttributes.podLabels" parameter is deprecated, please use ".Values.extraAttributes.fromLabels" instead.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
 {{ end }}
+{{- if not (eq (toString .Values.otelAgent) "<nil>") }}
+[WARNING] "otelAgent" parameter group is deprecated, please rename it to "agent" in your custom values.yaml.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
+{{ end }}
+{{- if not (eq (toString .Values.otelCollector) "<nil>") }}
+[WARNING] "otelCollector" parameter group is deprecated, please rename it to "gateway" in your custom values.yaml.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
+{{ end }}
+{{- if not (eq (toString .Values.otelK8sClusterReceiver) "<nil>") }}
+[WARNING] "otelK8sClusterReceiver" parameter group is deprecated, please rename it to "clusterReceiver" in your custom values.yaml.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
+{{ end }}

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -272,3 +272,39 @@ distribution helper to support backward compatibility with the deprecated name.
 {{- define "splunk-otel-collector.distribution" -}}
 {{- .Values.distribution | default .Values.distro | default "" -}}
 {{- end -}}
+
+{{/*
+Helper that returns "agent" parameter group yaml taking care of backward
+compatibility with the old config group name: "otelAgent".
+*/}}
+{{- define "splunk-otel-collector.agent" -}}
+{{- if eq (toString .Values.otelAgent) "<nil>" }}
+{{- .Values.agent | toYaml }}
+{{- else }}
+{{- deepCopy .Values.otelAgent | mustMergeOverwrite (deepCopy .Values.agent) | toYaml }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Helper that returns "gateway" parameter group yaml taking care of backward
+compatibility with the old config group name: "otelCollector".
+*/}}
+{{- define "splunk-otel-collector.gateway" -}}
+{{- if eq (toString .Values.otelCollector) "<nil>" }}
+{{- .Values.gateway | toYaml }}
+{{- else }}
+{{- deepCopy .Values.otelCollector | mustMergeOverwrite (deepCopy .Values.gateway) | toYaml }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Helper that returns "clusterReceiver" parameter group yaml taking care of backward
+compatibility with the old config group name: "otelK8sClusterReceiver".
+*/}}
+{{- define "splunk-otel-collector.clusterReceiver" -}}
+{{- if eq (toString .Values.otelK8sClusterReceiver) "<nil>" }}
+{{- .Values.clusterReceiver | toYaml }}
+{{- else }}
+{{- deepCopy .Values.otelK8sClusterReceiver | mustMergeOverwrite (deepCopy .Values.clusterReceiver) | toYaml }}
+{{- end }}
+{{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -2,7 +2,7 @@
 Config for the otel-collector agent
 The values can be overridden in .Values.agent.config
 */}}
-{{- define "splunk-otel-collector.otelAgentConfig" -}}
+{{- define "splunk-otel-collector.agentConfig" -}}
 {{ $agent := fromYaml (include "splunk-otel-collector.agent" .) -}}
 {{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) -}}
 extensions:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -2,7 +2,7 @@
 Config for the optional standalone collector
 The values can be overridden in .Values.gateway.config
 */}}
-{{- define "splunk-otel-collector.otelCollectorConfig" -}}
+{{- define "splunk-otel-collector.gatewayConfig" -}}
 {{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) -}}
 extensions:
   health_check:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -1,8 +1,9 @@
 {{/*
 Config for the optional standalone collector
-The values can be overridden in .Values.otelCollector.config
+The values can be overridden in .Values.gateway.config
 */}}
 {{- define "splunk-otel-collector.otelCollectorConfig" -}}
+{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) -}}
 extensions:
   health_check:
 
@@ -77,7 +78,7 @@ processors:
   {{- include "splunk-otel-collector.resourceLogsProcessor" . | nindent 2 }}
   {{- include "splunk-otel-collector.filterLogsProcessors" . | nindent 2 }}
 
-  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" .Values.otelCollector | nindent 2 }}
+  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" $gateway | nindent 2 }}
 
   batch:
 
@@ -159,7 +160,7 @@ service:
     {{- end }}
 
   # The default pipelines should not need to be changed. You can add any custom pipeline instead.
-  # In order to disable a default pipeline just set it to `null` in otelCollector.config overrides.
+  # In order to disable a default pipeline just set it to `null` in gateway.config overrides.
   pipelines:
     {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" $) "true") }}
     # default traces pipeline

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -2,7 +2,7 @@
 Config for the otel-collector k8s cluster receiver deployment.
 The values can be overridden in .Values.clusterReceiver.config
 */}}
-{{- define "splunk-otel-collector.otelK8sClusterReceiverConfig" -}}
+{{- define "splunk-otel-collector.clusterReceiverConfig" -}}
 {{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) -}}
 {{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) -}}
 extensions:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -1,8 +1,10 @@
 {{/*
 Config for the otel-collector k8s cluster receiver deployment.
-The values can be overridden in .Values.otelK8sClusterReceiver.config
+The values can be overridden in .Values.clusterReceiver.config
 */}}
 {{- define "splunk-otel-collector.otelK8sClusterReceiverConfig" -}}
+{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) -}}
+{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) -}}
 extensions:
   health_check:
 
@@ -26,7 +28,7 @@ receivers:
     {{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
     distribution: openshift
     {{- end }}
-  {{- if .Values.otelK8sClusterReceiver.k8sEventsEnabled }}
+  {{- if $clusterReceiver.k8sEventsEnabled }}
   smartagent/kubernetes-events:
     type: kubernetes-events
     alwaysClusterReporter: true
@@ -42,13 +44,13 @@ receivers:
   {{- end }}
 
 processors:
-  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" .Values.otelK8sClusterReceiver | nindent 2 }}
+  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" $clusterReceiver | nindent 2 }}
 
   batch:
 
   {{- include "splunk-otel-collector.resourceDetectionProcessor" . | nindent 2 }}
 
-  {{- if and .Values.otelK8sClusterReceiver.k8sEventsEnabled (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") }}
+  {{- if and $clusterReceiver.k8sEventsEnabled (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") }}
   resource/add_event_k8s:
     attributes:
       - action: insert
@@ -111,7 +113,7 @@ processors:
 exporters:
   {{- if eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true" }}
   signalfx:
-    {{- if .Values.otelCollector.enabled }}
+    {{- if $gateway.enabled }}
     ingest_url: http://{{ include "splunk-otel-collector.fullname" . }}:9943
     api_url: http://{{ include "splunk-otel-collector.fullname" . }}:6060
     {{- else }}
@@ -122,7 +124,7 @@ exporters:
     timeout: 10s
   {{- end }}
 
-  {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") .Values.otelK8sClusterReceiver.k8sEventsEnabled }}
+  {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") $clusterReceiver.k8sEventsEnabled }}
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
@@ -168,7 +170,7 @@ service:
         {{- end }}
     {{- end }}
 
-    {{- if and .Values.otelK8sClusterReceiver.k8sEventsEnabled (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") }}
+    {{- if and $clusterReceiver.k8sEventsEnabled (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") }}
     logs/events:
       receivers:
         - smartagent/kubernetes-events

--- a/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
@@ -1,4 +1,5 @@
-{{ if .Values.otelAgent.enabled }}
+{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
+{{ if $agent.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,5 +13,5 @@ metadata:
 data:
   relay: |
     {{- $config := include "splunk-otel-collector.otelAgentConfig" . | fromYaml }}
-    {{- .Values.otelAgent.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
+    {{- $agent.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
@@ -12,6 +12,6 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   relay: |
-    {{- $config := include "splunk-otel-collector.otelAgentConfig" . | fromYaml }}
+    {{- $config := include "splunk-otel-collector.agentConfig" . | fromYaml }}
     {{- $agent.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
@@ -1,4 +1,5 @@
-{{ if and .Values.otelK8sClusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
+{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
+{{ if and $clusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,5 +13,5 @@ metadata:
 data:
   relay: |
     {{- $config := include "splunk-otel-collector.otelK8sClusterReceiverConfig" . | fromYaml }}
-    {{- .Values.otelK8sClusterReceiver.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
+    {{- $clusterReceiver.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
@@ -12,6 +12,6 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   relay: |
-    {{- $config := include "splunk-otel-collector.otelK8sClusterReceiverConfig" . | fromYaml }}
+    {{- $config := include "splunk-otel-collector.clusterReceiverConfig" . | fromYaml }}
     {{- $clusterReceiver.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-cri.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-cri.yaml
@@ -1,4 +1,5 @@
-{{ if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.otelAgent.enabled (eq .Values.logsEngine "fluentd") }}
+{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
+{{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") $agent.enabled (eq .Values.logsEngine "fluentd") }}
 {{/*
 Fluentd config parts applied only to clusters with containerd/cri-o runtime.
 */}}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
@@ -1,4 +1,5 @@
-{{ if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.otelAgent.enabled (eq .Values.logsEngine "fluentd") }}
+{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
+{{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") $agent.enabled (eq .Values.logsEngine "fluentd") }}
 {{/*
 Fluentd config parts applied only to clusters with docker runtime.
 */}}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -1,4 +1,5 @@
-{{ if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.otelAgent.enabled (eq .Values.logsEngine "fluentd") }}
+{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
+{{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") $agent.enabled (eq .Values.logsEngine "fluentd") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
@@ -1,4 +1,5 @@
-{{ if .Values.otelCollector.enabled }}
+{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
+{{ if $gateway.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,5 +13,5 @@ metadata:
 data:
   relay: |
     {{- $config := include "splunk-otel-collector.otelCollectorConfig" . | fromYaml }}
-    {{- .Values.otelCollector.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
+    {{- $gateway.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
@@ -12,6 +12,6 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   relay: |
-    {{- $config := include "splunk-otel-collector.otelCollectorConfig" . | fromYaml }}
+    {{- $config := include "splunk-otel-collector.gatewayConfig" . | fromYaml }}
     {{- $gateway.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.otelAgent.enabled }}
+{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
+{{- if $agent.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -12,9 +13,9 @@ metadata:
     {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (eq .Values.logsEngine "fluentd") }}
     engine: fluentd
     {{- end }}
-  {{- if .Values.otelAgent.annotations }}
+  {{- if $agent.annotations }}
   annotations:
-    {{- toYaml .Values.otelAgent.annotations | nindent 4 }}
+    {{- toYaml $agent.annotations | nindent 4 }}
   {{- end }}
 spec:
   updateStrategy:
@@ -28,14 +29,14 @@ spec:
       labels:
         app: {{ template "splunk-otel-collector.name" . }}
         release: {{ .Release.Name }}
-        {{- if .Values.otelAgent.podLabels }}
-        {{- toYaml .Values.otelAgent.podLabels | nindent 8 }}
+        {{- if $agent.podLabels }}
+        {{- toYaml $agent.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ print (include (print $.Template.BasePath "/configmap-fluentd.yaml") .) (include (print $.Template.BasePath "/configmap-otel-agent.yaml") .) | sha256sum }}
+        checksum/config: {{ print (include (print $.Template.BasePath "/configmap-fluentd.yaml") .) (include (print $.Template.BasePath "/configmap-agent.yaml") .) | sha256sum }}
         kubectl.kubernetes.io/default-container: otel-collector
-        {{- if .Values.otelAgent.podAnnotations }}
-        {{- toYaml .Values.otelAgent.podAnnotations | nindent 8 }}
+        {{- if $agent.podAnnotations }}
+        {{- toYaml $agent.podAnnotations | nindent 8 }}
         {{- end }}
         {{- if .Values.autodetect.istio }}
         sidecar.istio.io/inject: "false"
@@ -193,11 +194,11 @@ spec:
         - --config=/conf/relay.yaml
         {{- end }}
         - --metrics-addr=0.0.0.0:8889
-        {{- range .Values.otelAgent.extraArgs }}
+        {{- range $agent.extraArgs }}
         - {{ . }}
         {{- end }}
         ports:
-        {{- range $key, $port := .Values.otelAgent.ports }}
+        {{- range $key, $port := $agent.ports }}
         {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.o11yTracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) }}
         - name: {{ $key }}
           {{- omit $port "enabled_for" | toYaml | trim | nindent 10 }}
@@ -205,18 +206,18 @@ spec:
         {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
-        {{- if or .Values.otelAgent.securityContext (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (eq .Values.logsEngine "otel")) }}
+        {{- if or $agent.securityContext (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (eq .Values.logsEngine "otel")) }}
         securityContext:
           {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (eq .Values.logsEngine "otel") }}
           runAsUser: 0
           {{- end }}
-          {{- if .Values.otelAgent.securityContext }}
-          {{ toYaml .Values.otelAgent.securityContext | nindent 10 }}
+          {{- if $agent.securityContext }}
+          {{ toYaml $agent.securityContext | nindent 10 }}
           {{- end }}
         {{- end }}
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB
-            value: "{{ include "splunk-otel-collector.convertMemToMib" .Values.otelAgent.resources.limits.memory }}"
+            value: "{{ include "splunk-otel-collector.convertMemToMib" $agent.resources.limits.memory }}"
           - name: K8S_NODE_NAME
             valueFrom:
               fieldRef:
@@ -272,7 +273,7 @@ spec:
           - name: HOST_DEV
             value: {{ .Values.isWindows | ternary "C:\\hostfs\\dev" "/hostfs/dev" }}
           {{- end }}
-          {{- with .Values.otelAgent.extraEnvs }}
+          {{- with $agent.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}
 
@@ -291,7 +292,7 @@ spec:
             path: /
             port: 13133
         resources:
-          {{- toYaml .Values.otelAgent.resources | nindent 10 }}
+          {{- toYaml $agent.resources | nindent 10 }}
         volumeMounts:
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: otel-configmap
@@ -336,8 +337,8 @@ spec:
         - name: checkpoint
           mountPath: {{ .Values.logsCollection.checkpointPath }}
         {{- end }}
-        {{- if .Values.otelAgent.extraVolumeMounts }}
-        {{- toYaml .Values.otelAgent.extraVolumeMounts | nindent 8 }}
+        {{- if $agent.extraVolumeMounts }}
+        {{- toYaml $agent.extraVolumeMounts | nindent 8 }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
@@ -421,8 +422,8 @@ spec:
           items:
             - key: relay
               path: relay.yaml
-      {{- if .Values.otelAgent.extraVolumes }}
-      {{- toYaml .Values.otelAgent.extraVolumes | nindent 6 }}
+      {{- if $agent.extraVolumes }}
+      {{- toYaml $agent.extraVolumes | nindent 6 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -1,40 +1,41 @@
-{{ if .Values.otelCollector.enabled }}
+{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
+{{- if and $clusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "splunk-otel-collector.fullname" . }}
+  name: {{ template "splunk-otel-collector.fullname" . }}-k8s-cluster-receiver
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}
-    component: otel-collector
+    component: otel-k8s-cluster-receiver
     chart: {{ template "splunk-otel-collector.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    app.kubernetes.io/component: otel-collector
-  {{- if .Values.otelCollector.annotations }}
+    app.kubernetes.io/component: otel-k8s-cluster-receiver
+  {{- if $clusterReceiver.annotations }}
   annotations:
-    {{- toYaml .Values.otelCollector.annotations | nindent 4 }}
+    {{- toYaml $clusterReceiver.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.otelCollector.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       app: {{ template "splunk-otel-collector.name" . }}
-      component: otel-collector
+      component: otel-k8s-cluster-receiver
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "splunk-otel-collector.name" . }}
-        component: otel-collector
+        component: otel-k8s-cluster-receiver
         release: {{ .Release.Name }}
-        {{- if .Values.otelCollector.podLabels }}
-        {{- toYaml .Values.otelCollector.podLabels | nindent 8 }}
+        {{- if $clusterReceiver.podLabels }}
+        {{- toYaml $clusterReceiver.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap-otel-collector.yaml") . | sha256sum }}
-        {{- if .Values.otelCollector.podAnnotations }}
-        {{- toYaml .Values.otelCollector.podAnnotations | nindent 8 }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-cluster-receiver.yaml") . | sha256sum }}
+        {{- if $clusterReceiver.podAnnotations }}
+        {{- toYaml $clusterReceiver.podAnnotations | nindent 8 }}
         {{- end }}
         {{- if .Values.autodetect.istio }}
         sidecar.istio.io/inject: "false"
@@ -42,22 +43,22 @@ spec:
     spec:
       serviceAccountName: {{ template "splunk-otel-collector.serviceAccountName" . }}
       nodeSelector:
-        {{- if .Values.otelCollector.nodeSelector }}
-        {{ toYaml .Values.otelCollector.nodeSelector | nindent 8 }}
+        {{- if $clusterReceiver.nodeSelector }}
+        {{ toYaml $clusterReceiver.nodeSelector | nindent 8 }}
         {{- else }}
           kubernetes.io/os: {{ .Values.isWindows | ternary "windows" "linux" }}
         {{- end }}
-      {{- if .Values.otelCollector.tolerations }}
+      {{- if $clusterReceiver.tolerations }}
       tolerations:
-        {{ toYaml .Values.otelCollector.tolerations | nindent 8 }}
+        {{ toYaml $clusterReceiver.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.otelCollector.affinity }}
+      {{- if $clusterReceiver.affinity }}
       affinity:
-        {{- toYaml .Values.otelCollector.affinity | nindent 8 }}
+        {{- toYaml $clusterReceiver.affinity | nindent 8 }}
       {{- end }}
-      {{- if .Values.otelCollector.securityContext }}
+      {{- if $clusterReceiver.securityContext }}
       securityContext:
-        {{ toYaml .Values.otelCollector.securityContext | nindent 8 }}
+        {{ toYaml $clusterReceiver.securityContext | nindent 8 }}
       {{- end }}
       containers:
       - name: otel-collector
@@ -72,14 +73,14 @@ spec:
         - --config=/conf/relay.yaml
         {{- end }}
         - --metrics-addr=0.0.0.0:8889
-        {{- range .Values.otelCollector.extraArgs }}
+        {{- range $clusterReceiver.extraArgs }}
         - {{ . }}
         {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB
-            value: "{{ include "splunk-otel-collector.convertMemToMib" .Values.otelCollector.resources.limits.memory }}"
+            value: "{{ include "splunk-otel-collector.convertMemToMib" $clusterReceiver.resources.limits.memory }}"
           - name: K8S_NODE_NAME
             valueFrom:
               fieldRef:
@@ -115,16 +116,9 @@ spec:
                 name: {{ include "splunk-otel-collector.secret" . }}
                 key: splunk_platform_hec_token
           {{- end }}
-          {{- with .Values.otelCollector.extraEnvs }}
+          {{- with $clusterReceiver.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}
-        ports:
-        {{- range $key, $port := .Values.otelCollector.ports }}
-        {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) }}
-        - name: {{ $key }}
-          {{- omit $port "enabled_for" | toYaml | trim | nindent 10 }}
-        {{- end }}
-        {{- end }}
         readinessProbe:
           {{- if .Values.readinessProbe.initialDelaySeconds }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
@@ -140,25 +134,25 @@ spec:
             path: /
             port: 13133
         resources:
-          {{- toYaml .Values.otelCollector.resources | nindent 10 }}
+          {{- toYaml $clusterReceiver.resources | nindent 10 }}
         volumeMounts:
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: collector-configmap
-        {{- if .Values.otelCollector.extraVolumeMounts }}
-        {{- toYaml .Values.otelCollector.extraVolumeMounts | nindent 8 }}
+        {{- if $clusterReceiver.extraVolumeMounts }}
+        {{- toYaml $clusterReceiver.extraVolumeMounts | nindent 8 }}
         {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.otelCollector.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $clusterReceiver.terminationGracePeriodSeconds }}
       volumes:
       - name: collector-configmap
         configMap:
-          name: {{ template "splunk-otel-collector.fullname" . }}-otel-collector
+          name: {{ template "splunk-otel-collector.fullname" . }}-otel-k8s-cluster-receiver
           items:
             - key: relay
               path: relay.yaml
-      {{- if .Values.otelCollector.extraVolumes }}
-      {{- toYaml .Values.otelCollector.extraVolumes | nindent 6 }}
+      {{- if $clusterReceiver.extraVolumes }}
+      {{- toYaml $clusterReceiver.extraVolumes | nindent 6 }}
       {{- end }}
-      {{- if .Values.otelCollector.priorityClassName }}
-      priorityClassName: {{ .Values.otelCollector.priorityClassName }}
+      {{- if $clusterReceiver.priorityClassName }}
+      priorityClassName: {{ $clusterReceiver.priorityClassName }}
       {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -1,40 +1,41 @@
-{{ if and .Values.otelK8sClusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
+{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
+{{ if $gateway.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "splunk-otel-collector.fullname" . }}-k8s-cluster-receiver
+  name: {{ template "splunk-otel-collector.fullname" . }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}
-    component: otel-k8s-cluster-receiver
+    component: otel-collector
     chart: {{ template "splunk-otel-collector.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    app.kubernetes.io/component: otel-k8s-cluster-receiver
-  {{- if .Values.otelK8sClusterReceiver.annotations }}
+    app.kubernetes.io/component: otel-collector
+  {{- if $gateway.annotations }}
   annotations:
-    {{- toYaml .Values.otelK8sClusterReceiver.annotations | nindent 4 }}
+    {{- toYaml $gateway.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ $gateway.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "splunk-otel-collector.name" . }}
-      component: otel-k8s-cluster-receiver
+      component: otel-collector
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "splunk-otel-collector.name" . }}
-        component: otel-k8s-cluster-receiver
+        component: otel-collector
         release: {{ .Release.Name }}
-        {{- if .Values.otelK8sClusterReceiver.podLabels }}
-        {{- toYaml .Values.otelK8sClusterReceiver.podLabels | nindent 8 }}
+        {{- if $gateway.podLabels }}
+        {{- toYaml $gateway.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap-otel-k8s-cluster-receiver.yaml") . | sha256sum }}
-        {{- if .Values.otelK8sClusterReceiver.podAnnotations }}
-        {{- toYaml .Values.otelK8sClusterReceiver.podAnnotations | nindent 8 }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-gateway.yaml") . | sha256sum }}
+        {{- if $gateway.podAnnotations }}
+        {{- toYaml $gateway.podAnnotations | nindent 8 }}
         {{- end }}
         {{- if .Values.autodetect.istio }}
         sidecar.istio.io/inject: "false"
@@ -42,22 +43,22 @@ spec:
     spec:
       serviceAccountName: {{ template "splunk-otel-collector.serviceAccountName" . }}
       nodeSelector:
-        {{- if .Values.otelK8sClusterReceiver.nodeSelector }}
-        {{ toYaml .Values.otelK8sClusterReceiver.nodeSelector | nindent 8 }}
+        {{- if $gateway.nodeSelector }}
+        {{ toYaml $gateway.nodeSelector | nindent 8 }}
         {{- else }}
           kubernetes.io/os: {{ .Values.isWindows | ternary "windows" "linux" }}
         {{- end }}
-      {{- if .Values.otelK8sClusterReceiver.tolerations }}
+      {{- if $gateway.tolerations }}
       tolerations:
-        {{ toYaml .Values.otelK8sClusterReceiver.tolerations | nindent 8 }}
+        {{ toYaml $gateway.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.otelK8sClusterReceiver.affinity }}
+      {{- if $gateway.affinity }}
       affinity:
-        {{- toYaml .Values.otelK8sClusterReceiver.affinity | nindent 8 }}
+        {{- toYaml $gateway.affinity | nindent 8 }}
       {{- end }}
-      {{- if .Values.otelK8sClusterReceiver.securityContext }}
+      {{- if $gateway.securityContext }}
       securityContext:
-        {{ toYaml .Values.otelK8sClusterReceiver.securityContext | nindent 8 }}
+        {{ toYaml $gateway.securityContext | nindent 8 }}
       {{- end }}
       containers:
       - name: otel-collector
@@ -72,14 +73,14 @@ spec:
         - --config=/conf/relay.yaml
         {{- end }}
         - --metrics-addr=0.0.0.0:8889
-        {{- range .Values.otelK8sClusterReceiver.extraArgs }}
+        {{- range $gateway.extraArgs }}
         - {{ . }}
         {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB
-            value: "{{ include "splunk-otel-collector.convertMemToMib" .Values.otelK8sClusterReceiver.resources.limits.memory }}"
+            value: "{{ include "splunk-otel-collector.convertMemToMib" $gateway.resources.limits.memory }}"
           - name: K8S_NODE_NAME
             valueFrom:
               fieldRef:
@@ -115,9 +116,16 @@ spec:
                 name: {{ include "splunk-otel-collector.secret" . }}
                 key: splunk_platform_hec_token
           {{- end }}
-          {{- with .Values.otelK8sClusterReceiver.extraEnvs }}
+          {{- with $gateway.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}
+        ports:
+        {{- range $key, $port := $gateway.ports }}
+        {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) }}
+        - name: {{ $key }}
+          {{- omit $port "enabled_for" | toYaml | trim | nindent 10 }}
+        {{- end }}
+        {{- end }}
         readinessProbe:
           {{- if .Values.readinessProbe.initialDelaySeconds }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
@@ -133,25 +141,25 @@ spec:
             path: /
             port: 13133
         resources:
-          {{- toYaml .Values.otelK8sClusterReceiver.resources | nindent 10 }}
+          {{- toYaml $gateway.resources | nindent 10 }}
         volumeMounts:
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: collector-configmap
-        {{- if .Values.otelK8sClusterReceiver.extraVolumeMounts }}
-        {{- toYaml .Values.otelK8sClusterReceiver.extraVolumeMounts | nindent 8 }}
+        {{- if $gateway.extraVolumeMounts }}
+        {{- toYaml $gateway.extraVolumeMounts | nindent 8 }}
         {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.otelK8sClusterReceiver.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $gateway.terminationGracePeriodSeconds }}
       volumes:
       - name: collector-configmap
         configMap:
-          name: {{ template "splunk-otel-collector.fullname" . }}-otel-k8s-cluster-receiver
+          name: {{ template "splunk-otel-collector.fullname" . }}-otel-collector
           items:
             - key: relay
               path: relay.yaml
-      {{- if .Values.otelK8sClusterReceiver.extraVolumes }}
-      {{- toYaml .Values.otelK8sClusterReceiver.extraVolumes | nindent 6 }}
+      {{- if $gateway.extraVolumes }}
+      {{- toYaml $gateway.extraVolumes | nindent 6 }}
       {{- end }}
-      {{- if .Values.otelK8sClusterReceiver.priorityClassName }}
-      priorityClassName: {{ .Values.otelK8sClusterReceiver.priorityClassName }}
+      {{- if $gateway.priorityClassName }}
+      priorityClassName: {{ $gateway.priorityClassName }}
       {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
@@ -1,4 +1,5 @@
-{{- if and (and .Values.otelK8sClusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" $) "true")) .Values.podDisruptionBudget }}
+{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
+{{- if and (and $clusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" $) "true")) .Values.podDisruptionBudget }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.otelCollector.enabled .Values.podDisruptionBudget }}
+{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
+{{- if and $gateway.enabled .Values.podDisruptionBudget }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -1,4 +1,5 @@
-{{ if .Values.otelCollector.enabled }}
+{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
+{{ if $gateway.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,7 +19,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  {{- range $key, $port := .Values.otelCollector.ports }}
+  {{- range $key, $port := $gateway.ports }}
   {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) }}
   - name: {{ $key }}
     port: {{ $port.containerPort }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -267,8 +267,8 @@
         }
       }
     },
-    "otelAgent": {
-      "description": "Splunk OpenTelemetry collector agent configuration.",
+    "agent": {
+      "description": "Splunk OpenTelemetry Collector agent configuration.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -377,8 +377,13 @@
         }
       }
     },
-    "otelK8sClusterReceiver": {
-      "description": "Splunk OpenTelemetry Kubernetes cluster receiver configuration.",
+    "otelAgent": {
+      "description": "[DEPRECATED] Splunk OpenTelemetry Collector agent configuration.",
+      "type": "object",
+      "deprecated": true
+    },
+    "clusterReceiver": {
+      "description": "Splunk OpenTelemetry Collector cluster receiver configuration.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -473,6 +478,11 @@
           "type": "object"
         }
       }
+    },
+    "otelK8sClusterReceiver": {
+      "description": "[DEPRECATED] Splunk OpenTelemetry Collector cluster receiver configuration.",
+      "type": "object",
+      "deprecated": true
     },
     "logsCollection": {
       "description": "Native OpenTelemetry logs collection configuration.",
@@ -835,8 +845,8 @@
       "description": "Apply for k8s cluster with windows worker node.",
       "type": "boolean"
     },
-    "otelCollector": {
-      "description": "Splunk OpenTelemetry collector k8s deployment configuration.",
+    "gateway": {
+      "description": "Splunk OpenTelemetry Collector gateway deployment configuration.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -962,6 +972,11 @@
           "type": "object"
         }
       }
+    },
+    "otelCollector": {
+      "description": "[DEPRECATED] Splunk OpenTelemetry Collector gateway deployment configuration.",
+      "type": "object",
+      "deprecated": true
     },
     "service": {
       "description": "Splunk OpenTelemetry collector service configuration.",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -199,13 +199,13 @@ extraAttributes:
 # It collects metrics and traces and send them to Signalfx backend.
 ################################################################################
 
-otelAgent:
+agent:
   enabled: true
 
   # The ports to be exposed by the agent to the host.
   # Make sure that only necessary ports are exposed, <hostIP, hostPort, protocol> combination must
   # be unique across all the nodes in k8s cluster. Any port can be disabled,
-  # For example to disable zipkin ports set `otelAgent.ports.zipkin: null`.
+  # For example to disable zipkin ports set `agent.ports.zipkin: null`.
   ports:
     otlp:
       containerPort: 4317
@@ -286,10 +286,10 @@ otelAgent:
 # specifically for collecting metrics from kubernetes API.
 ################################################################################
 
-# Kubernetes cluster receiver collects cluster level metrics from the Kubernetes API.
+# Cluster receiver collects cluster level metrics from the Kubernetes API.
 # It has to be running on one pod, so it uses its own dedicated deployment with 1 replica.
 
-otelK8sClusterReceiver:
+clusterReceiver:
   enabled: true
 
   # Need to be adjusted based on size of the monitored cluster
@@ -314,7 +314,7 @@ otelK8sClusterReceiver:
 
   # This Flag enables k8s events collection with smartagent/kubernetes-events receiver
   # You can override list of events collected by default using the following config option:
-  # `otelK8sClusterReceiver.config.receivers.smartagent/kubernetes-events.whitelistedEvents`
+  # `clusterReceiver.config.receivers.smartagent/kubernetes-events.whitelistedEvents`
   k8sEventsEnabled: false
 
   # k8s cluster receiver extra pod labels
@@ -764,7 +764,7 @@ isWindows: false
 # passthrough mode is recommended for large k8s clusters, disabled by default.
 ################################################################################
 
-otelCollector:
+gateway:
   # Defines if collector deployment is enabled
   # Recommended for large k8s clusters, disabled by default.
   enabled: false

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -396,7 +396,7 @@ logsCollection:
   checkpointPath: "/var/addon/splunk/otel_pos"
 
   # Files on k8s nodes to tail.
-  # Make sure to configure volume mounts properly at `otelAgent.extraVolumes` and `otelAgent.extraVolumeMounts`.
+  # Make sure to configure volume mounts properly at `agent.extraVolumes` and `agent.extraVolumeMounts`.
   extraFileLogs: {}
   # Sample configuration to collect Audit logs. Please note hostPath can vary depending on the audit-policy.yaml configuration.
   # extraFileLogs:

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-agent.yaml
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -30,8 +30,6 @@ data:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
-      file_storage:
-        directory: /var/addon/splunk/otel_pos
       health_check: null
       k8s_observer:
         auth_type: serviceAccount
@@ -47,6 +45,17 @@ data:
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"
+      groupbyattrs/logs:
+        keys:
+        - com.splunk.source
+        - com.splunk.sourcetype
+        - container.id
+        - fluent.tag
+        - istio_service_name
+        - k8s.container.name
+        - k8s.namespace.name
+        - k8s.pod.name
+        - k8s.pod.uid
       k8sattributes:
         extract:
           annotations:
@@ -124,96 +133,6 @@ data:
         override: false
         timeout: 10s
     receivers:
-      filelog:
-        encoding: utf-8
-        exclude:
-        - /var/log/pods/default_default-splunk-otel-collector*_*/otel-collector/*.log
-        fingerprint_size: 1kb
-        force_flush_period: "0"
-        include:
-        - /var/log/pods/*/*/*.log
-        include_file_name: false
-        include_file_path: true
-        max_concurrent_files: 1024
-        max_log_size: 1MiB
-        operators:
-        - id: get-format
-          routes:
-          - expr: $$$$body matches "^\\{"
-            output: parser-docker
-          - expr: $$$$body matches "^[^ Z]+ "
-            output: parser-crio
-          - expr: $$$$body matches "^[^ Z]+Z"
-            output: parser-containerd
-          type: router
-        - id: parser-crio
-          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
-          timestamp:
-            layout: "2006-01-02T15:04:05.000000000-07:00"
-            layout_type: gotime
-            parse_from: time
-          type: regex_parser
-        - combine_field: log
-          id: crio-recombine
-          is_last_entry: ($$.logtag) == 'F'
-          type: recombine
-        - id: crio-handle_empty_log
-          if: $$.log == nil
-          ops:
-          - add:
-              field: log
-              value: ""
-          output: filename
-          type: restructure
-        - id: parser-containerd
-          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
-          timestamp:
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: time
-          type: regex_parser
-        - combine_field: log
-          id: containerd-recombine
-          is_last_entry: ($$.logtag) == 'F'
-          type: recombine
-        - id: containerd-handle_empty_log
-          if: $$.log == nil
-          ops:
-          - add:
-              field: log
-              value: ""
-          output: filename
-          type: restructure
-        - id: parser-docker
-          timestamp:
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: time
-          type: json_parser
-        - id: filename
-          resource:
-            com.splunk.source: EXPR($$$$attributes["file.path"])
-          type: metadata
-        - id: extract_metadata_from_filepath
-          parse_from: $$$$attributes["file.path"]
-          regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
-          type: regex_parser
-        - attributes:
-            stream: EXPR($$.stream)
-          resource:
-            com.splunk.sourcetype: EXPR("kube:container:"+$$.container_name)
-            k8s.container.name: EXPR($$.container_name)
-            k8s.container.restart_count: EXPR($$.restart_count)
-            k8s.namespace.name: EXPR($$.namespace)
-            k8s.pod.name: EXPR($$.pod_name)
-            k8s.pod.uid: EXPR($$.uid)
-          type: metadata
-        - id: clean-up-log-record
-          ops:
-          - move:
-              from: log
-              to: $$
-          type: restructure
-        poll_interval: 200ms
-        start_at: beginning
       fluentforward:
         endpoint: 0.0.0.0:8006
       hostmetrics:
@@ -270,7 +189,6 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
-      - file_storage
       - health_check
       - k8s_observer
       - memory_ballast
@@ -281,6 +199,7 @@ data:
           - splunk_hec/o11y
           processors:
           - memory_limiter
+          - groupbyattrs/logs
           - k8sattributes
           - batch
           - filter/logs
@@ -288,7 +207,6 @@ data:
           - resource/logs
           - resourcedetection
           receivers:
-          - filelog
           - fluentforward
           - otlp
         metrics:

--- a/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-k8s-cluster-receiver.yaml
+# Source: splunk-otel-collector/templates/configmap-cluster-receiver.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 13ebf1992ec4b891314554315d658530379d3449244854d3d8abe4deb4a2e2c1
+        checksum/config: 851a5e0b7eeea8b1ad0d1b4efc3e4a98f79d8b9b72c0d5525dd083a24fc4d54b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+# Source: splunk-otel-collector/templates/deployment-cluster-receiver.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f9ce25501546034c03ac1afe9b8df53bc190f57d388290ad7c67ad2088a048
+        checksum/config: c760da301afa505e28f3cd489c8cab2784c403916a1b3e5c7f28d8ec6ff8136f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -1,9 +1,9 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-agent.yaml
+# Source: splunk-otel-collector/templates/configmap-gateway.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: default-splunk-otel-collector-otel-agent
+  name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.37.1
@@ -23,17 +23,15 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
-        correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
-        sync_host_metadata: true
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null
-      k8s_observer:
-        auth_type: serviceAccount
-        node: ${K8S_NODE_NAME}
+      http_forwarder:
+        egress:
+          endpoint: https://api.CHANGEME.signalfx.com
       memory_ballast:
         size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
@@ -45,17 +43,6 @@ data:
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"
-      groupbyattrs/logs:
-        keys:
-        - com.splunk.source
-        - com.splunk.sourcetype
-        - container.id
-        - fluent.tag
-        - istio_service_name
-        - k8s.container.name
-        - k8s.namespace.name
-        - k8s.pod.name
-        - k8s.pod.uid
       k8sattributes:
         extract:
           annotations:
@@ -80,11 +67,6 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        filter:
-          node_from_env_var: K8S_NODE_NAME
         pod_association:
         - from: resource_attribute
           name: k8s.pod.uid
@@ -98,16 +80,16 @@ data:
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
-      resource:
+      resource/add_cluster_name:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_collector_k8s:
         attributes:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.cluster.name
-          value: CHANGEME
-      resource/add_agent_k8s:
-        attributes:
         - action: insert
           key: k8s.pod.name
           value: ${K8S_POD_NAME}
@@ -133,119 +115,87 @@ data:
         override: false
         timeout: 10s
     receivers:
-      fluentforward:
-        endpoint: 0.0.0.0:8006
-      hostmetrics:
-        collection_interval: 10s
-        scrapers:
-          cpu: null
-          disk: null
-          filesystem: null
-          load: null
-          memory: null
-          network: null
-          paging: null
-          processes: null
       jaeger:
         protocols:
           grpc:
             endpoint: 0.0.0.0:14250
           thrift_http:
             endpoint: 0.0.0.0:14268
-      kubeletstats:
-        auth_type: serviceAccount
-        collection_interval: 10s
-        endpoint: ${K8S_NODE_IP}:10250
-        extra_metadata_labels:
-        - container.id
-        metric_groups:
-        - container
-        - pod
-        - node
       otlp:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
-      prometheus/agent:
+      prometheus/collector:
         config:
           scrape_configs:
-          - job_name: otel-agent
+          - job_name: otel-collector
             scrape_interval: 10s
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8889
-      receiver_creator:
-        receivers: null
-        watch_observers:
-        - k8s_observer
       signalfx:
+        access_token_passthrough: true
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
       - health_check
-      - k8s_observer
       - memory_ballast
       - zpages
+      - http_forwarder
       pipelines:
         logs:
           exporters:
           - splunk_hec/o11y
           processors:
           - memory_limiter
-          - groupbyattrs/logs
           - k8sattributes
           - batch
           - filter/logs
-          - resource
           - resource/logs
-          - resourcedetection
           receivers:
-          - fluentforward
           - otlp
+        logs/signalfx-events:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          receivers:
+          - signalfx
         metrics:
           exporters:
           - signalfx
           processors:
           - memory_limiter
           - batch
-          - resource
-          - resourcedetection
+          - resource/add_cluster_name
           receivers:
-          - hostmetrics
-          - kubeletstats
           - otlp
-          - receiver_creator
           - signalfx
-        metrics/agent:
+        metrics/collector:
           exporters:
           - signalfx
           processors:
           - memory_limiter
           - batch
-          - resource
-          - resource/add_agent_k8s
+          - resource/add_cluster_name
+          - resource/add_collector_k8s
           - resourcedetection
           receivers:
-          - prometheus/agent
+          - prometheus/collector
         traces:
           exporters:
           - sapm
-          - signalfx
           processors:
           - memory_limiter
-          - k8sattributes
           - batch
-          - resource
-          - resourcedetection
+          - k8sattributes
+          - resource/add_cluster_name
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/deployment-collector.yaml
+# Source: splunk-otel-collector/templates/deployment-gateway.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2bd79e3573ec78f7208ea22d30e1c47dea3a2b18028bcbaed4280cb16f1825f4
+        checksum/config: 177a5fa5b2953d28890a139373ad3e78c57af4482ceee949f77bd41c4e7a8fa8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -1,9 +1,9 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-collector.yaml
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: default-splunk-otel-collector-otel-collector
+  name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.37.1
@@ -17,21 +17,20 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        sync_host_metadata: true
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null
-      http_forwarder:
-        egress:
-          endpoint: https://api.CHANGEME.signalfx.com
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
       memory_ballast:
         size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
@@ -43,6 +42,17 @@ data:
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"
+      groupbyattrs/logs:
+        keys:
+        - com.splunk.source
+        - com.splunk.sourcetype
+        - container.id
+        - fluent.tag
+        - istio_service_name
+        - k8s.container.name
+        - k8s.namespace.name
+        - k8s.pod.name
+        - k8s.pod.uid
       k8sattributes:
         extract:
           annotations:
@@ -67,6 +77,11 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
+        filter:
+          node_from_env_var: K8S_NODE_NAME
         pod_association:
         - from: resource_attribute
           name: k8s.pod.uid
@@ -80,16 +95,16 @@ data:
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
-      resource/add_cluster_name:
-        attributes:
-        - action: upsert
-          key: k8s.cluster.name
-          value: CHANGEME
-      resource/add_collector_k8s:
+      resource:
         attributes:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
+        - action: insert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_agent_k8s:
+        attributes:
         - action: insert
           key: k8s.pod.name
           value: ${K8S_POD_NAME}
@@ -115,87 +130,52 @@ data:
         override: false
         timeout: 10s
     receivers:
-      jaeger:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:14250
-          thrift_http:
-            endpoint: 0.0.0.0:14268
+      fluentforward:
+        endpoint: 0.0.0.0:8006
       otlp:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
           http:
             endpoint: 0.0.0.0:4318
-      prometheus/collector:
+      prometheus/agent:
         config:
           scrape_configs:
-          - job_name: otel-collector
+          - job_name: otel-agent
             scrape_interval: 10s
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8889
-      signalfx:
-        access_token_passthrough: true
-        endpoint: 0.0.0.0:9943
-      zipkin:
-        endpoint: 0.0.0.0:9411
     service:
       extensions:
       - health_check
+      - k8s_observer
       - memory_ballast
       - zpages
-      - http_forwarder
       pipelines:
         logs:
           exporters:
           - splunk_hec/o11y
           processors:
           - memory_limiter
+          - groupbyattrs/logs
           - k8sattributes
           - batch
           - filter/logs
+          - resource
           - resource/logs
-          receivers:
-          - otlp
-        logs/signalfx-events:
-          exporters:
-          - signalfx
-          processors:
-          - memory_limiter
-          - batch
-          receivers:
-          - signalfx
-        metrics:
-          exporters:
-          - signalfx
-          processors:
-          - memory_limiter
-          - batch
-          - resource/add_cluster_name
-          receivers:
-          - otlp
-          - signalfx
-        metrics/collector:
-          exporters:
-          - signalfx
-          processors:
-          - memory_limiter
-          - batch
-          - resource/add_cluster_name
-          - resource/add_collector_k8s
           - resourcedetection
           receivers:
-          - prometheus/collector
-        traces:
+          - fluentforward
+          - otlp
+        metrics/agent:
           exporters:
-          - sapm
+          - signalfx
           processors:
           - memory_limiter
           - batch
-          - k8sattributes
-          - resource/add_cluster_name
+          - resource
+          - resource/add_agent_k8s
+          - resourcedetection
           receivers:
-          - otlp
-          - jaeger
-          - zipkin
+          - prometheus/agent

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 2707d59b2e0bb73579a56c15fcd55255c8b419b2cb391ac2347fdcdbd4d08071
+        checksum/config: 01011f93defb4e8ba71fc75e7abc1fbbdc307edc565fa382bd8b331160db70eb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-agent.yaml
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-k8s-cluster-receiver.yaml
+# Source: splunk-otel-collector/templates/configmap-cluster-receiver.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 767afdeffa0130189e91f88f541efe348dea9752cd67fe4273399fd39469346d
+        checksum/config: 403978a539841a0613c2cfd6e2ff708b3453b5a1ca0b22a30f3a59845b0ea0e8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+# Source: splunk-otel-collector/templates/deployment-cluster-receiver.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f9ce25501546034c03ac1afe9b8df53bc190f57d388290ad7c67ad2088a048
+        checksum/config: c760da301afa505e28f3cd489c8cab2784c403916a1b3e5c7f28d8ec6ff8136f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-agent.yaml
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,7 +26,12 @@ data:
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
+      splunk_hec/o11y:
+        endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
+      file_storage:
+        directory: /var/addon/splunk/otel_pos
       health_check: null
       k8s_observer:
         auth_type: serviceAccount
@@ -42,17 +47,6 @@ data:
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"
-      groupbyattrs/logs:
-        keys:
-        - com.splunk.source
-        - com.splunk.sourcetype
-        - container.id
-        - fluent.tag
-        - istio_service_name
-        - k8s.container.name
-        - k8s.namespace.name
-        - k8s.pod.name
-        - k8s.pod.uid
       k8sattributes:
         extract:
           annotations:
@@ -130,12 +124,125 @@ data:
         override: false
         timeout: 10s
     receivers:
+      filelog:
+        encoding: utf-8
+        exclude:
+        - /var/log/pods/default_default-splunk-otel-collector*_*/otel-collector/*.log
+        fingerprint_size: 1kb
+        force_flush_period: "0"
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        max_concurrent_files: 1024
+        max_log_size: 1MiB
+        operators:
+        - id: get-format
+          routes:
+          - expr: $$$$body matches "^\\{"
+            output: parser-docker
+          - expr: $$$$body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: $$$$body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
+          timestamp:
+            layout: "2006-01-02T15:04:05.000000000-07:00"
+            layout_type: gotime
+            parse_from: time
+          type: regex_parser
+        - combine_field: log
+          id: crio-recombine
+          is_last_entry: ($$.logtag) == 'F'
+          type: recombine
+        - id: crio-handle_empty_log
+          if: $$.log == nil
+          ops:
+          - add:
+              field: log
+              value: ""
+          output: filename
+          type: restructure
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: time
+          type: regex_parser
+        - combine_field: log
+          id: containerd-recombine
+          is_last_entry: ($$.logtag) == 'F'
+          type: recombine
+        - id: containerd-handle_empty_log
+          if: $$.log == nil
+          ops:
+          - add:
+              field: log
+              value: ""
+          output: filename
+          type: restructure
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: time
+          type: json_parser
+        - id: filename
+          resource:
+            com.splunk.source: EXPR($$$$attributes["file.path"])
+          type: metadata
+        - id: extract_metadata_from_filepath
+          parse_from: $$$$attributes["file.path"]
+          regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - attributes:
+            stream: EXPR($$.stream)
+          resource:
+            com.splunk.sourcetype: EXPR("kube:container:"+$$.container_name)
+            k8s.container.name: EXPR($$.container_name)
+            k8s.container.restart_count: EXPR($$.restart_count)
+            k8s.namespace.name: EXPR($$.namespace)
+            k8s.pod.name: EXPR($$.pod_name)
+            k8s.pod.uid: EXPR($$.uid)
+          type: metadata
+        - id: clean-up-log-record
+          ops:
+          - move:
+              from: log
+              to: $$
+          type: restructure
+        poll_interval: 200ms
+        start_at: beginning
+      fluentforward:
+        endpoint: 0.0.0.0:8006
+      hostmetrics:
+        collection_interval: 10s
+        scrapers:
+          cpu: null
+          disk: null
+          filesystem: null
+          load: null
+          memory: null
+          network: null
+          paging: null
+          processes: null
       jaeger:
         protocols:
           grpc:
             endpoint: 0.0.0.0:14250
           thrift_http:
             endpoint: 0.0.0.0:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 10s
+        endpoint: ${K8S_NODE_IP}:10250
+        extra_metadata_labels:
+        - container.id
+        metric_groups:
+        - container
+        - pod
+        - node
       otlp:
         protocols:
           grpc:
@@ -150,6 +257,12 @@ data:
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8889
+      receiver_creator:
+        receivers: null
+        watch_observers:
+        - k8s_observer
+      signalfx:
+        endpoint: 0.0.0.0:9943
       smartagent/signalfx-forwarder:
         listenAddress: 0.0.0.0:9080
         type: signalfx-forwarder
@@ -157,11 +270,41 @@ data:
         endpoint: 0.0.0.0:9411
     service:
       extensions:
+      - file_storage
       - health_check
       - k8s_observer
       - memory_ballast
       - zpages
       pipelines:
+        logs:
+          exporters:
+          - splunk_hec/o11y
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - batch
+          - filter/logs
+          - resource
+          - resource/logs
+          - resourcedetection
+          receivers:
+          - filelog
+          - fluentforward
+          - otlp
+        metrics:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource
+          - resourcedetection
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - otlp
+          - receiver_creator
+          - signalfx
         metrics/agent:
           exporters:
           - signalfx
@@ -176,6 +319,7 @@ data:
         traces:
           exporters:
           - sapm
+          - signalfx
           processors:
           - memory_limiter
           - k8sattributes

--- a/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-k8s-cluster-receiver.yaml
+# Source: splunk-otel-collector/templates/configmap-cluster-receiver.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 04f50d53a5a07b84b460bc9ff0e9411318a737d71a3823711b2ad694fce644fe
+        checksum/config: e73b2f1f1048c7e2d13b567693eb1f3c7ea915c6b740f37fd74ae54a1c8a8420
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/deployment-k8s-cluster-receiver.yaml
+# Source: splunk-otel-collector/templates/deployment-cluster-receiver.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f9ce25501546034c03ac1afe9b8df53bc190f57d388290ad7c67ad2088a048
+        checksum/config: c760da301afa505e28f3cd489c8cab2784c403916a1b3e5c7f28d8ec6ff8136f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/traces-only/configmap-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-agent.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: splunk-otel-collector/templates/configmap-otel-agent.yaml
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,15 +17,15 @@ metadata:
 data:
   relay: |
     exporters:
+      sapm:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
-      splunk_hec/o11y:
-        endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
-        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null
       k8s_observer:
@@ -130,8 +130,12 @@ data:
         override: false
         timeout: 10s
     receivers:
-      fluentforward:
-        endpoint: 0.0.0.0:8006
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:14250
+          thrift_http:
+            endpoint: 0.0.0.0:14268
       otlp:
         protocols:
           grpc:
@@ -146,6 +150,11 @@ data:
             static_configs:
             - targets:
               - ${K8S_POD_IP}:8889
+      smartagent/signalfx-forwarder:
+        listenAddress: 0.0.0.0:9080
+        type: signalfx-forwarder
+      zipkin:
+        endpoint: 0.0.0.0:9411
     service:
       extensions:
       - health_check
@@ -153,21 +162,6 @@ data:
       - memory_ballast
       - zpages
       pipelines:
-        logs:
-          exporters:
-          - splunk_hec/o11y
-          processors:
-          - memory_limiter
-          - groupbyattrs/logs
-          - k8sattributes
-          - batch
-          - filter/logs
-          - resource
-          - resource/logs
-          - resourcedetection
-          receivers:
-          - fluentforward
-          - otlp
         metrics/agent:
           exporters:
           - signalfx
@@ -179,3 +173,17 @@ data:
           - resourcedetection
           receivers:
           - prometheus/agent
+        traces:
+          exporters:
+          - sapm
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - batch
+          - resource
+          - resourcedetection
+          receivers:
+          - otlp
+          - jaeger
+          - smartagent/signalfx-forwarder
+          - zipkin

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ab0039eb8569a5206eb2b1c230530729d4e2443653653ba4ec6b1deff4011d77
+        checksum/config: 8d6a5adc49b59030b5a5e829fa941e5482d3ad3cdb0bc29ab9a91ac207d89d1e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
Rename the following parameter groups according to [Splunk GDI Specification](https://github.com/signalfx/gdi-specification/blob/main/specification/configuration.md#kubernetes-package-management-solutions):
- `otelAgent` -> `agent`
- `otelCollector` -> `gateway`
- `otelK8sClusterReceiver` -> `clusterReceiver`