### PR TITLE
Automatically collect metrics, logs from K8s Control Plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Auto collect metrics for the apiserver control plane component
+
 ### Fixed
 
 - Double expansion issue splunk-otel-collector (#357). See [upgrade

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -247,3 +247,31 @@ autodetect:
 ## Override underlying OpenTelemetry agent configuration
 
 If you want to use your own OpenTelemetry Agent configuration, you can override it by providing a custom configuration in the `agent.config` parameter in the values.yaml, which will be merged into the default agent configuration, list parts of the configuration (for example, `service.pipelines.logs.processors`) to be fully re-defined.
+
+### Override a control plane configuration
+
+If your control plane is using non-standard ports or custom TLS certificates, then you can provide a custom
+configuration so the otel-collector agent can still successfully connect to it.
+
+To collect control plane metrics, we use a
+[receiver creator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/receivercreator/README.md)
+that instantiates
+[smartagent/{control_plane_component}](https://docs.splunk.com/observability/gdi/orchestration.html#nav-Orchestration)
+receivers at runtime.
+
+Below is an example configuration of how you could set up the agent to connect to an apiserver that is running on port
+8443 (instead of the normal 443) and use custom TLS configurations.
+
+```yaml
+agent:
+  config:
+    receivers:
+      receiver_creator:
+        receivers:
+          smartagent/kubernetes-apiserver:
+            rule: type == "port" && port == 8443 && pod.labels["k8s-app"] == "kube-apiserver"
+            config:
+              clientCertPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              clientKeyPath: /var/run/secrets/kubernetes.io/serviceaccount/token
+              useServiceAccount: false
+```

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -219,6 +219,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "controlPlane": {
+          "type": "boolean"
+        },
         "prometheus": {
           "type": "boolean"
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -144,6 +144,10 @@ distribution: ""
 
 ################################################################################
 # Optional: Automatic detection of additional metric sources.
+# We collect k8s control plane metrics by default, you can disable this by
+# setting autodetect.controlPlane=false. This controlPlane integration
+# relies on having access the k8s control plane which k8s clusters run as a
+# managed service do not support.
 # Set autodetect.prometheus=true if you want the otel-collector agent to scrape
 # prometheus metrics from pods that have prometheus-style annotations like
 # "prometheus.io/scrape".
@@ -151,6 +155,7 @@ distribution: ""
 ################################################################################
 
 autodetect:
+  controlPlane: true
   prometheus: false
   istio: false
 

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -172,7 +172,16 @@ data:
             - targets:
               - ${K8S_POD_IP}:8889
       receiver_creator:
-        receivers: null
+        receivers:
+          smartagent/kubernetes-apiserver:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-apiserver
+              skipVerify: true
+              type: kubernetes-apiserver
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
         watch_observers:
         - k8s_observer
       signalfx:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ea2970db4e6183ec5c16bd1ba3a6f0010d2a4abc69e3a36b6ebd31b7086398d9
+        checksum/config: e00f6eb1a871f75816afa765fe4f58f744f80e2b720c08e7f985ff73667f2db7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -163,7 +163,16 @@ data:
             - targets:
               - ${K8S_POD_IP}:8889
       receiver_creator:
-        receivers: null
+        receivers:
+          smartagent/kubernetes-apiserver:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-apiserver
+              skipVerify: true
+              type: kubernetes-apiserver
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
         watch_observers:
         - k8s_observer
       signalfx:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ede25c3ed94716a26848bfc77635d767cc0be84a73bd61c49ceb43c2c8a71c57
+        checksum/config: 71bba5fe50521c7eeb4cd6c9196b15321be8e8139678250adf375f7bc1146035
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -258,7 +258,16 @@ data:
             - targets:
               - ${K8S_POD_IP}:8889
       receiver_creator:
-        receivers: null
+        receivers:
+          smartagent/kubernetes-apiserver:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-apiserver
+              skipVerify: true
+              type: kubernetes-apiserver
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
         watch_observers:
         - k8s_observer
       signalfx:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ea0bb7a5bcd707268a902feec74217c929c1bff378507cf3c20cc10dab6394b1
+        checksum/config: 457799396896cfa51ad626794f4ec6267a00df99306f9b7f15f69f34d11973e9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
Overview
- Added support for collecting the k8s control plane apiserver metrics via the smartagent/kubernetes-apiserver receiver.
- Collection of metrics from other control plane components will be in a future PR.
- Collection of logs from control plane components will be in a future PR.

Notes:
- I'm open to suggestions and changing how I feed the apisever.config value from values.yaml to the _otel-agent file durring the render process. This was the best solution I could come up with. I wanted to support having different default config values based on k8s distribution and also support allowing the user to supply their own custom config. 