### PR TITLE
Allow global property in values schema

### DIFF
--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -9,6 +9,9 @@
   "title": "Values",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "type": "object"
+    },
     "nameOverride": {
       "description": "Override name of the chart used in Kubernetes object names.",
       "type": "string"


### PR DESCRIPTION
Fix for #328; Enables this chart to be used as a sub chart (dependency).

Same issue and fix as in https://github.com/istio/istio/issues/35495 / https://github.com/istio/istio/pull/35496