### PR TITLE
Do not send clusterReceiver metrics through gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The receiver.k8sclusterreceiver.reportCpuMetricsAsDouble feature gate has been removed (#487)
   - If you are using this feature gate, then see the [upgrade guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0540-to-0550)
+- Do not send clusterReceiver metrics through gateway (#491)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-### Fixed
+### Changed
 
 - Do not send clusterReceiver metrics through gateway (#491)
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -3,7 +3,6 @@ Config for the otel-collector k8s cluster receiver deployment.
 The values can be overridden in .Values.clusterReceiver.config
 */}}
 {{- define "splunk-otel-collector.clusterReceiverConfig" -}}
-{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) -}}
 {{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) -}}
 extensions:
   health_check:
@@ -141,13 +140,8 @@ processors:
 exporters:
   {{- if or (eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true") (eq (include "splunk-otel-collector.o11yInfraMonEventsEnabled" .) "true") }}
   signalfx:
-    {{- if $gateway.enabled }}
-    ingest_url: http://{{ include "splunk-otel-collector.fullname" . }}:9943
-    api_url: http://{{ include "splunk-otel-collector.fullname" . }}:6060
-    {{- else }}
     ingest_url: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
-    {{- end }}
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     timeout: 10s
   {{- end }}
@@ -235,15 +229,11 @@ service:
         - resource/add_environment
         {{- end }}
       exporters:
-        {{- if $gateway.enabled }}
-        - otlp
-        {{- else }}
         {{- if (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") }}
         - splunk_hec/o11y
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
         - splunk_hec/platform_logs
-        {{- end }}
         {{- end }}
     {{- end }}
 

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
@@ -19,8 +19,8 @@ data:
     exporters:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        api_url: http://default-splunk-otel-collector:6060
-        ingest_url: http://default-splunk-otel-collector:9943
+        api_url: https://api.CHANGEME.signalfx.com
+        ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:
       health_check: null

--- a/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8b2c2f272b1f13ca542bded19b56625dc405edf5bb953be32192c94aa0ed1739
+        checksum/config: 9f24ad8e484567552199c9c3bd310f43385df26b9ccdd8bea4e1e9a4549fbafa
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
Reasoning for this change:
- Currently platform metrics are not being sent through the gateway even if the gateway is enabled. K8s event collection is broken if the gateway is enabled (https://github.com/signalfx/splunk-otel-collector-chart/issues/490). It has to be consistent: send everything from cluster receiver through gateway or send everything directly to the backends.
- Sending telemetry though the gateway from one pod  doesn't look like providing any real value except for additional overhead:
  - If gateway is assigned on some special nodes that have internet connection, the same way cluster receiver can be assigned to the same nodes.
  - Cluster receiver has to talk a lot to k8s API in k8scluster receiver, that part cannot be moved to the gateway as it's done for for agents. Gateway also talks a lot to k8s API, so it makes sense to collocate them together.