### PR TITLE
Clarify ports condition in service template

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
   {{ $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
   {{ $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}
   {{ $profilingEnabled := and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for) }}
-  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled /* Helm 3.5 (due to Go 1.15) doesn't support newlines in actions. 👉 https://github.com/signalfx/splunk-otel-collector-chart/pull/416 */ }}
+  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled /* Helm 3.5 (due to Go 1.15) doesn't support newlines in actions. 👉 https://github.com/signalfx/splunk-otel-collector-chart/pull/416#issuecomment-1076160057 */ }}
   - name: {{ $key }}
     port: {{ $port.containerPort }}
     targetPort: {{ $key }}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -20,13 +20,11 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   {{- range $key, $port := $gateway.ports }}
-  {{- if
-    or
-      (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for))
-      (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for))
-      (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for))
-      (and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for))
-  }}
+  {{ $metricsEnabled   := and (eq (include "splunk-otel-collector.metricsEnabled"   $) "true") (has "metrics"   $port.enabled_for) }}
+  {{ $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
+  {{ $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}
+  {{ $profilingEnabled := and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for) }}
+  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled /* Helm 3.5 (due to Go 1.15) doesn't support newlines in actions. 👉 https://github.com/signalfx/splunk-otel-collector-chart/pull/416 */ }}
   - name: {{ $key }}
     port: {{ $port.containerPort }}
     targetPort: {{ $key }}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -20,10 +20,10 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   {{- range $key, $port := $gateway.ports }}
-  {{ $metricsEnabled   := and (eq (include "splunk-otel-collector.metricsEnabled"   $) "true") (has "metrics"   $port.enabled_for) }}
-  {{ $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
-  {{ $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}
-  {{ $profilingEnabled := and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for) }}
+  {{- $metricsEnabled   := and (eq (include "splunk-otel-collector.metricsEnabled"   $) "true") (has "metrics"   $port.enabled_for) }}
+  {{- $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
+  {{- $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}
+  {{- $profilingEnabled := and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for) }}
   {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled }}
   - name: {{ $key }}
     port: {{ $port.containerPort }}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
   {{- $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
   {{- $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}
   {{- $profilingEnabled := and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for) }}
-  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled }}{{/* Helm 3.5 (due to Go 1.15) doesn't support newlines in actions. 👉 https://github.com/signalfx/splunk-otel-collector-chart/pull/416#issuecomment-1076160057 */}}
+  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled }}
   - name: {{ $key }}
     port: {{ $port.containerPort }}
     targetPort: {{ $key }}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
   {{- $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
   {{- $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}
   {{- $profilingEnabled := and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for) }}
-  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled }}
+  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled }}{{/* Helm 3.5 (due to Go 1.15) doesn't support newlines in actions. 👉 https://github.com/signalfx/splunk-otel-collector-chart/pull/416#issuecomment-1076160057 */}}
   - name: {{ $key }}
     port: {{ $port.containerPort }}
     targetPort: {{ $key }}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
   {{ $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
   {{ $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}
   {{ $profilingEnabled := and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for) }}
-  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled /* Helm 3.5 (due to Go 1.15) doesn't support newlines in actions. 👉 https://github.com/signalfx/splunk-otel-collector-chart/pull/416#issuecomment-1076160057 */ }}
+  {{- if or $metricsEnabled $tracesEnabled $logsEnabled $profilingEnabled }}
   - name: {{ $key }}
     port: {{ $port.containerPort }}
     targetPort: {{ $key }}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -20,7 +20,13 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   {{- range $key, $port := $gateway.ports }}
-  {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) (and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for)) }}
+  {{- if
+    or
+      (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for))
+      (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for))
+      (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for))
+      (and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for))
+  }}
   - name: {{ $key }}
     port: {{ $port.containerPort }}
     targetPort: {{ $key }}


### PR DESCRIPTION
This PR clarifies the condition in two ways:

  * It replaces `eq true …` with `or …`, which should be easier to
    understand for most readers.

  * It moves the four disjuncts to their own lines, making it easier for
    a human to parse the condition as a whole and its subexpressions.

💡 `git show --color-words` is useful.