### PR TITLE
Add link to migrating from SCK document

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
     <a href="CONTRIBUTING.md">Getting Involved</a>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/signalfx/splunk-otel-collector/blob/main/docs/signalfx-smart-agent-migration.md">Migrating from Smart Agent</a>
+    &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+    <a href="https://github.com/signalfx/splunk-otel-collector/blob/main/docs/migration-from-sck.md">Migrating from Splunk Connect for Kubernetes</a>
   </strong>
 </p>
 


### PR DESCRIPTION
Adds a link to the migration document from the top menu