### PR TITLE
Remove redundant arguments to otelMemoryLimiterConfig helper

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -3,7 +3,6 @@ Config for the otel-collector agent
 The values can be overridden in .Values.agent.config
 */}}
 {{- define "splunk-otel-collector.agentConfig" -}}
-{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) -}}
 {{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) -}}
 extensions:
   {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (eq .Values.logsEngine "otel") }}
@@ -317,7 +316,7 @@ processors:
   {{- include "splunk-otel-collector.filterLogsProcessors" . | nindent 2 }}
   {{- end }}
 
-  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" $agent | nindent 2 }}
+  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" . | nindent 2 }}
 
   batch:
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -3,7 +3,6 @@ Config for the optional standalone collector
 The values can be overridden in .Values.gateway.config
 */}}
 {{- define "splunk-otel-collector.gatewayConfig" -}}
-{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) -}}
 extensions:
   health_check:
 
@@ -78,7 +77,7 @@ processors:
   {{- include "splunk-otel-collector.resourceLogsProcessor" . | nindent 2 }}
   {{- include "splunk-otel-collector.filterLogsProcessors" . | nindent 2 }}
 
-  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" $gateway | nindent 2 }}
+  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" . | nindent 2 }}
 
   batch:
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -44,7 +44,7 @@ receivers:
   {{- end }}
 
 processors:
-  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" $clusterReceiver | nindent 2 }}
+  {{- include "splunk-otel-collector.otelMemoryLimiterConfig" . | nindent 2 }}
 
   batch:
 


### PR DESCRIPTION
The helper used to receive specific component resources as argument to calculate memory limit. This is not needed anymore since calculation was moved to the image itself