### PR TITLE
Use add/move operators instead of metadata/restructure

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -389,24 +389,23 @@ receivers:
     priority: {{ $unit.priority }}
     operators:
     - type: add
-        field: $$resource["com.splunk.source"]
-        value: {{ $.Values.logsCollection.journald.directory }}
+      field: $$resource["com.splunk.source"]
+      value: {{ $.Values.logsCollection.journald.directory }}
     - type: add
-        field: $$resource["com.splunk.sourcetype"]
-        value: EXPR("kube:journald:"+$$._SYSTEMD_UNIT)
+      field: $$resource["com.splunk.sourcetype"]
+      value: 'EXPR("kube:journald:"+$$._SYSTEMD_UNIT)'
     - type: add
-        field: $$resource.com.splunk.index
-        value: {{ $.Values.logsCollection.journald.index | default $.Values.splunkPlatform.index}}
+      field: $$resource["com.splunk.index"]
+      value: {{ $.Values.logsCollection.journald.index | default $.Values.splunkPlatform.index }}
     - type: add
-        field: $$resource["host.name"]
-        value: EXPR(env("K8S_NODE_NAME"))
-    # adding journald priority and unit as attributes
+      field: $$resource["host.name"]
+      value: 'EXPR(env("K8S_NODE_NAME"))'
     - type: add
-        field: $$resource["journald.priority.number"]
-        value: EXPR($$.PRIORITY)
+      field: $$resource["journald.priority.number"]
+      value: 'EXPR($$.PRIORITY)'
     - type: add
-        field: $$resource["journald.unit.name"]
-        value: EXPR($$._SYSTEMD_UNIT)
+      field: $$resource["journald.unit.name"]
+      value: 'EXPR($$._SYSTEMD_UNIT)'
 
     # extract MESSAGE field into the log body and discard rest of the fields
     - type: move

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -158,14 +158,12 @@ data:
           id: crio-recombine
           is_last_entry: ($$.logtag) == 'F'
           type: recombine
-        - id: crio-handle_empty_log
+        - field: $$body.log
+          id: crio-handle_empty_log
           if: $$.log == nil
-          ops:
-          - add:
-              field: log
-              value: ""
           output: filename
-          type: restructure
+          type: add
+          value: ""
         - id: parser-containerd
           regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
           timestamp:
@@ -176,43 +174,50 @@ data:
           id: containerd-recombine
           is_last_entry: ($$.logtag) == 'F'
           type: recombine
-        - id: containerd-handle_empty_log
+        - field: $$body.log
+          id: containerd-handle_empty_log
           if: $$.log == nil
-          ops:
-          - add:
-              field: log
-              value: ""
           output: filename
-          type: restructure
+          type: add
+          value: ""
         - id: parser-docker
           timestamp:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: time
           type: json_parser
-        - id: filename
-          resource:
-            com.splunk.source: EXPR($$attributes["file.path"])
-          type: metadata
+        - field: $$resource["com.splunk.source"]
+          id: filename
+          type: add
+          value: EXPR($$attributes["file.path"])
         - id: extract_metadata_from_filepath
           parse_from: $$attributes["file.path"]
           regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
           type: regex_parser
-        - attributes:
-            log.iostream: EXPR($$.stream)
-          resource:
-            com.splunk.sourcetype: EXPR("kube:container:"+$$.container_name)
-            k8s.container.name: EXPR($$.container_name)
-            k8s.container.restart_count: EXPR($$.restart_count)
-            k8s.namespace.name: EXPR($$.namespace)
-            k8s.pod.name: EXPR($$.pod_name)
-            k8s.pod.uid: EXPR($$.uid)
-          type: metadata
-        - id: clean-up-log-record
-          ops:
-          - move:
-              from: log
-              to: $$
-          type: restructure
+        - field: $$resource["k8s.pod.uid"]
+          type: add
+          value: EXPR($$.uid)
+        - field: $$resource["k8s.container.restart_count"]
+          type: add
+          value: EXPR($$.restart_count)
+        - field: $$resource["k8s.container.name"]
+          type: add
+          value: EXPR($$.container_name)
+        - field: $$resource["k8s.namespace.name"]
+          type: add
+          value: EXPR($$.namespace)
+        - field: $$resource["k8s.pod.name"]
+          type: add
+          value: EXPR($$.pod_name)
+        - field: $$resource["com.splunk.sourcetype"]
+          type: add
+          value: EXPR("kube:container:"+$$.container_name)
+        - field: $$attributes["log.iostream"]
+          type: add
+          value: EXPR($$.stream)
+        - from: $$body.log
+          id: clean-up-log-record
+          to: $$
+          type: move
         poll_interval: 200ms
         start_at: beginning
       fluentforward:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d179a4553e5009e2b70b962863c235e2d7aa30f6135b686dadd316b2dd13fd67
+        checksum/config: fa0d199a23871cace4f204a78d4801fe5062eefe4ba026add5e0c5940006e1f0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 013db8a9f0249bd6c67479b9ed9263d1cbb1ac4631141c5230db477d8a3cdd2c
+        checksum/config: 7dd0618dfb7291452f34ec765ec28489a7307bcee571682b8dc28bf853be92a7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
metadata and restructure operators are removed from opentelemetry-log-collection v0.28.0 (https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/CHANGELOG.md#breaking-changes-1)