### PR TITLE
Explicitly set `match_type` parameter in filter processor

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -167,6 +167,7 @@ Filter logs processor
 filter/logs:
   logs:
     {{ .Values.logsCollection.containers.useSplunkIncludeAnnotation | ternary "include" "exclude" }}:
+      match_type: strict
       resource_attributes:
         - key: {{ include "splunk-otel-collector.filterAttr" . }}
           value: "true"

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -42,6 +42,7 @@ data:
       filter/logs:
         logs:
           exclude:
+            match_type: strict
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: aa7528ec9c709cc3ba572b82a01e5655bc4b4f3dfc033dfe63416f7dfc938f1e
+        checksum/config: 0f9d655547d838d756caa945851e4b3fa9c7dc077aeb87e29b9fe7be0cabfc89
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/eks-fargate/configmap-gateway.yaml
+++ b/rendered/manifests/eks-fargate/configmap-gateway.yaml
@@ -40,6 +40,7 @@ data:
       filter/logs:
         logs:
           exclude:
+            match_type: strict
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"

--- a/rendered/manifests/eks-fargate/deployment-gateway.yaml
+++ b/rendered/manifests/eks-fargate/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 47a5973ab9684c31d4ea82f2aeb8194527083cfcc20ec43c293c54f6d0ef3676
+        checksum/config: 4bece69606d91681bbbf6d563e9cf975bef2f0e2eb65d0c4c2c5195d36ae3cee
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -40,6 +40,7 @@ data:
       filter/logs:
         logs:
           exclude:
+            match_type: strict
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 85899e674fbc0355d85fbb7d822a4bea21dd0e3c1a4b0f6c889e6218db593a94
+        checksum/config: 542eb9adab3ab14cb34d4cfe176b071dbfe33685b187f8d992024af92b27b78d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -39,6 +39,7 @@ data:
       filter/logs:
         logs:
           exclude:
+            match_type: strict
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3ab283e375e0dd2e5fc5b4fa26bf0935b3029d42c2d77f36623a8003473f9978
+        checksum/config: 6f3510034b23bf0bdc80c125bc872a4e958c2074fa3a7264b4363499ad63072d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -39,6 +39,7 @@ data:
       filter/logs:
         logs:
           exclude:
+            match_type: strict
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7084567f96152193e375f201b458d6723fb0ce8be9ca3b4f9edce25fd7da0525
+        checksum/config: 1d4258d58071c97907dfd41cec47975188901435328e0710c2176515fe4cffed
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -44,6 +44,7 @@ data:
       filter/logs:
         logs:
           exclude:
+            match_type: strict
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5ad23fec85ce0c684fdf787156ac399d29bbc574d9fcd9af80a2fcc292579525
+        checksum/config: b3036ac596045014d775fcc8e5571ede014ad8fe9930105b44c8fbb89ecba89a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/traces-only/configmap-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-agent.yaml
@@ -42,6 +42,7 @@ data:
       filter/logs:
         logs:
           exclude:
+            match_type: strict
             resource_attributes:
             - key: splunk.com/exclude
               value: "true"

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 2a3d6ef153bd2553d4bdcbcf0ec967978a09bff154e992dd56eb5654d1f8e1e3
+        checksum/config: 01339a894491164cc8db28eaac6db1f5319e1e4b5a1ff1f9056539895301e1da
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
`match_type` became required parameter of filter processor after https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7552

This change ensures non-breaking upgrade to Otel Collector 0.45.0