### PR TITLE
Adding note about GKE ARM support

### DIFF
--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -158,6 +158,15 @@ the following line to your custom values.yaml:
 priorityClassName: splunk-otel-agent-priority
 ```
 
+## GKE ARM support
+
+We support ARM workloads on GKE with default configurations of this helm chart.
+Make sure to set the required `distribution` value to `gke`:
+
+```yaml
+distribution: gke
+```
+
 ## EKS Fargate support
 
 If you want to run the Splunk OpenTelemetry Collector in [Amazon Elastic Kubernetes Service


### PR DESCRIPTION
GCP are launching GKE Arm on July 13th and we would like to add a link related to our support to the section about Splunk in the launch blog post.