### PR TITLE
Make sure that logs are enabled to send k8s events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Make sure that logs are enabled to send k8s events (#481)
+
 ## [0.54.1] - 2022-07-01
 
 ### Fixed
 
-- Fix failing cluster receiver with enabled profiling and disabled logs (#481)
+- Fix failing cluster receiver with enabled profiling and disabled logs (#480)
 
 ## [0.54.0] - 2022-06-29
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -36,7 +36,7 @@ receivers:
     {{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
     distribution: openshift
     {{- end }}
-  {{- if $clusterReceiver.eventsEnabled }}
+  {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   k8s_events:
     auth_type: serviceAccount
   {{- end }}
@@ -222,7 +222,7 @@ service:
         {{- end }}
     {{- end }}
 
-    {{- if $clusterReceiver.eventsEnabled }}
+    {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
     logs:
       receivers:
         - k8s_events

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -416,6 +416,8 @@ clusterReceiver:
 
   # This flag enables Kubernetes events collection using OpenTelemetry Kubernetes Events Receiver
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver
+  # This option requires `logsEnabled` to be set to `true` for either `splunkObservability` or `splunkPlatform`
+  # depending on where you want to send the events. Otherwise this option will not have any effect.
   # The receiver currently is in alpha state which means that events format might change over time.
   # Once the receiver is stabilized, it'll be enabled by default in this helm chart
   eventsEnabled: false


### PR DESCRIPTION
Add configuration protection and a clarification that logs must be enabled on either Splunk Observability or Splunk Platform if `clusterReceiver.eventsEnabled` is set to `true`.