### PR TITLE
Add GKE Autopilot support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Google Kubernetes Engine Autopilot support (#338)
+
 ## [0.40.0] - 2021-12-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Kubernetes distributions:
 - [Amazon Elastic Kubernetes Service](https://aws.amazon.com/eks)
 - [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks)
 - [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)
+  including [GKE Autopilot](docs/advanced-configuration.md#gke-autopilot-support)
 - [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift)
 
 While this helm chart should work for other Kubernetes distributions, it may

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -67,7 +67,7 @@ resourcedetection:
     # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
     # before it gets set later by the cloud provider detector.
     - env
-    {{- if eq (include "splunk-otel-collector.distribution" .) "gke" }}
+    {{- if hasPrefix "gke" (include "splunk-otel-collector.distribution" .) }}
     - gke
     {{- else if eq (include "splunk-otel-collector.distribution" .) "eks" }}
     - eks

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -77,8 +77,15 @@ receivers:
 
   kubeletstats:
     collection_interval: 10s
+    {{- if eq .Values.distribution "gke/autopilot" }}
+    # GKE Autopilot doesn't allow using the secure kubelet endpoint,
+    # use the read-only endpoint instead.
+    auth_type: none
+    endpoint: ${K8S_NODE_IP}:10255
+    {{- else }}
     auth_type: serviceAccount
     endpoint: ${K8S_NODE_IP}:10250
+    {{- end }}
     metric_groups:
       - container
       - pod

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -95,6 +95,7 @@ spec:
             - name: fluentd-config-cri
               mountPath: /fluentd/etc/cri
         {{- else }}
+        {{- if not (eq .Values.distribution "gke/autopilot") }}
         - name: copy-old-checkpoint
           image: {{ template "splunk-otel-collector.image.otelcol" . }}
           imagePullPolicy: {{ .Values.image.fluentd.pullPolicy }}
@@ -138,6 +139,7 @@ spec:
               mountPath: /var/log
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
+        {{- end }}
         {{- if and $agent.securityContext.runAsUser $agent.securityContext.runAsGroup }}
         - name: chown
           image: registry.access.redhat.com/ubi8/ubi

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -198,6 +198,7 @@
       "enum": [
         "eks",
         "gke",
+        "gke/autopilot",
         "aks",
         "openshift",
         " ",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -126,7 +126,8 @@ cloudProvider: ""
 ################################################################################
 # Kubernetes distribution being run. Leave empty for other.
 # - "eks" (Amazon Elastic Kubernetes Service)
-# - "gke" (Google Google Kubernetes Engine)
+# - "gke" (Google Kubernetes Engine / Standard mode)
+# - "gke/autopilot" (Google Kubernetes Engine / Autopilot mode)
 # - "aks" (Azure Kubernetes Service)
 # - "openshift" (RedHat OpenShift)
 ################################################################################


### PR DESCRIPTION
Docs and configuration changes to support GKE Autopilot operation mode. The change depends on a [kubelet read-only endpoint support](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6488) which was added to OpenTelemetry Collector in 0.41.0