### PR TITLE
Make sure that logs or profiling data is sent only when it's enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Make sure that logs or profiling data is sent only when it's enabled (#444)
+
 ## [0.49.0] - 2022-04-28
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -187,6 +187,7 @@ splunk_hec/platform_logs:
   timeout: {{ .Values.splunkPlatform.timeout }}
   splunk_app_name: {{ .Chart.Name }}
   splunk_app_version: {{ .Chart.Version }}
+  profiling_data_enabled: false
   tls:
     insecure_skip_verify: {{ .Values.splunkPlatform.insecureSkipVerify }}
     {{- if .Values.splunkPlatform.clientCert }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -567,6 +567,8 @@ exporters:
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
+    log_data_enabled: {{ .Values.splunkObservability.logsEnabled }}
+    profiling_data_enabled: {{ .Values.splunkObservability.profilingEnabled }}
   {{- end }}
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
   {{- include "splunk-otel-collector.splunkPlatformLogsExporter" . | nindent 2 }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -139,6 +139,8 @@ exporters:
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
+    log_data_enabled: {{ .Values.splunkObservability.logsEnabled }}
+    profiling_data_enabled: {{ .Values.splunkObservability.profilingEnabled }}
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -146,6 +146,8 @@ exporters:
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
     sourcetype: kube:events
     source: kubelet
+    log_data_enabled: {{ .Values.splunkObservability.logsEnabled }}
+    profiling_data_enabled: false
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" .) "true") }}

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -25,6 +25,8 @@ data:
         sync_host_metadata: true
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        log_data_enabled: true
+        profiling_data_enabled: false
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d66de8c118a34e9f9943189ada33fe4beac929b36275b8252d74b3031464e7d7
+        checksum/config: 38f8329848b0c78662dbcf8b22eb4a5b8ad06f827499e55422a3121d899cdc2f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -28,6 +28,8 @@ data:
         sync_host_metadata: true
       splunk_hec/o11y:
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        log_data_enabled: true
+        profiling_data_enabled: false
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       file_storage:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 20fb02d5cdac7e1599d846aa5e0c88c1aaf6417e19edb4989a028082f38e3da2
+        checksum/config: 2de91f8f2b9592467c802548de0ecec4d2970e44af26cbd6feca40913ba931c7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
This change helps to avoid situations when profiling or logs data can be sent to the backend even if it's disabled