### PR TITLE
Remove the quadruple dollar hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Double expansion issue splunk-otel-collector (#357). See [upgrade
+guideline](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0410-to-0420)
+
 ### Removed
 
 - Temporary helper initContainer for OTel checkpointing log path move (#358)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,13 @@
 # Upgrade guidelines
 
+## 0.41.0 to 0.42.0
+
+[#357 Double expansion issue in splunk-otel-collector is
+fixed](https://github.com/signalfx/splunk-otel-collector-chart/pull/357)
+
+If you use OTel native logs collection with any custom log processing operators
+in `filelog` receiver, please replace any occurrences of `$$$$` with `$$`.
+
 ## 0.38.0 to 0.39.0
 
 [#325 Logs collection is now disabled by default for Splunk Observability

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -218,15 +218,15 @@ Create a filter expression for multiline logs configuration.
 {{- $expr := "" }}
 {{- if .namespaceName }}
 {{- $useRegexp := eq (toString .namespaceName.useRegexp | default "false") "true" }}
-{{- $expr = cat "($$$$resource[\"k8s.namespace.name\"])" (ternary "matches" "==" $useRegexp) (quote .namespaceName.value) "&&" }}
+{{- $expr = cat "($$resource[\"k8s.namespace.name\"])" (ternary "matches" "==" $useRegexp) (quote .namespaceName.value) "&&" }}
 {{- end }}
 {{- if .podName }}
 {{- $useRegexp := eq (toString .podName.useRegexp | default "false") "true" }}
-{{- $expr = cat $expr "($$$$resource[\"k8s.pod.name\"])" (ternary "matches" "==" $useRegexp) (quote .podName.value) "&&" }}
+{{- $expr = cat $expr "($$resource[\"k8s.pod.name\"])" (ternary "matches" "==" $useRegexp) (quote .podName.value) "&&" }}
 {{- end }}
 {{- if .containerName }}
 {{- $useRegexp := eq (toString .containerName.useRegexp | default "false") "true" }}
-{{- $expr = cat $expr "($$$$resource[\"k8s.container.name\"])" (ternary "matches" "==" $useRegexp) (quote .containerName.value) "&&" }}
+{{- $expr = cat $expr "($$resource[\"k8s.container.name\"])" (ternary "matches" "==" $useRegexp) (quote .containerName.value) "&&" }}
 {{- end }}
 {{- $expr | trimSuffix "&&" | trim }}
 {{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -139,11 +139,11 @@ receivers:
         id: get-format
         routes:
           - output: parser-docker
-            expr: '$$$$body matches "^\\{"'
+            expr: '$$body matches "^\\{"'
           - output: parser-crio
-            expr: '$$$$body matches "^[^ Z]+ "'
+            expr: '$$body matches "^[^ Z]+ "'
           - output: parser-containerd
-            expr: '$$$$body matches "^[^ Z]+Z"'
+            expr: '$$body matches "^[^ Z]+Z"'
       {{- end }}
       {{- if or (not .Values.logsCollection.containers.containerRuntime) (eq .Values.logsCollection.containers.containerRuntime "cri-o") }}
       # Parse CRI-O format
@@ -199,12 +199,12 @@ receivers:
       - type: metadata
         id: filename
         resource:
-          com.splunk.source: EXPR($$$$attributes["file.path"])
+          com.splunk.source: EXPR($$attributes["file.path"])
       # Extract metadata from file path
       - type: regex_parser
         id: extract_metadata_from_filepath
         regex: '^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
-        parse_from: $$$$attributes["file.path"]
+        parse_from: $$attributes["file.path"]
       # Move out attributes to Attributes
       - type: metadata
         resource:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -712,9 +712,9 @@ image:
 
   otelcol:
     # The registry and name of the opentelemetry collector image to pull
-    repository: quay.io/signalfx/splunk-otel-collector
+    repository: quay.io/signalfx/splunk-otel-collector-dev
     # The tag of the Splunk OTel Collector image, default value is the chart appVersion
-    tag: ""
+    tag: 91f554caad6cc5fb52b4bcbdccc94256f0562610
     # The policy that specifies when the user wants the opentelemetry collector images to be pulled
     pullPolicy: IfNotPresent
 

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -76,7 +76,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -41,7 +41,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -41,7 +41,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -129,7 +129,7 @@ spec:
         - name: otlp-http-old
           containerPort: 55681
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -60,7 +60,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -41,7 +41,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -139,11 +139,11 @@ data:
         operators:
         - id: get-format
           routes:
-          - expr: $$$$body matches "^\\{"
+          - expr: $$body matches "^\\{"
             output: parser-docker
-          - expr: $$$$body matches "^[^ Z]+ "
+          - expr: $$body matches "^[^ Z]+ "
             output: parser-crio
-          - expr: $$$$body matches "^[^ Z]+Z"
+          - expr: $$body matches "^[^ Z]+Z"
             output: parser-containerd
           type: router
         - id: parser-crio
@@ -190,10 +190,10 @@ data:
           type: json_parser
         - id: filename
           resource:
-            com.splunk.source: EXPR($$$$attributes["file.path"])
+            com.splunk.source: EXPR($$attributes["file.path"])
           type: metadata
         - id: extract_metadata_from_filepath
-          parse_from: $$$$attributes["file.path"]
+          parse_from: $$attributes["file.path"]
           regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
           type: regex_parser
         - attributes:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: cc641bdc22a677c320c67f9335e7100b21b7cb654613f730df21b106da9e425d
+        checksum/config: ea0bb7a5bcd707268a902feec74217c929c1bff378507cf3c20cc10dab6394b1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -41,7 +41,7 @@ spec:
           key: node-role.kubernetes.io/master
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.41.0
+          image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -111,7 +111,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -41,7 +41,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -72,7 +72,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.41.0
+        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB


### PR DESCRIPTION
Double expansion issue was fixed with [the recent splunk-otel-collector upgrade](https://github.com/signalfx/splunk-otel-collector/pull/1099). Now OTel collector configs are expanded only once and hack with `$$$$` is not needed anymore.

+ temporary set the splunk-otel-collector docker image to the latest dev version to keep the main in a working state.