### PR TITLE
Remove container.image.tag extraction in clusterReceiver

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -94,21 +94,6 @@ processors:
         key: {{ .name }}
         value: {{ .value }}
       {{- end }}
-      # Extract "container.image.tag" attribute from "container.image.name" here until k8scluster
-      # receiver does it natively.
-      - key: container.image.name
-        pattern: ^(?P<temp_container_image_name>[^\:]+)(?:\:(?P<temp_container_image_tag>.*))?
-        action: extract
-      - key: container.image.name
-        from_attribute: temp_container_image_name
-        action: upsert
-      - key: temp_container_image_name
-        action: delete
-      - key: container.image.tag
-        from_attribute: temp_container_image_tag
-        action: upsert
-      - key: temp_container_image_tag
-        action: delete
 
 exporters:
   {{- if eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true" }}

--- a/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
@@ -42,19 +42,6 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
-        - action: extract
-          key: container.image.name
-          pattern: ^(?P<temp_container_image_name>[^\:]+)(?:\:(?P<temp_container_image_tag>.*))?
-        - action: upsert
-          from_attribute: temp_container_image_name
-          key: container.image.name
-        - action: delete
-          key: temp_container_image_name
-        - action: upsert
-          from_attribute: temp_container_image_tag
-          key: container.image.tag
-        - action: delete
-          key: temp_container_image_tag
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d36cbca4359ba3381f413c586ab78a7fd17051a81e5815acf0459c09841ad239
+        checksum/config: 534468877b40ff3f36f1da7d0dbead8f32624f55ed3e660b2f04cf8006a89e31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
@@ -42,19 +42,6 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
-        - action: extract
-          key: container.image.name
-          pattern: ^(?P<temp_container_image_name>[^\:]+)(?:\:(?P<temp_container_image_tag>.*))?
-        - action: upsert
-          from_attribute: temp_container_image_name
-          key: container.image.name
-        - action: delete
-          key: temp_container_image_name
-        - action: upsert
-          from_attribute: temp_container_image_tag
-          key: container.image.tag
-        - action: delete
-          key: temp_container_image_tag
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d36cbca4359ba3381f413c586ab78a7fd17051a81e5815acf0459c09841ad239
+        checksum/config: 534468877b40ff3f36f1da7d0dbead8f32624f55ed3e660b2f04cf8006a89e31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
@@ -42,19 +42,6 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
-        - action: extract
-          key: container.image.name
-          pattern: ^(?P<temp_container_image_name>[^\:]+)(?:\:(?P<temp_container_image_tag>.*))?
-        - action: upsert
-          from_attribute: temp_container_image_name
-          key: container.image.name
-        - action: delete
-          key: temp_container_image_name
-        - action: upsert
-          from_attribute: temp_container_image_tag
-          key: container.image.tag
-        - action: delete
-          key: temp_container_image_tag
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d36cbca4359ba3381f413c586ab78a7fd17051a81e5815acf0459c09841ad239
+        checksum/config: 534468877b40ff3f36f1da7d0dbead8f32624f55ed3e660b2f04cf8006a89e31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
Otel Collector starting from 0.42.0 already reports `container.image.name` and `container.image.tag` as separate fields. There is no need to do it in this helm chart anymore. This change in no-op for the end user.

Corresponding change in OTel collector: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6436