### PR TITLE
eks/fargate: truncate stateful set name

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -345,7 +345,14 @@ compatibility with the old config group name: "otelK8sClusterReceiver".
 {{- end -}}
 
 {{/*
-"clusterReceiverServiceName" for the eks/fargate cluster receiver statefulSet
+"clusterReceiverTruncatedName" for the eks/fargate cluster receiver statefulSet name accounting for 11 appended random chars
+*/}}
+{{- define "splunk-otel-collector.clusterReceiverTruncatedName" -}}
+{{ printf "%s-k8s-cluster-receiver" ( include "splunk-otel-collector.fullname" . ) | trunc 52 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+"clusterReceiverServiceName" for the eks/fargate cluster receiver statefulSet headless service
 */}}
 {{- define "splunk-otel-collector.clusterReceiverServiceName" -}}
 {{ printf "%s-k8s-cluster-receiver" ( include "splunk-otel-collector.fullname" . ) | trunc 63 | trimSuffix "-" }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -8,7 +8,8 @@ The second replica monitors the first replica's kubelet and the cluster.
 */}}
 kind: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }} StatefulSet {{- else }} Deployment {{- end }}
 metadata:
-  name: {{ template "splunk-otel-collector.fullname" . }}-k8s-cluster-receiver
+  {{- /* StatefulSet names must be truncated or the `statefulset.kubernetes.io/pod-name` label value will be too long */}}
+  name: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }} {{ template "splunk-otel-collector.clusterReceiverTruncatedName" . }} {{- else }} {{ template "splunk-otel-collector.fullname" . }}-k8s-cluster-receiver {{- end }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}


### PR DESCRIPTION
If installing with `--generate-name` the stateful set pod names will be too long for the `statefulset.kubernetes.io/pod-name` label value and lead to pod creation errors: 

```
statefulset/splunk-otel-collector-1645717371-k8s-cluster-receiver   create Pod splunk-otel-collector-1645717371-k8s-cluster-receiver-0 in StatefulSet splunk-otel-collector-1645717371-k8s-cluster-receiver failed error: Pod "splunk-otel-collector-1645717371-k8s-cluster-receiver-0" is invalid: metadata.labels: Invalid value: "splunk-otel-collector-1645717371-k8s-cluster-receiver-7944b495c4": must be no more than 63 characters
```

These changes add an even more truncated name for the stateful set.

Appears related to https://github.com/kubernetes/kubernetes/issues/64023, which went stale.