### PR TITLE
Fix bug where Prometheus errors out using default configuration on EKS and GKE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Bug where Prometheus errors out using default configuration on EKS and GKE (#401, #405)
+
 ## [0.44.1] - 2022-03-08
 
 ### Fixed

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -76,7 +76,9 @@ receivers:
       {{- end }}
 
       # Receivers for collecting k8s control plane metrics.
+      # Distributions besides Kubernetes and Openshift are not supported.
       # Verified with Kubernetes v1.22 and Openshift v4.9.
+      {{- if or (eq .Values.distribution "openshift") (eq .Values.distribution "") }}
       # Below, the TLS certificate verification is often skipped because the k8s default certificate is self signed and
       # will fail the verification.
       {{- if .Values.agent.controlPlaneMetrics.coredns.enabled }}
@@ -183,7 +185,8 @@ receivers:
             metric_source: kubernetes-scheduler
           port: 10251
           type: kubernetes-scheduler
-      {{- end}}
+      {{- end }}
+      {{- end }}
 
   kubeletstats:
     collection_interval: 10s


### PR DESCRIPTION
Description:
Control plane metrics are enabled by default when installing the splunk otel collector with the Helm Chart. This can cause prometheus to error out when installing the collector in EKS or GKE. 

```
GKE:
2022-03-08T15:10:42.294Z	error	prometheusexporter/prometheus.go:141	Could not get prometheus metrics	{"kind": "receiver", "name": "receiver_creator", "monitorType": "coredns", "error": "Get \"http://X.X.X.X:9153/metrics\": dial tcp X.X.X.X:9153: connect: connection refused"}
EKS:
2022-03-08T14:55:47.171Z	error	prometheusexporter/prometheus.go:141	Could not get prometheus metrics	{"kind": "receiver", "name": "receiver_creator", "monitorType": "kubernetes-proxy", "error": "Get \"http://X.X.X.X:10249/metrics\": dial tcp X.X.X.X:10249: connect: connection refused"}
```

We don't support control plane metrics for other distributions besides Kubernetes (kops) and Openshift at this time. To prevent prometheus from trying and failing to collect metrics from control plane components in unsupported clusters,  let's update the Helm Chart to only allow setting up control plane metrics in supported clusters.

Related Issue:
https://github.com/signalfx/splunk-otel-collector-chart/issues/401