### PR TITLE
Fix native OTel logs collection where 0 length logs cause errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Fix native OTel logs collection where 0 length logs cause errors after the 0.29.0 opentelemetry-logs-library changes in 0.49.0 (#TBD)
+
 ## [0.50.0] - 2022-05-03
 
 ### Fixed

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -271,7 +271,7 @@ receivers:
       # Parse CRI-O format
       - type: regex_parser
         id: parser-crio
-        regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$'
+        regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)[ ]{0,1}(?P<log>.*)$'
         timestamp:
           parse_from: attributes.time
           layout_type: gotime
@@ -287,7 +287,7 @@ receivers:
       # Parse CRI-Containerd format
       - type: regex_parser
         id: parser-containerd
-        regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$'
+        regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)[ ]{0,1}(?P<log>.*)$'
         timestamp:
           parse_from: attributes.time
           layout: '%Y-%m-%dT%H:%M:%S.%LZ'

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -150,7 +150,7 @@ data:
             output: parser-containerd
           type: router
         - id: parser-crio
-          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)[ ]{0,1}(?P<log>.*)$
           timestamp:
             layout: "2006-01-02T15:04:05.000000000-07:00"
             layout_type: gotime
@@ -163,7 +163,7 @@ data:
           source_identifier: attributes["log.file.path"]
           type: recombine
         - id: parser-containerd
-          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)[ ]{0,1}(?P<log>.*)$
           timestamp:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: attributes.time

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 91a4013ef735bc25949b0cd89399aa3d69c764c3020868cb966e51b1177430ba
+        checksum/config: b59d6df816752d448e4f0d5d1747800b6a771a5cdceb45eceefbfca06c29c1aa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
Fix native OTel logs collection where 0 length log lines cause errors after the 0.29.0 opentelemetry-logs-library changes in v0.49.0 of the collector. 

Testing:
Verified this is only an issue with v0.49.0 of the collector and after.

Example:
An application logs an error stack trace like such:
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>  File "/usr/local/lib/python3.8/site-packages/requests/adapters.py", line 439, in send
>  ...

The collector will throw an error like such:
> 2022-05-03T20:44:50.359Z	error	helper/transformer.go:110	Failed to process entry	{"kind": "receiver", "name": "filelog", "operator_id": "parser-containerd", "operator_type": "regex_parser", "error": "regex pattern does not match", "action": "send", "entry": {"observed_timestamp":"2022-05-03T20:44:50.359464261Z","timestamp":"0001-01-01T00:00:00Z","body":"2022-05-03T20:44:36.873466616Z stderr F","attributes":{"log.file.path":"/var/log/pods/xxxx/server/0.log"},"severity":0,"scope_name":""}}

If these changes are merged, I plan on submitting a PR for the [opentelemetry-collector-contrib example](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/0e06e0d1644b4f05c94a3ccdbea189d12cc09ece/examples/kubernetes/otel-collector-config.yml#L25) that is related.