### PR TITLE
Add missing processors to metrics pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## [0.44.1] - 2022-03-09
+## [0.44.1] - 2022-03-08
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Add environment processor to metrics pipeline when sending metrics to Splunk (#399)
+- Add environment processor to metrics pipeline when sending metrics to Splunk Platform (#399)
 
 ## [0.44.0] - 2022-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## [0.44.1] - 2022-03-09
+
+### Fixed
+
+- Add environment processor to metrics pipeline when sending metrics to Splunk (#399)
+
 ## [0.44.0] - 2022-03-03
 
 ### Added

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.44.0
+version: 0.44.1
 appVersion: 0.44.0
 description: Splunk OpenTelemetry Collector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -693,6 +693,9 @@ service:
         - batch
         - resourcedetection
         - resource
+        {{- if (and .Values.splunkPlatform.metricsEnabled .Values.environment) }}
+        - resource/add_environment
+        {{- end }}
         {{- if .Values.isWindows }}
         - metricstransform
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -193,6 +193,9 @@ service:
         {{- if .Values.extraAttributes.custom }}
         - resource/add_custom_attrs
         {{- end }}
+        {{- if (and .Values.splunkPlatform.metricsEnabled .Values.environment) }}
+        - resource/add_environment
+        {{- end }}
       exporters:
         {{- if (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") }}
         - signalfx

--- a/rendered/manifests/agent-only/clusterRole.yaml
+++ b/rendered/manifests/agent-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/agent-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/agent-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 22485775cf7aa15d84c29f3b263478c8094585023d7835357d3b75903a80b381
+        checksum/config: d9bdeeee21bc8da10680e6338d3c530701df3c580a7788264aa362acab2fcf7a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f071e6903141bc1aa59f94faf8eef2e519f56acb4cf28cfd38c5fe295ce2b5b8
+        checksum/config: c66f93805b2b2e5fb1c4d21ebe36fb1a6688d7451b6bc8ebf468f0fd5bce78c9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/agent-only/secret-splunk.yaml
+++ b/rendered/manifests/agent-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/agent-only/serviceAccount.yaml
+++ b/rendered/manifests/agent-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm

--- a/rendered/manifests/eks-fargate/clusterRole.yaml
+++ b/rendered/manifests/eks-fargate/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/eks-fargate/clusterRoleBinding.yaml
+++ b/rendered/manifests/eks-fargate/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-cr-node-discoverer-script
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/eks-fargate/configmap-gateway.yaml
+++ b/rendered/manifests/eks-fargate/configmap-gateway.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a4127846f195dd23e69913307ee6e25e5f810546e7a5c25ec81b7d8f747b54ae
+        checksum/config: d739a74eb5a8404135fe62b0730cb2e7fd8e8372dbc3f265d943a9e27c62ca03
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/deployment-gateway.yaml
+++ b/rendered/manifests/eks-fargate/deployment-gateway.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: aea5807dba6bcab44c89502c99a514f8c0a784e613eddd792bf4edd53724ac8f
+        checksum/config: d00b2479ef868a93e0c99374748ec9d9bc7bff151450dccf46b3ac6dac4971f4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/secret-splunk.yaml
+++ b/rendered/manifests/eks-fargate/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/eks-fargate/service.yaml
+++ b/rendered/manifests/eks-fargate/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector

--- a/rendered/manifests/eks-fargate/serviceAccount.yaml
+++ b/rendered/manifests/eks-fargate/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm

--- a/rendered/manifests/gateway-only/clusterRole.yaml
+++ b/rendered/manifests/gateway-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/gateway-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/gateway-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: fea9fd8b247dd110f9bc4dfa15e5bd6d6c62a6f3a5515c1105b8f3828c334a15
+        checksum/config: ed9d7dbf16a961f837294e39169e73078ddb72fbdb110257b6b2850625b7b51e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/secret-splunk.yaml
+++ b/rendered/manifests/gateway-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/gateway-only/service.yaml
+++ b/rendered/manifests/gateway-only/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector

--- a/rendered/manifests/gateway-only/serviceAccount.yaml
+++ b/rendered/manifests/gateway-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm

--- a/rendered/manifests/logs-only/clusterRole.yaml
+++ b/rendered/manifests/logs-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/logs-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/logs-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd-cri
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd-json.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-json.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3080540364c611eed578b28063b7db12e38051d177ccfbb844ea2416d3662d9e
+        checksum/config: 85b1d5ab479e29526aff37f06d8465eb32593cc5260e99e182841d537decd6f9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/logs-only/secret-splunk.yaml
+++ b/rendered/manifests/logs-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/logs-only/serviceAccount.yaml
+++ b/rendered/manifests/logs-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm

--- a/rendered/manifests/metrics-only/clusterRole.yaml
+++ b/rendered/manifests/metrics-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/metrics-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/metrics-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ad3551349920cd56d9694ac64b86d673f0e8598eca94c7b1cda31d14b062f2b4
+        checksum/config: ec387349c370950a1c8b1cfe63f52e9c72a1c71acd97a228f7a2460ac5d07836
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f071e6903141bc1aa59f94faf8eef2e519f56acb4cf28cfd38c5fe295ce2b5b8
+        checksum/config: c66f93805b2b2e5fb1c4d21ebe36fb1a6688d7451b6bc8ebf468f0fd5bce78c9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/metrics-only/secret-splunk.yaml
+++ b/rendered/manifests/metrics-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/metrics-only/serviceAccount.yaml
+++ b/rendered/manifests/metrics-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm

--- a/rendered/manifests/otel-logs/clusterRole.yaml
+++ b/rendered/manifests/otel-logs/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/otel-logs/clusterRoleBinding.yaml
+++ b/rendered/manifests/otel-logs/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ece94087ba057daa9680d4a8fcbea1ce0aecb0b549e16ce1a55870c9fd28daa4
+        checksum/config: 7e2f7c80d9352d39b2d9494afcd799bf4cb428cd84349cbfeec4912c2c871c19
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f071e6903141bc1aa59f94faf8eef2e519f56acb4cf28cfd38c5fe295ce2b5b8
+        checksum/config: c66f93805b2b2e5fb1c4d21ebe36fb1a6688d7451b6bc8ebf468f0fd5bce78c9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/otel-logs/secret-splunk.yaml
+++ b/rendered/manifests/otel-logs/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/otel-logs/serviceAccount.yaml
+++ b/rendered/manifests/otel-logs/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm

--- a/rendered/manifests/traces-only/clusterRole.yaml
+++ b/rendered/manifests/traces-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/traces-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/traces-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/traces-only/configmap-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 721f04389a813eb41afecd50b5b9dd35ea9e16a9464482a1969d8811e336ea0d
+        checksum/config: 2b9c75e9c6bb8e37dc627698dcf48964718d7e2d787f107f4620a237dcf518f9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/traces-only/secret-splunk.yaml
+++ b/rendered/manifests/traces-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/traces-only/serviceAccount.yaml
+++ b/rendered/manifests/traces-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.44.0
+    helm.sh/chart: splunk-otel-collector-0.44.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.44.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.44.0
+    chart: splunk-otel-collector-0.44.1
     release: default
     heritage: Helm


### PR DESCRIPTION
We've seen that some labels that are present on logs are not present on metrics, add the `k8sattributes` and `resource/add_environment` processors to the metrics pipeline fixes this issue.