### PR TITLE
Remove extraArgs config parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UP
 ### Removed
 
 - Busybox image dependency (#275)
+- `extraArgs` config parameter (#313)
 
 ## [0.37.1] - 2021-11-01
 

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -194,9 +194,6 @@ spec:
         - --config=/conf/relay.yaml
         {{- end }}
         - --metrics-addr=0.0.0.0:8889
-        {{- range $agent.extraArgs }}
-        - {{ . }}
-        {{- end }}
         ports:
         {{- range $key, $port := $agent.ports }}
         {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.o11yTracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -73,9 +73,6 @@ spec:
         - --config=/conf/relay.yaml
         {{- end }}
         - --metrics-addr=0.0.0.0:8889
-        {{- range $clusterReceiver.extraArgs }}
-        - {{ . }}
-        {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -73,9 +73,6 @@ spec:
         - --config=/conf/relay.yaml
         {{- end }}
         - --metrics-addr=0.0.0.0:8889
-        {{- range $gateway.extraArgs }}
-        - {{ . }}
-        {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:


### PR DESCRIPTION
With the latest collector releases, all arguments were moved to configuration. And `extraArgs` parameter is already removed from the schema, so it cannot be used since 0.37.0.