### PR TITLE
Add support for otelcol feature gates to the agent, clusterReceiver, and gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Add support for otelcol feature gates to the agent, clusterReceiver, and gateway (#410)
+
 ## [0.45.0] - 2022-03-10
 
 ### Changed

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -524,11 +524,10 @@ details see the
 
 Helm Install Example:
 ```bash
-# Due to syntax limitations, when using "," characters between feature gate identifiers you must escape them with "\\".
-helm install {name} --set agent.featureGates=+feature1 --set=clusterReceiver.featureGates=feature1\\,-feature2 {other_flags}
+helm install {name} --set agent.featureGates=+feature1 --set clusterReceiver.featureGates=feature2 --set gateway.featureGates=-feature2 {other_flags}
 ```
-Would result in the agent having feature1 enabled, the clusterReceiver having feature1 enabled, and the clusterReceiver
-having feature2 disabled.
+Would result in the agent having feature1 enabled, the clusterReceiver having feature2 enabled, and the gateway having
+feature2 disabled.
 
 ### Highlighted feature gates
 - receiver.k8sclusterreceiver.reportCpuMetricsAsDouble

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -515,6 +515,37 @@ autodetect:
   prometheus: true
 ```
 
+## Using feature gates
+Enable or disable features of the otel-collector agent, clusterReceiver, and gateway (respectively) using feature
+gates. Use the agent.featureGates, clusterReceiver.featureGates, and gateway.featureGates configs to enable or disable
+features, these configs will be used to populate the otelcol binary startup argument "--feature-gates". For more
+details see the
+[feature gate documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/service/featuregate/README.md).
+
+Helm Install Example:
+```bash
+helm install {name} --set agent.featureGates=feature1,clusterReceiver.featureGates=+feature2,gateway.featureGates=-feature3 {other_flags}
+```
+Would result in the agent having feature1 enabled, the clusterReceiver having feature2 enabled, and the gateway having
+feature3 disabled.
+
+### Highlighted feature gates
+- receiver.k8sclusterreceiver.reportCpuMetricsAsDouble
+  - Description
+    - The k8s container and node cpu metrics being reported by the k8sclusterreceiver are transitioning from being
+    reported as integer millicpu units to being reported as double cpu units to adhere to opentelemetry cpu metric
+    specifications. Please update any monitoring this might affect, the change will cause cpu metrics to be double
+    instead of integer values as well as metric values will be scaled down by 1000x.
+  - Availability
+    - v0.47.0 - v0.53.0
+  - Usage
+    - Install with the feature gate enabled:
+      - helm install {name} --set clusterReceiver.featureGates=receiver.k8sclusterreceiver.reportCpuMetricsAsDouble {other_flags}
+    - Install with the feature gate disabled:
+      - helm install {name} --set clusterReceiver.featureGates=-receiver.k8sclusterreceiver.reportCpuMetricsAsDouble {other_flags}
+  - More Information
+    - [k8sclusterreceiver feature gate configurations](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/README.md#feature-gate-configurations)
+
 ## Override underlying OpenTelemetry agent configuration
 
 If you want to use your own OpenTelemetry Agent configuration, you can override it by providing a custom configuration in the `agent.config` parameter in the values.yaml, which will be merged into the default agent configuration, list parts of the configuration (for example, `service.pipelines.logs.processors`) to be fully re-defined.

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -524,10 +524,11 @@ details see the
 
 Helm Install Example:
 ```bash
-helm install {name} --set agent.featureGates=feature1,clusterReceiver.featureGates=+feature2,gateway.featureGates=-feature3 {other_flags}
+# Due to syntax limitations, when using "," characters between feature gate identifiers you must escape them with "\\".
+helm install {name} --set agent.featureGates=+feature1 --set=clusterReceiver.featureGates=feature1\\,-feature2 {other_flags}
 ```
-Would result in the agent having feature1 enabled, the clusterReceiver having feature2 enabled, and the gateway having
-feature3 disabled.
+Would result in the agent having feature1 enabled, the clusterReceiver having feature1 enabled, and the clusterReceiver
+having feature2 disabled.
 
 ### Highlighted feature gates
 - receiver.k8sclusterreceiver.reportCpuMetricsAsDouble

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -223,6 +223,9 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         {{- end }}
+        {{- if .Values.agent.featureGates }}
+        - --feature-gates={{ .Values.agent.featureGates }}
+        {{- end }}
         ports:
         {{- range $key, $port := $agent.ports }}
         {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.o11yTracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) (and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for)) }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -120,6 +120,9 @@ spec:
         - --config=/conf/relay.yaml
         {{- end }}
         {{- end }}
+        {{- if .Values.clusterReceiver.featureGates }}
+        - --feature-gates={{ .Values.clusterReceiver.featureGates }}
+        {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -72,6 +72,9 @@ spec:
         - /otelcol
         - --config=/conf/relay.yaml
         {{- end }}
+        {{- if .Values.gateway.featureGates }}
+        - --feature-gates={{ .Values.gateway.featureGates }}
+        {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -537,6 +537,9 @@
             "type": "object"
           }
         },
+        "featureGates": {
+          "type": "string"
+        },
         "config": {
           "type": "object"
         }
@@ -638,6 +641,9 @@
           "items": {
             "type": "object"
           }
+        },
+        "featureGates": {
+          "type": "string"
         },
         "config": {
           "type": "object"
@@ -1171,6 +1177,9 @@
           "items": {
             "type": "object"
           }
+        },
+        "featureGates": {
+          "type": "string"
         },
         "config": {
           "type": "object"

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -341,6 +341,9 @@ agent:
   extraVolumes: []
   extraVolumeMounts: []
 
+  # Enable or disable features of the agent.
+  featureGates: ""
+
   # OpenTelemetry Collector configuration for otel-agent daemonset can be overriden in this field.
   # Default configuration defined in templates/config/_otel-agent.tpl
   # Any additional fields will be merged into the defaults,
@@ -393,6 +396,9 @@ clusterReceiver:
   # Extra volumes to be mounted to the k8s cluster receiver container.
   extraVolumes: []
   extraVolumeMounts: []
+
+  # Enable or disable features of the cluster receiver.
+  featureGates: ""
 
   # OpenTelemetry Collector configuration for K8s Cluster Receiver deployment can be overriden in this field.
   # Default configuration defined in templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -941,6 +947,9 @@ gateway:
   # Extra volumes to be mounted to the OTel Collector container.
   extraVolumes: []
   extraVolumeMounts: []
+
+  # Enable or disable features of the gateway.
+  featureGates: ""
 
   # OpenTelemetry Collector configuration for standalone otel-collector deployment can be overriden in this field.
   # Default configuration defined in config/otel-collector-config.yaml


### PR DESCRIPTION
Description:
We have a bug fix coming out in v0.47.0 that uses a feature gate. Now seems like a good time to add feature gate support to the collector chart.

Testing:
Tested these changes manually, I couldn't come up with a good way to unit or e2e test these changes.