### PR TITLE
Adding a maxUnavailable variable for daemonSet.RollingUpdate

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -23,6 +23,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.agent.maxUnavailable }}
   selector:
     matchLabels:
       app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -362,6 +362,16 @@
         "securityContext": {
           "type": "object"
         },
+	      "maxUnavailable": {
+	        "oneOf": [
+	          {
+	            "type": "string"
+            },
+            {
+	            "type": "integer"
+	          }
+	        ]
+	      },
         "annotations": {
           "type": "object"
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -279,6 +279,10 @@ agent:
   #   runAsUser: 20000
   #   runAsGroup: 20000
 
+  # Specifies the maximum of pods that can be unavailable during update process.
+  # Can be an absolute number or a percentage. The default is 1.
+  maxUnavailable: 1
+
   # OTel agent annotations
   annotations: {}
   podAnnotations: {}

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -17,6 +17,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: splunk-otel-collector

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -18,6 +18,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: splunk-otel-collector

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -17,6 +17,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: splunk-otel-collector

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -17,6 +17,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: splunk-otel-collector

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -17,6 +17,8 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: splunk-otel-collector


### PR DESCRIPTION
We've recently realised that rolling updates are very time-consuming (if applicable, can also cause timeouts) when the number of pods grows significantly and [the default maxUnavailable is set to 1](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#performing-a-rolling-update).
This change provides an easy way to adjust the number if needed.