### PR TITLE
Add gateway support for Host Logs

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -667,11 +667,15 @@ service:
         - resource/add_environment
         {{- end }}
       exporters:
+        {{- if $gateway.enabled }}
+        - otlp
+        {{- else }}
         {{- if eq (include "splunk-otel-collector.platformLogsEnabled" .) "true" }}
         - splunk_hec/platform_logs
         {{- end }}
         {{- if eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true" }}
         - splunk_hec/o11y
+        {{- end }}
         {{- end }}
         {{- end }}
     {{- end }}


### PR DESCRIPTION
Host logs does not currently support gateway mode. If running the agent in gateway mode, the exporters section of the logs/host pipeline will be set to splunk_hec/platform_logs. In gateway mode, the agent does not have this exporter configured and it is only present on the collector. Therefore, the exporter must be set to otlp so that logs are sent to the collector.

This is the same approach used for main logs pipeline on lines 637 - 647 - if running in gateway mode use the otlp exporter, otherwise use the splunk_hec/o11y or splunk_hec/platform_logs exporters depending on configuration.

n.b. the triple `{{- end }}` at the end of this diff may seem confusing. I think the first `{{-end }}` on line 678 closes the if statement in 676, but prior to this change the second `{{-end }}` on line 679 closes the if statement on line 649 and is indented wrongly? With this change, it's now the third `{{-end }}` on line 680 that closes the if statement on line 649 and is still indented wrongly. As i'm essentially just adding a new if/else that needs closing, I have not fixed the indentation of the "final" if statement. If anyone else thinks this statement is wrongly indented, I can add another commit to fix it.