### PR TITLE
updated helm gateway examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -103,15 +103,17 @@ gateway:
 ## Deploy gateway-mode OTel Collector only
 
 This configuration will install collector as a gateway deployment only.
-No metrics or logs will be collector, the gateway can be used to forward
-telemetry data through it for aggregation, enrichment purposes.
+No metrics or logs will be collected from the gateway instance(s), the gateway
+can be used to forward telemetry data through it for aggregation, enrichment
+purposes.
 
 ```yaml
 gateway:
   enabled: true
 agent:
   enabled: false
-logsEnabled: false
+clusterReceiver:
+  enabled: false
 ```
 
 ## Route telemetry data through a gateway deployed separately
@@ -135,6 +137,8 @@ agent:
         traces:
           exporters: [otlp, signalfx]
         metrics:
+          exporters: [otlp]
+        logs:
           exporters: [otlp]
 
 clusterReceiver:

--- a/examples/gateway-only-values.yaml
+++ b/examples/gateway-only-values.yaml
@@ -7,4 +7,5 @@ gateway:
   enabled: true
 agent:
   enabled: false
-logsEnabled: false
+clusterReceiver:
+  enabled: false

--- a/examples/use-custom-gateway-values.yaml
+++ b/examples/use-custom-gateway-values.yaml
@@ -18,6 +18,8 @@ agent:
           exporters: [otlp, signalfx]
         metrics:
           exporters: [otlp]
+        logs:
+          exporters: [otlp]
 
 clusterReceiver:
   config:


### PR DESCRIPTION
For the "Deploy gateway-mode Otel Collector only"
We need logsEnabled to true, so it can receive logs over otlp and forward over to splunk_hec/o11y