### PR TITLE
Mark image.fluentd.initContainer as deprecated instead of dropping it

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -55,6 +55,12 @@ extraAttributes:
     - key: git_sha
 ```
 
+[#316 Busybox dependency is removed, splunk/fluentd-hec image is used in init container
+instead](https://github.com/signalfx/splunk-otel-collector-chart/pull/316)
+
+`image.fluentd.initContainer` is not being used anymore. Please remove it from
+your custom values.yaml.
+
 ## 0.36.2 to 0.37.0
 
 [#232 Access to underlying node's filesystem was reduced to the minimum scope

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -57,3 +57,7 @@ Splunk OpenTelemetry Connector is installed and configured to send data to Splun
 [WARNING] "otelK8sClusterReceiver" parameter group is deprecated, please rename it to "clusterReceiver" in your custom values.yaml.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
 {{ end }}
+{{- if not (eq (toString .Values.image.fluentd.initContainer) "<nil>") }}
+[WARNING] "image.fluentd.initContainer" parameter is deprecated now. Now we use the same splunk/fluentd-hec image in init container.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
+{{ end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -732,6 +732,10 @@
                 "Always",
                 "Never"
               ]
+            },
+            "initContainer": {
+              "type": "object",
+              "deprecated": "true"
             }
           }
         },


### PR DESCRIPTION
There are few customers that use their own docker registry. We don't want to break upgrade experience for them.