### PR TITLE
Fix native container logs collection after logs-library changes in 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Make sure that logs or profiling data is sent only when it's enabled (#444)
+- Fix native OTel logs collection broken after the 0.29.0 opentelemetry-logs-library changes in 0.49.0 release (#448)
 
 ## [0.49.0] - 2022-04-28
 

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -156,69 +156,63 @@ data:
             layout_type: gotime
             parse_from: attributes.time
           type: regex_parser
-        - combine_field: body.log
+        - combine_field: attributes.log
           id: crio-recombine
-          is_last_entry: (body.logtag) == 'F'
+          is_last_entry: attributes.logtag == 'F'
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
           type: recombine
-        - field: body.log
-          id: crio-handle_empty_log
-          if: body.log == nil
-          output: filename
-          type: add
-          value: ""
         - id: parser-containerd
           regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
           timestamp:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: attributes.time
           type: regex_parser
-        - combine_field: body.log
+        - combine_field: attributes.log
           id: containerd-recombine
-          is_last_entry: (body.logtag) == 'F'
+          is_last_entry: attributes.logtag == 'F'
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
           type: recombine
-        - field: body.log
-          id: containerd-handle_empty_log
-          if: body.log == nil
-          output: filename
-          type: add
-          value: ""
         - id: parser-docker
-          parse_to: body
+          output: handle_empty_log
           timestamp:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: body.time
+            parse_from: attributes.time
           type: json_parser
-        - field: resource["com.splunk.source"]
-          id: filename
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
           type: add
-          value: EXPR(attributes["log.file.path"])
-        - id: extract_metadata_from_filepath
-          parse_from: attributes["log.file.path"]
-          parse_to: body
+          value: ""
+        - parse_from: attributes["log.file.path"]
           regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
           type: regex_parser
-        - field: resource["k8s.pod.uid"]
-          type: add
-          value: EXPR(body.uid)
-        - field: resource["k8s.container.restart_count"]
-          type: add
-          value: EXPR(body.restart_count)
-        - field: resource["k8s.container.name"]
-          type: add
-          value: EXPR(body.container_name)
-        - field: resource["k8s.namespace.name"]
-          type: add
-          value: EXPR(body.namespace)
-        - field: resource["k8s.pod.name"]
-          type: add
-          value: EXPR(body.pod_name)
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
         - field: resource["com.splunk.sourcetype"]
           type: add
-          value: EXPR("kube:container:"+body.container_name)
-        - field: attributes["log.iostream"]
-          type: add
-          value: EXPR(body.stream)
-        - from: body.log
+          value: EXPR("kube:container:"+resource["k8s.container.name"])
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes["log.file.path"]
+          to: resource["com.splunk.source"]
+          type: move
+        - from: attributes.log
           id: clean-up-log-record
           to: body
           type: move

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 2de91f8f2b9592467c802548de0ecec4d2970e44af26cbd6feca40913ba931c7
+        checksum/config: a4bb9d79512fd99a48bdd83e453ae751cd308fd33fe3cf024ac76b3d96060c34
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
This change fixes OTel native logs collection for containers that was broken in 0.49.0 release due to set of breaking changes in OTel Logs Collection library: https://github.com/open-telemetry/opentelemetry-log-collection/releases/tag/v0.29.0