### PR TITLE
Ensure fluentd config path is respected

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -65,7 +65,7 @@ data:
       @type tail
       @label @CONCAT
       tag tail.containers.*
-      path {{ .Values.fluentd.path | default "/var/log/containers/*.log" }}
+      path {{ .Values.fluentd.config.path | default "/var/log/containers/*.log" }}
       {{- if .Values.fluentd.config.excludePath }}
       exclude_path {{ .Values.fluentd.config.excludePath | toJson }}
       {{- end }}


### PR DESCRIPTION
This PR fixes an issue where `fluentd.path` is incorrectly used instead of `fluentd.config.path`, causing the default value `/var/log/containers/*.log` to be used.