### PR TITLE
Add or update documentation for the v0.49.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Migrate filelog operators to follow opentelemetry-log-collection v0.29.0 changes (#436)
+- Migrate filelog operators to follow opentelemetry-log-collection v0.29.0 changes (#436, #441)
   - [BREAKING CHANGE] Several breaking changes were made that affect the
     filelog, syslog, tcplog, and journald receivers. Any use of the
     extraFileLogs config, logsCollection.containers.extraOperators config,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Migrate filelog operators to follow opentelemetry-log-collection v0.29.0 changes ([#436](https://github.com/signalfx/splunk-otel-collector-chart/pull/436))
+- Migrate filelog operators to follow opentelemetry-log-collection v0.29.0 changes (#436)
   - [BREAKING CHANGE] Several breaking changes were made that affect the
-    filelog, syslog, tcplog, udplog, and journald receivers. Any use of the
-    [extraFileLogs](https://github.com/signalfx/splunk-otel-collector-chart/blob/941ad7f255cce585f4c06dd46c0cd63ef57d9903/helm-charts/splunk-otel-collector/values.yaml#L488) config, [logsCollection.containers.extraOperators](https://github.com/signalfx/splunk-otel-collector-chart/blob/941ad7f255cce585f4c06dd46c0cd63ef57d9903/helm-charts/splunk-otel-collector/values.yaml#L431) config,
+    filelog, syslog, tcplog, and journald receivers. Any use of the
+    extraFileLogs config, logsCollection.containers.extraOperators config,
     and affected receivers in a custom manner should be reviewed. See
-    [upgrading guidelines](https://github.com/open-telemetry/opentelemetry-log-collection/blob/v0.29.0/CHANGELOG.md#upgrading-to-v0290)
+    [upgrade guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0480-to-0490)
 
 ## [0.48.0] - 2022-04-13
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,33 @@
 # Upgrade guidelines
 
+## 0.48.0 to 0.49.0
+
+New releases of opentelemetry-log-collection (
+[v0.29.0](https://github.com/open-telemetry/opentelemetry-log-collection/blob/v0.29.0/CHANGELOG.md#0290---2022-04-11),
+[v0.28.0](https://github.com/open-telemetry/opentelemetry-log-collection/blob/v0.29.0/CHANGELOG.md#0280---2022-03-28)
+) have breaking changes
+
+Several of the logging receivers supported by the Splunk Otel Collector Chart
+were updated to use v0.29.0 instead v0.27.2 of opentelemetry-log-collection.
+
+- Affected Receivers
+  - [filelog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)
+  - [syslog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/syslogreceiver)
+  - [tcplog](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/tcplogreceiver)
+  - [journald](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver)
+
+1) Check to see if you have any custom log monitoring setup with the
+[extraFileLogs](https://github.com/signalfx/splunk-otel-collector-chart/blob/941ad7f255cce585f4c06dd46c0cd63ef57d9903/helm-charts/splunk-otel-collector/values.yaml#L488)
+config, the
+[logsCollection.containers.extraOperators](https://github.com/signalfx/splunk-otel-collector-chart/blob/941ad7f255cce585f4c06dd46c0cd63ef57d9903/helm-charts/splunk-otel-collector/values.yaml#L431)
+config, or any of the affected receivers. If you don't have any custom log
+monitoring setup, you can stop here.
+2) Read the documentation for
+[upgrading to opentelemetry-log-collection v0.29.0](https://github.com/open-telemetry/opentelemetry-log-collection/blob/v0.29.0/CHANGELOG.md#upgrading-to-v0290).
+3) If opentelemetry-log-collection v0.29.0 or v0.28.0 will break any of your
+custom log monitoring, update your log monitoring to accommodate the breaking
+changes.
+
 ## 0.47.0 to 0.47.1
 
 [[receiver/k8sclusterreceiver] Fix k8s node and container cpu metrics not being reported properly](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/8245)


### PR DESCRIPTION
Added notes to UPGRADING.md. 
Removed references to the udplog receiver since the Splunk Otel Collector does not currently support it.