### PR TITLE
Remove redundant secret from fluentd container

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -217,9 +217,6 @@ spec:
           readOnly: true
         - name: fluentd-config
           mountPath: /fluentd/etc
-        - name: secrets
-          mountPath: /fluentd/etc/splunk
-          readOnly: true
       {{- end }}
       - name: otel-collector
         command:
@@ -388,9 +385,6 @@ spec:
       - name: journallogpath
         hostPath:
           path: {{ .Values.fluentd.config.journalLogPath | quote }}
-      - name: secrets
-        secret:
-          secretName: {{ template "splunk-otel-collector.secret" . }}
       - name: fluentd-config
         emptyDir: {}
       - name: fluentd-config-common

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -109,9 +109,6 @@ spec:
           readOnly: true
         - name: fluentd-config
           mountPath: /fluentd/etc
-        - name: secrets
-          mountPath: /fluentd/etc/splunk
-          readOnly: true
       - name: otel-collector
         command:
         - /otelcol
@@ -246,9 +243,6 @@ spec:
       - name: journallogpath
         hostPath:
           path: "/run/log/journal"
-      - name: secrets
-        secret:
-          secretName: splunk-otel-collector
       - name: fluentd-config
         emptyDir: {}
       - name: fluentd-config-common

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -109,9 +109,6 @@ spec:
           readOnly: true
         - name: fluentd-config
           mountPath: /fluentd/etc
-        - name: secrets
-          mountPath: /fluentd/etc/splunk
-          readOnly: true
       - name: otel-collector
         command:
         - /otelcol
@@ -195,9 +192,6 @@ spec:
       - name: journallogpath
         hostPath:
           path: "/run/log/journal"
-      - name: secrets
-        secret:
-          secretName: splunk-otel-collector
       - name: fluentd-config
         emptyDir: {}
       - name: fluentd-config-common


### PR DESCRIPTION
It was used when fluent was sending data directly to the backend, not being used anymore