### PR TITLE
Change log "stream' attribute according to OTel semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UP
   - `otelAgent` -> `agent`
   - `otelCollector` -> `gateway`
   - `otelK8sClusterReceiver` -> `clusterReceiver`
+- Rename `stream` log attribute to `log.iostream` (#311)
 
 ### Fixed
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -209,7 +209,7 @@ receivers:
           k8s.pod.name: 'EXPR($$.pod_name)'
           com.splunk.sourcetype: 'EXPR("kube:container:"+$$.container_name)'
         attributes:
-          stream: 'EXPR($$.stream)'
+          log.iostream: 'EXPR($$.stream)'
       {{- if .Values.logsCollection.containers.multilineConfigs }}
       - type: router
         routes:

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -197,7 +197,7 @@ data:
           regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
           type: regex_parser
         - attributes:
-            stream: EXPR($$.stream)
+            log.iostream: EXPR($$.stream)
           resource:
             com.splunk.sourcetype: EXPR("kube:container:"+$$.container_name)
             k8s.container.name: EXPR($$.container_name)

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e73b2f1f1048c7e2d13b567693eb1f3c7ea915c6b740f37fd74ae54a1c8a8420
+        checksum/config: 10a67e090122e6b58df427f82dfba0ffd078a3b1aef01fa51ab5602a89bfcbd0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
Rename `stream` log attribute to `log.iostream` according to [OTel semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/semantic_conventions/media.md#io-stream)