### PR TITLE
Remove temporary initContainer, helper for OTel native log path move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Removed
+
+- Temporary helper initContainer for OTel checkpointing log path move (#358)
+
 ## [0.41.0] - 2021-12-13
 
 ### Added

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -96,19 +96,6 @@ spec:
               mountPath: /fluentd/etc/cri
         {{- else }}
         {{- if not (eq .Values.distribution "gke/autopilot") }}
-        - name: copy-old-checkpoint
-          image: {{ template "splunk-otel-collector.image.otelcol" . }}
-          imagePullPolicy: {{ .Values.image.fluentd.pullPolicy }}
-          command: [ "sh", "-c"]
-          securityContext:
-            runAsUser: 0
-          args:
-            - cp -n /var/lib/otel_pos/* /var/addon/splunk/otel_pos/ || true
-          volumeMounts:
-            - name: checkpoint
-              mountPath: /var/addon/splunk/otel_pos
-            - name: old-checkpoint
-              mountPath: /var/lib/otel_pos
         - name: migrate-checkpoint
           image: {{ template "splunk-otel-collector.image.otelcol" . }}
           imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
@@ -409,10 +396,6 @@ spec:
       - name: checkpoint
         hostPath:
           path: {{ .Values.logsCollection.checkpointPath }}
-          type: DirectoryOrCreate
-      - name: old-checkpoint
-        hostPath:
-          path: /var/lib/otel_pos
           type: DirectoryOrCreate
       {{- end}}
       {{- end}}

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -40,19 +40,6 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
       initContainers:
-        - name: copy-old-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.41.0
-          imagePullPolicy: IfNotPresent
-          command: [ "sh", "-c"]
-          securityContext:
-            runAsUser: 0
-          args:
-            - cp -n /var/lib/otel_pos/* /var/addon/splunk/otel_pos/ || true
-          volumeMounts:
-            - name: checkpoint
-              mountPath: /var/addon/splunk/otel_pos
-            - name: old-checkpoint
-              mountPath: /var/lib/otel_pos
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.41.0
           imagePullPolicy: IfNotPresent
@@ -228,10 +215,6 @@ spec:
       - name: checkpoint
         hostPath:
           path: /var/addon/splunk/otel_pos
-          type: DirectoryOrCreate
-      - name: old-checkpoint
-        hostPath:
-          path: /var/lib/otel_pos
           type: DirectoryOrCreate
       - name: host-dev
         hostPath:


### PR DESCRIPTION
This initContainer was needed to support change of the default path for native OTel logs collection checkpointing to avoid data duplication with an upgrade. We waited enough to remove the helper. Also it relies on otel-collector-image with smart-agent bundle which is not available for ARM architectures. So in some cases, this initContainer can block the collector from running on ARM architectures.