### PR TITLE
Improve documentation for Windows nodes

### DIFF
--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -81,6 +81,42 @@ splunkPlatform:
   logsEnabled: true
 ```
 
+## Windows worker nodes support
+
+Splunk OpenTelemetry Collector for Kubernetes supports collection of metrics,
+traces and logs (using OTel native logs collection only) from Windows nodes.
+
+All windows images are available in a separate `quay.io` repository:
+`quay.io/signalfx/splunk-otel-collector-windows`.
+
+Use the following values.yaml configuration to install the helm chart on Windows
+worker nodes:
+
+```yaml
+isWindows: true
+image:
+  otelcol:
+    repository: quay.io/signalfx/splunk-otel-collector-windows
+logsEngine: otel
+readinessProbe:
+  initialDelaySeconds: 60
+livenessProbe:
+  initialDelaySeconds: 60
+```
+
+If you have both Windows and Linux worker nodes in your Kubernetes cluster, you
+need to install the helm chart twice. One of the installations with default
+configuration `isWindows: false` will be applied on Linux nodes. Another
+installation with values.yaml configuration that provided above will be applied
+on Windows nodes. And it's important to disable `clusterReceiver` on one of the
+installations to avoid cluster-wide metrics duplication, add the following line
+to values.yaml of one of the installations:
+
+```yaml
+clusterReceiver:
+  enabled: false
+```
+
 ## GKE Autopilot support
 
 If you want to run Splunk OTel Collector in [Google Kubernetes Engine

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,25 +29,6 @@ splunkObservability:
   accessToken: my-access-token
 ```
 
-## Deploy for k8s cluster with windows worker node.
-
-This configuration will install application for windows worker node only.
-
-All windows images are available in a separate `quay.io` repository: `quay.io/signalfx/splunk-otel-collector-windows`.
-
-Logs collection on Windows is only available using OTel native logs collection. Fluentd log engine is not supported.
-
-```yaml
-image:
-  otelcol:
-    repository: quay.io/signalfx/splunk-otel-collector-windows
-readinessProbe:
-  initialDelaySeconds: 60
-livenessProbe:
-  initialDelaySeconds: 60
-isWindows: true
-```
-
 ## Enable traces sampling
 
 This example shows how to change default OTel Collector configuration to add


### PR DESCRIPTION
- Move it from examples/README.md to advanced-configuration.md 
- Add documentation for hybrid (Linux + Windows) clusters

Related issue: https://github.com/signalfx/splunk-otel-collector-chart/issues/351