### PR TITLE
Updating schema validation for imagePullSecrets as expected by chart

### DIFF
--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -710,13 +710,7 @@
         "imagePullSecrets": {
           "type": "array",
           "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "type": "string"
-              }
-            }
+            "type": "string"
           }
         },
         "fluentd": {


### PR DESCRIPTION
Updated chart validation schema for `imagePullSecrets` to sync with the expectation of the chart
Previously expected validation by the schema is as mentioned below but the chart expects string instead of object type:
```
imagePullSecrets:
  - name: myregistry
```
Expected by the chart:
```
imagePullSecrets:
  - myregistry
```