### PR TITLE
OTL-374 Added support to collect control plane component metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Added support to collect control plane component metrics; controller-manager, coredns, proxy, scheduler (#383)
+
 ## [0.43.2] - 2022-02-02
 
 ### Added

--- a/ci_scripts/sck_otel_values.yaml
+++ b/ci_scripts/sck_otel_values.yaml
@@ -33,6 +33,9 @@ logsEngine: otel
 
 clusterName: "functional-test"
 
+agent:
+  controlPlaneEnabled: true
+
 # Metadata to be set on the telemetry data from Kubernetes objects.
 # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sprocessor.
 #k8sMetadata:

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -185,6 +185,20 @@ Get Splunk Observability Access Token.
 {{- end -}}
 
 {{/*
+Helper that returns the controlPlaneEnabled parameter taking care of backward compatibility with the old parameter
+name "autodetect.controlPlane".
+*/}}
+{{- define "splunk-otel-collector.controlPlaneEnabled" -}}
+{{- if ne (toString .Values.agent.controlPlaneEnabled) "<nil>" }}
+{{- .Values.agent.controlPlaneEnabled }}
+{{- else if ne (toString .Values.autodetect.controlPlane) "<nil>" }}
+{{- .Values.autodetect.controlPlane }}
+{{- else }}
+{{- true }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the fluentd image name.
 */}}
 {{- define "splunk-otel-collector.image.fluentd" -}}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -225,7 +225,8 @@
       "additionalProperties": false,
       "properties": {
         "controlPlane": {
-          "type": "boolean"
+          "type": "boolean",
+          "deprecated": true
         },
         "prometheus": {
           "type": "boolean"
@@ -285,6 +286,9 @@
       "additionalProperties": false,
       "properties": {
         "enabled": {
+          "type": "boolean"
+        },
+        "controlPlaneEnabled": {
           "type": "boolean"
         },
         "ports": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -151,10 +151,6 @@ distribution: ""
 
 ################################################################################
 # Optional: Automatic detection of additional metric sources.
-# We collect k8s control plane metrics by default, you can disable this by
-# setting autodetect.controlPlane=false. This controlPlane integration
-# relies on having access the k8s control plane which k8s clusters run as a
-# managed service do not support.
 # Set autodetect.prometheus=true if you want the otel-collector agent to scrape
 # prometheus metrics from pods that have prometheus-style annotations like
 # "prometheus.io/scrape".
@@ -162,7 +158,6 @@ distribution: ""
 ################################################################################
 
 autodetect:
-  controlPlane: true
   prometheus: false
   istio: false
 
@@ -215,6 +210,10 @@ extraAttributes:
 
 agent:
   enabled: true
+
+  # This Flag enables k8s control plane metric collection.
+  # Details about control plane monitoring and related configurations are located in docs/advanced-configuration.md
+  controlPlaneEnabled: true
 
   # The ports to be exposed by the agent to the host.
   # Make sure that only necessary ports are exposed, <hostIP, hostPort, protocol> combination must

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -176,6 +176,23 @@ data:
               - ${K8S_POD_IP}:8889
       receiver_creator:
         receivers:
+          smartagent/coredns:
+            config:
+              extraDimensions:
+                metric_source: k8s-coredns
+              port: 9153
+              type: coredns
+            rule: type == "pod" && labels["k8s-app"] == "kube-dns"
+          smartagent/kube-controller-manager:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-controller-manager
+              port: 10257
+              skipVerify: true
+              type: kube-controller-manager
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-controller-manager"
           smartagent/kubernetes-apiserver:
             config:
               extraDimensions:
@@ -185,6 +202,20 @@ data:
               useHTTPS: true
               useServiceAccount: true
             rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
+          smartagent/kubernetes-proxy:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-proxy
+              port: 10249
+              type: kubernetes-proxy
+            rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
+          smartagent/kubernetes-scheduler:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-scheduler
+              port: 10251
+              type: kubernetes-scheduler
+            rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer
       signalfx:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7ceaa2db448ab1a0ebc167bc1aa68fbb65dddeb17d91a9c1fb9c3b0d0917515d
+        checksum/config: aa7528ec9c709cc3ba572b82a01e5655bc4b4f3dfc033dfe63416f7dfc938f1e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -167,6 +167,23 @@ data:
               - ${K8S_POD_IP}:8889
       receiver_creator:
         receivers:
+          smartagent/coredns:
+            config:
+              extraDimensions:
+                metric_source: k8s-coredns
+              port: 9153
+              type: coredns
+            rule: type == "pod" && labels["k8s-app"] == "kube-dns"
+          smartagent/kube-controller-manager:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-controller-manager
+              port: 10257
+              skipVerify: true
+              type: kube-controller-manager
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-controller-manager"
           smartagent/kubernetes-apiserver:
             config:
               extraDimensions:
@@ -176,6 +193,20 @@ data:
               useHTTPS: true
               useServiceAccount: true
             rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
+          smartagent/kubernetes-proxy:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-proxy
+              port: 10249
+              type: kubernetes-proxy
+            rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
+          smartagent/kubernetes-scheduler:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-scheduler
+              port: 10251
+              type: kubernetes-scheduler
+            rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer
       signalfx:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 1c65430f5d3a8f917baf994aedb62ab77d8b36732b0469f26842eb2ac50dfd47
+        checksum/config: 7084567f96152193e375f201b458d6723fb0ce8be9ca3b4f9edce25fd7da0525
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -259,6 +259,23 @@ data:
               - ${K8S_POD_IP}:8889
       receiver_creator:
         receivers:
+          smartagent/coredns:
+            config:
+              extraDimensions:
+                metric_source: k8s-coredns
+              port: 9153
+              type: coredns
+            rule: type == "pod" && labels["k8s-app"] == "kube-dns"
+          smartagent/kube-controller-manager:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-controller-manager
+              port: 10257
+              skipVerify: true
+              type: kube-controller-manager
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-controller-manager"
           smartagent/kubernetes-apiserver:
             config:
               extraDimensions:
@@ -268,6 +285,20 @@ data:
               useHTTPS: true
               useServiceAccount: true
             rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
+          smartagent/kubernetes-proxy:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-proxy
+              port: 10249
+              type: kubernetes-proxy
+            rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
+          smartagent/kubernetes-scheduler:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-scheduler
+              port: 10251
+              type: kubernetes-scheduler
+            rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer
       signalfx:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 1395bde0986ff27a101a1bc6d780aad4148a9f0b3c1494547520f5937fc3f8fa
+        checksum/config: 5ad23fec85ce0c684fdf787156ac399d29bbc574d9fcd9af80a2fcc292579525
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/test/k8s_metrics_test/test_config_metrics.py
+++ b/test/k8s_metrics_test/test_config_metrics.py
@@ -9,6 +9,12 @@ from ..common import check_metrics_from_splunk
 
 
 @pytest.mark.parametrize("metric", [
+  #Control Plane Metrics
+  ("apiserver_request_total"),
+  ("workqueue_adds_total"),
+  ("scheduler_scheduling_algorithm_duration_seconds"),
+  ("kubeproxy_sync_proxy_rules_duration_seconds_count"),
+  ("coredns_dns_requests_total"),
   #Container Metrics
   ("container.cpu.time"),
   ("container.cpu.utilization"),


### PR DESCRIPTION
Description:
This PR adds support for collecting metrics from the k8s controller-manager, coredns, proxy, and scheduler when installing the collector using the Helm chart. I have another PR coming after this to support etcd metrics, it seemed too big to fit into this PR. 

Testing:
I tested and verified these changes with Kubernetes, and Openshift.

