### PR TITLE
Adding native otel logs collection for windows nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Auto collect metrics for the apiserver control plane component
+- Add native OTel logs collection for the Windows node (#361)
 
 ### Fixed
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,7 +41,6 @@ Windows support covers traces and metrics collection only, no logs will be colle
 image:
   otelcol:
     repository: quay.io/signalfx/splunk-otel-collector-windows
-logsEnabled: false
 readinessProbe:
   initialDelaySeconds: 60
 livenessProbe:

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,7 +35,7 @@ This configuration will install application for windows worker node only.
 
 All windows images are available in a separate `quay.io` repository: `quay.io/signalfx/splunk-otel-collector-windows`.
 
-Windows support covers traces and metrics collection only, no logs will be collected. As of now, we don’t have fluentd-hec image for the windows worker node.
+Logs collection on Windows is only available using OTel native logs collection. fluentd log engine is not supported Because, as of now we don’t have fluentd-hec image for the windows worker node.
 
 ```yaml
 image:

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,7 +35,7 @@ This configuration will install application for windows worker node only.
 
 All windows images are available in a separate `quay.io` repository: `quay.io/signalfx/splunk-otel-collector-windows`.
 
-Logs collection on Windows is only available using OTel native logs collection. fluentd log engine is not supported Because, as of now we don’t have fluentd-hec image for the windows worker node.
+Logs collection on Windows is only available using OTel native logs collection. Fluentd log engine is not supported.
 
 ```yaml
 image:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -131,7 +131,7 @@ receivers:
   {{- if and (eq .Values.logsEngine "otel") .Values.logsCollection.containers.enabled }}
   filelog:
     {{- if .Values.isWindows }}
-    include: ["C:/var/log/pods/*/*/*.log"]
+    include: ["C:\\var\\log\\pods\\*\\*\\*.log"]
     {{- else }}
     include: ["/var/log/pods/*/*/*.log"]
     {{- end }}
@@ -140,7 +140,7 @@ receivers:
     exclude:
       {{- if .Values.logsCollection.containers.excludeAgentLogs }}
       {{- if .Values.isWindows }}
-      - C:/var/log/pods/{{ .Release.Namespace }}_{{ include "splunk-otel-collector.fullname" . }}*_*/otel-collector/*.log
+      - "C:\\var\\log\\pods\\{{ .Release.Namespace }}_{{ include "splunk-otel-collector.fullname" . }}*_*\\otel-collector\\*.log"
       {{- else }}
       - /var/log/pods/{{ .Release.Namespace }}_{{ include "splunk-otel-collector.fullname" . }}*_*/otel-collector/*.log
       {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -130,12 +130,20 @@ receivers:
 
   {{- if and (eq .Values.logsEngine "otel") .Values.logsCollection.containers.enabled }}
   filelog:
+    {{- if .Values.isWindows }}
+    include: ["C:/var/log/pods/*/*/*.log"]
+    {{- else }}
     include: ["/var/log/pods/*/*/*.log"]
+    {{- end }}
     # Exclude logs. The file format is
     # /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<restart_count>.log
     exclude:
       {{- if .Values.logsCollection.containers.excludeAgentLogs }}
+      {{- if .Values.isWindows }}
+      - C:/var/log/pods/{{ .Release.Namespace }}_{{ include "splunk-otel-collector.fullname" . }}*_*/otel-collector/*.log
+      {{- else }}
       - /var/log/pods/{{ .Release.Namespace }}_{{ include "splunk-otel-collector.fullname" . }}*_*/otel-collector/*.log
+      {{- end }}
       {{- end }}
       {{- range $_, $excludePath := .Values.logsCollection.containers.excludePaths }}
       - {{ $excludePath }}
@@ -221,7 +229,11 @@ receivers:
       # Extract metadata from file path
       - type: regex_parser
         id: extract_metadata_from_filepath
+        {{- if .Values.isWindows }}
+        regex: '^C:\\var\\log\\pods\\(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\\(?P<container_name>[^\._]+)\\(?P<restart_count>\d+)\.log$'
+        {{- else }}
         regex: '^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
+        {{- end }}
         parse_from: $$attributes["file.path"]
       # Move out attributes to Attributes
       - type: metadata

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -353,7 +353,7 @@ spec:
         - name: varlog
           mountPath: C:/var/log
           readOnly: true
-          # From C:/ProgramData Container storage location C:/ProgramData/docker/containers and C:/ProgramData/containerd/root are being used.
+          # C:/ProgramData mount is needed for access to container storage in C:/ProgramData/docker/containers and C:/ProgramData/containerd/root.
         - name: programdata
           mountPath: C:/ProgramData
           readOnly: true

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -351,11 +351,11 @@ spec:
         {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (eq .Values.logsEngine "otel") }}
         {{- if .Values.isWindows }}
         - name: varlog
-          mountPath: C:/var/log
+          mountPath: C:\var\log
           readOnly: true
-          # C:/ProgramData mount is needed for access to container storage in C:/ProgramData/docker/containers and C:/ProgramData/containerd/root.
+          # C:\ProgramData mount is needed for access to container storage in C:\ProgramData\docker\containers and C:\ProgramData\containerd\root.
         - name: programdata
-          mountPath: C:/ProgramData
+          mountPath: C:\ProgramData
           readOnly: true
         {{- else }}
         - name: varlog
@@ -400,10 +400,10 @@ spec:
       {{- if .Values.isWindows }}
       - name: varlog
         hostPath:
-          path: C:/var/log
+          path: C:\var\log
       - name: programdata
         hostPath:
-          path: C:/ProgramData
+          path: C:\ProgramData
       {{- else }}
       - name: varlog
         hostPath:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -61,7 +61,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+      {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (not .Values.isWindows) }}
       initContainers:
         {{- if (eq .Values.logsEngine "fluentd") }}
         - name: prepare-fluentd-config
@@ -349,12 +349,21 @@ spec:
           readOnly: true
         {{- end }}
         {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (eq .Values.logsEngine "otel") }}
+        {{- if .Values.isWindows }}
+        - name: varlog
+          mountPath: C:/var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: C:/ProgramData
+          readOnly: true
+        {{- else }}
         - name: varlog
           mountPath: /var/log
           readOnly: true
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        {{- end }}
         - name: checkpoint
           mountPath: {{ .Values.logsCollection.checkpointPath }}
         {{- end }}
@@ -387,12 +396,21 @@ spec:
           name: {{ template "splunk-otel-collector.fullname" . }}-fluentd-json
       {{- end}}
       {{- if eq .Values.logsEngine "otel" }}
+      {{- if .Values.isWindows }}
+      - name: varlog
+        hostPath:
+          path: C:/var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: C:/ProgramData
+      {{- else }}
       - name: varlog
         hostPath:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      {{- end }}
       - name: checkpoint
         hostPath:
           path: {{ .Values.logsCollection.checkpointPath }}

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -353,7 +353,8 @@ spec:
         - name: varlog
           mountPath: C:/var/log
           readOnly: true
-        - name: varlibdockercontainers
+          # From C:/ProgramData Container storage location C:/ProgramData/docker/containers and C:/ProgramData/containerd/root are being used.
+        - name: programdata
           mountPath: C:/ProgramData
           readOnly: true
         {{- else }}
@@ -400,7 +401,7 @@ spec:
       - name: varlog
         hostPath:
           path: C:/var/log
-      - name: varlibdockercontainers
+      - name: programdata
         hostPath:
           path: C:/ProgramData
       {{- else }}


### PR DESCRIPTION
Native logs support on windows k8s nodes
Ticket: [OTL-1349](https://signalfuse.atlassian.net/browse/OTL-1349)

**Changes:**
- Updating filelog path and regex to parse windows `$$attributes["file.path"]`
- Not creating `initContainers` in case of windows k8s nodes, because fluentd logging agent is not supported on a windows node
- Mounting C:/ProgramData of the host as var-lib-docker-containers in case of windows k8s nodes

**Testing outcome:**
For testing, I have used the following values.yaml input file to Otel helm chart
```
clusterName: nimesh-windows-cluster
splunkObservability:
  realm: <SPLUNK_REALM>
  accessToken: <SPLUNK_ACCESS_TOKEN>
  logsEnabled: true

image:
  otelcol:
    repository: quay.io/signalfx/splunk-otel-collector-windows-dev

logsEngine: "otel"
readinessProbe:
  initialDelaySeconds: 60
livenessProbe:
  initialDelaySeconds: 60

isWindows: true

agent:
  config:
    exporters:
      logging:
        loglevel: debug
    service:
      pipelines:
        logs:
          exporters: [ logging, splunk_hec/o11y ]
```
to generate a log I have created a sample deployment to print random numbers on the log file.

**Output:**
Console log of otel-collector agent.
<img width="1792" alt="Screenshot 2022-01-19 at 4 11 51 PM" src="https://user-images.githubusercontent.com/88535006/150116684-6ab61d8f-8327-42b2-a066-53794b6c9c66.png">

Splunk Log Observer.
<img width="1789" alt="Screenshot 2022-01-19 at 4 09 40 PM" src="https://user-images.githubusercontent.com/88535006/150117225-01067684-bab0-4604-90c7-baf8945b3833.png">
