### PR TITLE
Fix failing cluster receiver with enabled profiling and disabled logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## [0.54.1] - 2022-07-01
+
+### Fixed
+
+- Fix failing cluster receiver with enabled profiling and disabled logs (#481)
+
 ## [0.54.0] - 2022-06-29
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.54.0
+version: 0.54.1
 appVersion: 0.54.0
 description: Splunk OpenTelemetry Collector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -238,7 +238,7 @@ service:
         {{- if $gateway.enabled }}
         - otlp
         {{- else }}
-        {{- if (eq (include "splunk-otel-collector.o11yLogsOrProfilingEnabled" .) "true") }}
+        {{- if (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") }}
         - splunk_hec/o11y
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}

--- a/rendered/manifests/agent-only/clusterRole.yaml
+++ b/rendered/manifests/agent-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/agent-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/agent-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 10814ebe5211a41baacccebc124e56c2d3c1bd5d12318d918134128984d9682c
+        checksum/config: 310524247f0e5fe3486b9a34f411905392acbb2f9303c8f69ea871f6acbbe08b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a54671e151ad80be702e6dc58b50410f190190fcc6f3dcfc17ffb5cef4426e5e
+        checksum/config: 4a3d31bd5b5487b3b72919b85adf4a887c7533c466fafcb722a1aa246886be77
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/agent-only/secret-splunk.yaml
+++ b/rendered/manifests/agent-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/agent-only/serviceAccount.yaml
+++ b/rendered/manifests/agent-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm

--- a/rendered/manifests/eks-fargate/clusterRole.yaml
+++ b/rendered/manifests/eks-fargate/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/eks-fargate/clusterRoleBinding.yaml
+++ b/rendered/manifests/eks-fargate/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-cr-node-discoverer-script
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/eks-fargate/configmap-gateway.yaml
+++ b/rendered/manifests/eks-fargate/configmap-gateway.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c0402160b85914eb629c9950d115b3a709b96000006373814d0d1a57bad2c4a4
+        checksum/config: 8b2c2f272b1f13ca542bded19b56625dc405edf5bb953be32192c94aa0ed1739
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/deployment-gateway.yaml
+++ b/rendered/manifests/eks-fargate/deployment-gateway.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: bb9ef685ebe9cb5865d6733926893b380bdf2ea70bf0208a39f74e2ff939efa5
+        checksum/config: 4f79b87b6ed3adab546fb5d822180766915701bf328a1bbe5764059dec891e03
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/secret-splunk.yaml
+++ b/rendered/manifests/eks-fargate/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/eks-fargate/service.yaml
+++ b/rendered/manifests/eks-fargate/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector

--- a/rendered/manifests/eks-fargate/serviceAccount.yaml
+++ b/rendered/manifests/eks-fargate/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm

--- a/rendered/manifests/gateway-only/clusterRole.yaml
+++ b/rendered/manifests/gateway-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/gateway-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/gateway-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 3dc324e1be2a91d0eb1872493fb7ad3d144978a3f79ad6f058423bd2cc3219ef
+        checksum/config: 63206fcab10672f75c04963026de7fe13cb8486a0919ec53d6bfafce81a7d660
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/secret-splunk.yaml
+++ b/rendered/manifests/gateway-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/gateway-only/service.yaml
+++ b/rendered/manifests/gateway-only/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector

--- a/rendered/manifests/gateway-only/serviceAccount.yaml
+++ b/rendered/manifests/gateway-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm

--- a/rendered/manifests/logs-only/clusterRole.yaml
+++ b/rendered/manifests/logs-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/logs-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/logs-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd-cri
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd-json.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-json.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/configmap-fluentd.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 077dab1b10491978692af0105591f6687dc101964797acd685c2abb2cce687e1
+        checksum/config: 6a473b2b0f20240214793bb1c8a7086fac46337a53a5cc8f7844fe21a2287a8d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/logs-only/secret-splunk.yaml
+++ b/rendered/manifests/logs-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/logs-only/serviceAccount.yaml
+++ b/rendered/manifests/logs-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm

--- a/rendered/manifests/metrics-only/clusterRole.yaml
+++ b/rendered/manifests/metrics-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/metrics-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/metrics-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: b9d7fbae9a0d10421243041218727c43451dc98a7934109e3abf3a10458d25b7
+        checksum/config: 32d5bd06827f6b9aa33ba625458be2d1150f95941d23d8ac0f7054e01d4d3e1f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a54671e151ad80be702e6dc58b50410f190190fcc6f3dcfc17ffb5cef4426e5e
+        checksum/config: 4a3d31bd5b5487b3b72919b85adf4a887c7533c466fafcb722a1aa246886be77
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/metrics-only/secret-splunk.yaml
+++ b/rendered/manifests/metrics-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/metrics-only/serviceAccount.yaml
+++ b/rendered/manifests/metrics-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm

--- a/rendered/manifests/otel-logs/clusterRole.yaml
+++ b/rendered/manifests/otel-logs/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/otel-logs/clusterRoleBinding.yaml
+++ b/rendered/manifests/otel-logs/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3bb94064fa025827c546308f35b892a13d46780d1f897391acde1bf9cc609358
+        checksum/config: df59814215d5d41297d8bf7f4cc33efdd3a0a395f0bf5df46949310c15b14ff1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a54671e151ad80be702e6dc58b50410f190190fcc6f3dcfc17ffb5cef4426e5e
+        checksum/config: 4a3d31bd5b5487b3b72919b85adf4a887c7533c466fafcb722a1aa246886be77
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/otel-logs/secret-splunk.yaml
+++ b/rendered/manifests/otel-logs/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/otel-logs/serviceAccount.yaml
+++ b/rendered/manifests/otel-logs/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm

--- a/rendered/manifests/traces-only/clusterRole.yaml
+++ b/rendered/manifests/traces-only/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 rules:

--- a/rendered/manifests/traces-only/clusterRoleBinding.yaml
+++ b/rendered/manifests/traces-only/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 roleRef:

--- a/rendered/manifests/traces-only/configmap-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 data:

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: b3c6d0d89aef064d43961127a91a790bea10443efe4f96850b2cb55752f00a20
+        checksum/config: dab0b9e5f800466a991cacb7036a40f74a2d78b908ede1b9134f4e68146db5ad
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/traces-only/secret-splunk.yaml
+++ b/rendered/manifests/traces-only/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm
 type: Opaque

--- a/rendered/manifests/traces-only/serviceAccount.yaml
+++ b/rendered/manifests/traces-only/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.54.0
+    helm.sh/chart: splunk-otel-collector-0.54.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
     app.kubernetes.io/version: "0.54.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.54.0
+    chart: splunk-otel-collector-0.54.1
     release: default
     heritage: Helm


### PR DESCRIPTION
If k8s events are sent to Splunk Platform and Observability Profiling is enabled, clusterReceiver is failing with the following message:

```
 failed to get config: invalid configuration: pipeline "logs" references exporter "splunk_hec/o11y" which does not exist
```

This change fixes the bug.