### PR TITLE
Reconstruct large docker logs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- A recombine operator for OTel logs collection to reconstruct multiline logs on docker engine (#465)
+
 ### Changed
 
 - Scrape /proc/self/mountinfo in agent pods to avoid incorrect stat attempts (#467)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- A recombine operator for OTel logs collection to reconstruct multiline logs on docker engine (#465)
+- A recombine operator for OTel logs collection to reconstruct multiline logs on docker engine (#467)
 
 ### Changed
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -306,6 +306,13 @@ receivers:
         timestamp:
           parse_from: attributes.time
           layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+      - type: recombine
+        id: docker-recombine
+        output: handle_empty_log
+        combine_field: attributes.log
+        source_identifier: attributes["log.file.path"]
+        is_last_entry: attributes.log endsWith "\n"
+        combine_with: ""
       {{- end }}
       - type: add
         id: handle_empty_log

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -180,6 +180,13 @@ data:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: attributes.time
           type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
         - field: attributes.log
           id: handle_empty_log
           if: attributes.log == nil

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6fb015bfbdef60a21b10d1d206c3cf4b679b3bf61710dcc9b4ad777e0f0016e7
+        checksum/config: 9fe34dcb4e431463f201eae05cdeee1c72d505be80f4d2c3906a0f8dc4dcade8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
Docker engine uses `\n` marker at the ens of log entry. Large size log entries can be broken down into several records where only last one has `\n` marker at the end. 

This change adds a default recombine operator for OTel logs collection to reconstruct large logs broken into several entries by docker engine.

Resolves https://github.com/signalfx/splunk-otel-collector-chart/issues/396