### PR TITLE
Specify host mountinfo to agent self to prevent scraping errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Scrape /proc/self/mountinfo in agent pods to avoid incorrect stat attempts (#467)
+
 ## [0.53.0] - 2022-06-17
+
+### Changed
 
 - Upgrade splunk-otel-collector image to 0.53.0 (#466)
 

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -300,6 +300,13 @@ spec:
             value: {{ .Values.isWindows | ternary "C:\\hostfs\\run" "/hostfs/run" }}
           - name: HOST_DEV
             value: {{ .Values.isWindows | ternary "C:\\hostfs\\dev" "/hostfs/dev" }}
+          {{- if not .Values.isWindows }}
+          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
+          # is resolved fall back to previous gopsutil mountinfo path:
+          # https://github.com/shirou/gopsutil/issues/1271
+          - name: HOST_PROC_MOUNTINFO
+            value: /proc/self/mountinfo
+          {{- end }}
           {{- end }}
           {{- with $agent.extraEnvs }}
           {{- . | toYaml | nindent 10 }}

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -126,6 +126,11 @@ spec:
             value: /hostfs/run
           - name: HOST_DEV
             value: /hostfs/dev
+          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
+          # is resolved fall back to previous gopsutil mountinfo path:
+          # https://github.com/shirou/gopsutil/issues/1271
+          - name: HOST_PROC_MOUNTINFO
+            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -110,6 +110,11 @@ spec:
             value: /hostfs/run
           - name: HOST_DEV
             value: /hostfs/dev
+          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
+          # is resolved fall back to previous gopsutil mountinfo path:
+          # https://github.com/shirou/gopsutil/issues/1271
+          - name: HOST_PROC_MOUNTINFO
+            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -163,6 +163,11 @@ spec:
             value: /hostfs/run
           - name: HOST_DEV
             value: /hostfs/dev
+          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
+          # is resolved fall back to previous gopsutil mountinfo path:
+          # https://github.com/shirou/gopsutil/issues/1271
+          - name: HOST_PROC_MOUNTINFO
+            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:


### PR DESCRIPTION
Per https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879 https://github.com/shirou/gopsutil/pull/1133 the current agent configuration* almost guarantees failed disk usage metric generation by using unavailable host paths (which may be compounded by current SA receiver functionality: https://github.com/signalfx/splunk-otel-collector/pull/1615).