### PR TITLE
Removed unnecessary change of group ownership in chmod initContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Removed unnecessary change of group ownership in chmod initContainer (#486)
+
 ## [0.55.0] - 2022-07-19
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -144,21 +144,21 @@ spec:
           {{ if .Values.logsCollection.containers.enabled -}}
           if [ -d "/var/lib/docker/containers" ];
           then
-              chgrp -Rv {{ $agent.securityContext.runAsGroup | default 20000 }} /var/lib/docker/containers;
-              chmod -R g+rxs /var/lib/docker/containers;
-              setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/lib/docker/containers;
+              find /var/lib/docker/containers -name "*.log" -exec chgrp -v {{ $agent.securityContext.runAsGroup | default 20000 }} {} +;
+              find /var/lib/docker/containers -name "*.log" -exec chmod g+rxs {} +;
+              find /var/lib/docker/containers -name "*.log" -exec setfacl -n -m d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx {} +;
           fi;
           if [ -d "/var/log/crio/pods" ];
           then
-              chgrp -Rv {{ $agent.securityContext.runAsGroup | default 20000 }} /var/log/crio/pods;
-              chmod -R g+rxs /var/log/crio/pods;
-              setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/log/crio/pods;
+              find /var/log/crio/pods -name "*.log" -exec chgrp -Rv {{ $agent.securityContext.runAsGroup | default 20000 }} {} +;
+              find /var/log/crio/pods -name "*.log" -exec chmod -R g+rxs {} +;
+              find /var/log/crio/pods -name "*.log" -exec setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx {} +;
           fi;
           if [ -d "/var/log/pods" ];
           then
-              chgrp -Rv {{ $agent.securityContext.runAsGroup | default 20000 }} /var/log/pods;
-              chmod -R g+rxs /var/log/pods;
-              setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/log/pods;
+              find /var/log/pods -name "*.log" -exec chgrp -Rv {{ $agent.securityContext.runAsGroup | default 20000 }} {} +;
+              find /var/log/pods -name "*.log" -exec chmod -R g+rxs {} +;
+              find /var/log/pods -name "*.log" -exec setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx {} +;
           fi;
           {{- end }}']
           securityContext:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -144,21 +144,15 @@ spec:
           {{ if .Values.logsCollection.containers.enabled -}}
           if [ -d "/var/lib/docker/containers" ];
           then
-              find /var/lib/docker/containers -name "*.log" -exec chgrp -v {{ $agent.securityContext.runAsGroup | default 20000 }} {} +;
-              find /var/lib/docker/containers -name "*.log" -exec chmod g+rxs {} +;
-              find /var/lib/docker/containers -name "*.log" -exec setfacl -n -m d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx {} +;
+              setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/lib/docker/containers;
           fi;
           if [ -d "/var/log/crio/pods" ];
           then
-              find /var/log/crio/pods -name "*.log" -exec chgrp -Rv {{ $agent.securityContext.runAsGroup | default 20000 }} {} +;
-              find /var/log/crio/pods -name "*.log" -exec chmod -R g+rxs {} +;
-              find /var/log/crio/pods -name "*.log" -exec setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx {} +;
+              setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/log/crio/pods;
           fi;
           if [ -d "/var/log/pods" ];
           then
-              find /var/log/pods -name "*.log" -exec chgrp -Rv {{ $agent.securityContext.runAsGroup | default 20000 }} {} +;
-              find /var/log/pods -name "*.log" -exec chmod -R g+rxs {} +;
-              find /var/log/pods -name "*.log" -exec setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx {} +;
+              setfacl -n -Rm d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/log/pods;
           fi;
           {{- end }}']
           securityContext:


### PR DESCRIPTION
~~Instead of modifying permissions of the entire pod/container directory, modify only logs file.~~

A file access control list (ACL) can provide permissions to a specific user or group without modifying the user/group owner of the file.
So, there is no need to change the group owner here:
https://github.com/signalfx/splunk-otel-collector-chart/blob/f5f6df821655f34a2c4e9c126edc5283be7a79d4/helm-charts/splunk-otel-collector/templates/daemonset.yaml#L147-L149