### PR TITLE
Update the filelog operator regex values to match the opentelemetry-collector-contrib k8s examples

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -271,7 +271,7 @@ receivers:
       # Parse CRI-O format
       - type: regex_parser
         id: parser-crio
-        regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)[ ]{0,1}(?P<log>.*)$'
+        regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
         timestamp:
           parse_from: attributes.time
           layout_type: gotime
@@ -287,7 +287,7 @@ receivers:
       # Parse CRI-Containerd format
       - type: regex_parser
         id: parser-containerd
-        regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)[ ]{0,1}(?P<log>.*)$'
+        regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$'
         timestamp:
           parse_from: attributes.time
           layout: '%Y-%m-%dT%H:%M:%S.%LZ'

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -150,7 +150,7 @@ data:
             output: parser-containerd
           type: router
         - id: parser-crio
-          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)[ ]{0,1}(?P<log>.*)$
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
           timestamp:
             layout: "2006-01-02T15:04:05.000000000-07:00"
             layout_type: gotime
@@ -163,7 +163,7 @@ data:
           source_identifier: attributes["log.file.path"]
           type: recombine
         - id: parser-containerd
-          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)[ ]{0,1}(?P<log>.*)$
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
           timestamp:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: attributes.time

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ed5eec21824807ac2129b962acf12332828a2006e07c13fac32b17c97986657c
+        checksum/config: f3b47b65ff49891fc94e5953c5f493d4c83164acbf312f12ca313864a7cf902e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
Regex value changes were merged into opentelemetry-collector-contrib, updating this project with the same changes.

Related PR: [Update Kubernetes examples to fix native OTel logs collection issue where 0 length logs cause errors #9754](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9754)