### PR TITLE
Add option to disable helm hook for custom secret validation

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/secret-validation-hook.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-validation-hook.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secret.create }}
+{{- if and (not .Values.secret.create) (.Values.secret.validateSecret)}}
 # Helm hook validating that custom secret provided by user has all the required
 # fields.
 apiVersion: v1

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -824,6 +824,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "validateSecret": {
+          "type": "boolean"
         }
       }
     },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -751,6 +751,8 @@ rbac:
 secret:
   create: true
   name: ""
+  # Specifies whether secret provided by user should be validated.
+  validateSecret: true
 
 # This default tolerations allow the daemonset to be deployed on master nodes,
 # so that we can also collect logs and metrics from those nodes.


### PR DESCRIPTION
Pod running custom secret validation has little configuration options, which can block helm release in some cases, example: https://github.com/signalfx/splunk-otel-collector-chart/issues/349. An option to disable custom secret validation can be useful for  such cases.

Closes: https://github.com/signalfx/splunk-otel-collector-chart/issues/349