### PR TITLE
Bump soc version to 0.42.0

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: splunk-otel-collector
 version: 0.41.0
-appVersion: 0.41.0
+appVersion: 0.42.0
 description: Splunk OpenTelemetry Collector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -733,9 +733,9 @@ image:
 
   otelcol:
     # The registry and name of the opentelemetry collector image to pull
-    repository: quay.io/signalfx/splunk-otel-collector-dev
+    repository: quay.io/signalfx/splunk-otel-collector
     # The tag of the Splunk OTel Collector image, default value is the chart appVersion
-    tag: 91f554caad6cc5fb52b4bcbdccc94256f0562610
+    tag: ""
     # The policy that specifies when the user wants the opentelemetry collector images to be pulled
     pullPolicy: IfNotPresent
 

--- a/rendered/manifests/agent-only/clusterRole.yaml
+++ b/rendered/manifests/agent-only/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/agent-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/agent-only/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e00f6eb1a871f75816afa765fe4f58f744f80e2b720c08e7f985ff73667f2db7
+        checksum/config: 4b9aac7d7d90183a5bcec00029688185929c4d2f32a1fc62b980710442e6531b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -76,7 +76,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.41.0
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 534468877b40ff3f36f1da7d0dbead8f32624f55ed3e660b2f04cf8006a89e31
+        checksum/config: 308f7c45cd8200b593b05881f705c668cc8fd9e70115044d4e72ac8d1bdd52d1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/agent-only/secret.yaml
+++ b/rendered/manifests/agent-only/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/agent-only/serviceAccount.yaml
+++ b/rendered/manifests/agent-only/serviceAccount.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/gateway-only/clusterRole.yaml
+++ b/rendered/manifests/gateway-only/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/gateway-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/gateway-only/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.41.0
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9ffd4f770eda00b0c0e32b7aca5a6988996a1ae88937d3ebe12e697fb7a1ccce
+        checksum/config: 8ac5d1bf736f2d44e3496cbb38e193629c8cc1c3ebd18ea1f9b3151dc7f17465
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/gateway-only/secret.yaml
+++ b/rendered/manifests/gateway-only/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/gateway-only/service.yaml
+++ b/rendered/manifests/gateway-only/service.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.41.0

--- a/rendered/manifests/gateway-only/serviceAccount.yaml
+++ b/rendered/manifests/gateway-only/serviceAccount.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/logs-only/clusterRole.yaml
+++ b/rendered/manifests/logs-only/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/logs-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/logs-only/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/logs-only/configmap-fluentd-json.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-json.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/logs-only/configmap-fluentd.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: fd9ecf50cc3022fab396c16b398d2beb1f198a906c9d76b3ca195f763daece71
+        checksum/config: 20eaf1e6c3c9f5264efd4c1fa1a604c4bf9ac54da42887765b19007316f30466
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -129,7 +129,7 @@ spec:
         - name: otlp-http-old
           containerPort: 55681
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/logs-only/secret.yaml
+++ b/rendered/manifests/logs-only/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/logs-only/serviceAccount.yaml
+++ b/rendered/manifests/logs-only/serviceAccount.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/metrics-only/clusterRole.yaml
+++ b/rendered/manifests/metrics-only/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/metrics-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/metrics-only/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 71bba5fe50521c7eeb4cd6c9196b15321be8e8139678250adf375f7bc1146035
+        checksum/config: f725796ba8e37b4f8aaa38065330960447552faa21eff38d4120ac109be088b7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -60,7 +60,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.41.0
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 534468877b40ff3f36f1da7d0dbead8f32624f55ed3e660b2f04cf8006a89e31
+        checksum/config: 308f7c45cd8200b593b05881f705c668cc8fd9e70115044d4e72ac8d1bdd52d1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/metrics-only/secret.yaml
+++ b/rendered/manifests/metrics-only/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/metrics-only/serviceAccount.yaml
+++ b/rendered/manifests/metrics-only/serviceAccount.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/otel-logs/clusterRole.yaml
+++ b/rendered/manifests/otel-logs/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/otel-logs/clusterRoleBinding.yaml
+++ b/rendered/manifests/otel-logs/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 457799396896cfa51ad626794f4ec6267a00df99306f9b7f15f69f34d11973e9
+        checksum/config: 4da3245a992f7996d9a9cd45d85ccae9ce4208559257d118814f893883c5f07f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -41,7 +41,7 @@ spec:
           key: node-role.kubernetes.io/master
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+          image: quay.io/signalfx/splunk-otel-collector:0.42.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -111,7 +111,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.41.0
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 534468877b40ff3f36f1da7d0dbead8f32624f55ed3e660b2f04cf8006a89e31
+        checksum/config: 308f7c45cd8200b593b05881f705c668cc8fd9e70115044d4e72ac8d1bdd52d1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         - --metrics-addr=0.0.0.0:8889
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/otel-logs/secret.yaml
+++ b/rendered/manifests/otel-logs/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/otel-logs/serviceAccount.yaml
+++ b/rendered/manifests/otel-logs/serviceAccount.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/traces-only/clusterRole.yaml
+++ b/rendered/manifests/traces-only/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/traces-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/traces-only/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/traces-only/configmap-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-agent.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d13432639599dd918eea1220bfe301172cecd78ebe506946aab4a299369ce7ab
+        checksum/config: f850e7b16ef22530f98019a75f314a8a9faa25d385c71f7448c527a76a291dff
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -72,7 +72,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector-dev:91f554caad6cc5fb52b4bcbdccc94256f0562610
+        image: quay.io/signalfx/splunk-otel-collector:0.42.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/rendered/manifests/traces-only/secret.yaml
+++ b/rendered/manifests/traces-only/secret.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default

--- a/rendered/manifests/traces-only/serviceAccount.yaml
+++ b/rendered/manifests/traces-only/serviceAccount.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.41.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.41.0"
+    app.kubernetes.io/version: "0.42.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.41.0
     release: default


### PR DESCRIPTION
Now that we've released this version the temporary [dev image workaround](https://github.com/signalfx/splunk-otel-collector-chart/pull/357) is no longer necessary.