### PR TITLE
fix exporter name

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -478,7 +478,7 @@ service:
         {{- end }}
       exporters:
         {{- if eq (include "splunk-otel-collector.platformLogsEnabled" .) "true" }}
-        - splunk_hec/platform
+        - splunk_hec/platform_logs
         {{- end }}
         {{- if eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true" }}
         - splunk_hec/o11y


### PR DESCRIPTION
for extra host files, it is using wrong exporter name for Splunk platform. 
changing it to `splunk_hec/platform_logs`