### PR TITLE
Increase splunkObservability and splunkPlatform timeouts to 20s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Increase splunkObservability and splunkPlatform timeouts to 20s (#438)
+
 ## [0.48.0] - 2022-04-13
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -565,6 +565,7 @@ exporters:
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
+    timeout: {{ .Values.splunkObservability.timeout }}
   {{- end }}
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
   {{- include "splunk-otel-collector.splunkPlatformLogsExporter" . | nindent 2 }}
@@ -586,6 +587,7 @@ exporters:
     {{- end }}
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     sync_host_metadata: true
+    timeout: {{ .Values.splunkObservability.timeout }}
   {{- end }}
 
 service:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -129,6 +129,7 @@ exporters:
     ingest_url: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+    timeout: {{ .Values.splunkObservability.timeout }}
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
@@ -139,6 +140,7 @@ exporters:
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
+    timeout: {{ .Values.splunkObservability.timeout }}
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -137,7 +137,7 @@ exporters:
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
     {{- end }}
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-    timeout: 10s
+    timeout: {{ .Values.splunkObservability.timeout }}
   {{- end }}
 
   {{- if and (eq (include "splunk-otel-collector.logsEnabled" $) "true") $clusterReceiver.k8sEventsEnabled }}
@@ -146,6 +146,7 @@ exporters:
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
     sourcetype: kube:events
     source: kubelet
+    timeout: {{ .Values.splunkObservability.timeout }}
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" .) "true") }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -146,6 +146,9 @@
         "profilingEnabled": {
           "description": "Whether profiling data is enabled for Splunk Observability",
           "type": "boolean"
+        },
+        "timeout": {
+          "type": "string"
         }
       },
       "anyOf": [

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -42,10 +42,10 @@ splunkPlatform:
   sourcetype: ""
   # Maximum HTTP connections to use simultaneously when sending data.
   maxConnections: 200
-  # Whether to disable gzip compression over HTTP. Defaults to true.
+  # Whether to disable gzip compression over HTTP.
   disableCompression: true
-  # HTTP timeout when sending data. Defaults to 10s.
-  timeout: 10s
+  # HTTP timeout for sending data.
+  timeout: 20s
   # Whether to skip checking the certificate of the HEC endpoint when sending
   # data over HTTPS.
   insecureSkipVerify: false
@@ -107,6 +107,9 @@ splunkObservability:
   # Instrumentation libraries must be configured to send it to the collector.
   # If you don't use AlwaysOn Profiling for Splunk APM, you can disable it.
   profilingEnabled: false
+
+  # HTTP timeout for sending data.
+  timeout: 20s
 
 ################################################################################
 # Logs collection engine:

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -26,6 +26,7 @@ data:
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
+        timeout: 20s
     extensions:
       health_check: null
       k8s_observer:

--- a/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
@@ -21,7 +21,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
-        timeout: 10s
+        timeout: 20s
     extensions:
       health_check: null
       memory_ballast:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ed01f89e38f26d53f6fb0a3f91e765895b64fa6259c3b5d848c0d8842856bc1e
+        checksum/config: 62825712418cbe6dd4e2bfa74e5f9f4c8a483054a3df3226832c9b3ffe174cae
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7a450e9a0bd0ae563e6a8db9be5e5acfee9804cbe0b1df2fd2dc6c45f138a5f4
+        checksum/config: be78eb4c46d6f168072f525a857e60208710ead98f630ce625e62f222a1a7d83
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
@@ -21,7 +21,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: http://default-splunk-otel-collector:6060
         ingest_url: http://default-splunk-otel-collector:9943
-        timeout: 10s
+        timeout: 20s
     extensions:
       health_check: null
       k8s_observer:

--- a/rendered/manifests/eks-fargate/configmap-gateway.yaml
+++ b/rendered/manifests/eks-fargate/configmap-gateway.yaml
@@ -24,6 +24,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        timeout: 20s
     extensions:
       health_check: null
       http_forwarder:

--- a/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 817c53094a62283bae438d700377d942f978037f7b75601114487e151b25d233
+        checksum/config: a1e60a33a973a83e7b81aea4d8a87516ff835f8fd83fe833d0126a7060c9d821
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/deployment-gateway.yaml
+++ b/rendered/manifests/eks-fargate/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6c588e4f5a98c603bdf9f40f1bca2cf98e609dc94506ba44e848f1ac577d8331
+        checksum/config: 9ad032a455f168b6bd00bc7d8a2712caeaaaaa3d4c6bc941704d4362a58ffbed
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -24,6 +24,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        timeout: 20s
     extensions:
       health_check: null
       http_forwarder:

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 43bfe49fa123f92ffc516dd71400ac928a1c8777648e9b4861991cd2d46c4fc4
+        checksum/config: 4b939cc6a5e4ed1e246b40a5415afdc18a24463473acf0f3528253f5567b8b32
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -23,8 +23,10 @@ data:
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
+        timeout: 20s
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        timeout: 20s
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3ff5e3256a85880ef99ff373f53b1cb2bfb540e9544d6e02bac2cd56fb8f1881
+        checksum/config: f975a1f6590890d2a477480398f456e04db954e39045bdf5a371ad0937fabc48
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -23,6 +23,7 @@ data:
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
+        timeout: 20s
     extensions:
       health_check: null
       k8s_observer:

--- a/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
@@ -21,7 +21,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
-        timeout: 10s
+        timeout: 20s
     extensions:
       health_check: null
       memory_ballast:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: caff66ff9d07af31e234269ee8c894b356b4be0383fc42e793c5600d865ea6c1
+        checksum/config: e6da01b3d18cc6c53d80cf6015b015d1d649414eefd03f777dca79d31c7d72e7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7a450e9a0bd0ae563e6a8db9be5e5acfee9804cbe0b1df2fd2dc6c45f138a5f4
+        checksum/config: be78eb4c46d6f168072f525a857e60208710ead98f630ce625e62f222a1a7d83
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -26,8 +26,10 @@ data:
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
+        timeout: 20s
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        timeout: 20s
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       file_storage:

--- a/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
@@ -21,7 +21,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
-        timeout: 10s
+        timeout: 20s
     extensions:
       health_check: null
       memory_ballast:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: fa0d199a23871cace4f204a78d4801fe5062eefe4ba026add5e0c5940006e1f0
+        checksum/config: e80b14122a2dbbedb4476fe88519015fd3815736b84b1a73402aa8335e6aa7f2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7a450e9a0bd0ae563e6a8db9be5e5acfee9804cbe0b1df2fd2dc6c45f138a5f4
+        checksum/config: be78eb4c46d6f168072f525a857e60208710ead98f630ce625e62f222a1a7d83
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/traces-only/configmap-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-agent.yaml
@@ -26,6 +26,7 @@ data:
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
+        timeout: 20s
     extensions:
       health_check: null
       k8s_observer:

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f4eaf7f922b552d47ac77da603321dafb5d4abb810ce8866483573c9700afc9d
+        checksum/config: d28526f032cb2fec5935cbce98c56f8876af84b77e5b995ddc1c51fce6fbefda
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
Related Issue: https://github.com/signalfx/splunk-otel-collector/issues/1454

- Added timeout configuration to splunkObservability.
- Increased splunkObservability.timeout from 5s or 10s to 20s.
- Increase splunkPlatform.timeout from 10s to 20s.