### PR TITLE
default source identifier for recombine operator

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -354,6 +354,7 @@ receivers:
       - type: recombine
         id: {{ include "splunk-otel-collector.newlineKey" . | quote}}
         output: clean-up-log-record
+        source_identifier: $$resource["com.splunk.source"]
         combine_field: log
         is_first_entry: '($$.log) matches {{ .firstEntryRegex | quote }}'
       {{- end }}


### PR DESCRIPTION
the operator default is `attributes["file.path"]` but it is removed from data after regex parser operator
```
      # Extract metadata from file path
      - type: regex_parser
        id: extract_metadata_from_filepath
        {{- if .Values.isWindows }}
        regex: '^C:\\var\\log\\pods\\(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\\(?P<container_name>[^\._]+)\\(?P<restart_count>\d+)\.log$'
        {{- else }}
        regex: '^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$'
        {{- end }}
        parse_from: $$attributes["file.path"]
```