### PR TITLE
Set sourcetype on Kubernetes events sent to Splunk Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Make sure that logs are enabled to send k8s events (#481)
+- Make sure that "sourcetype" field is always set on k8s events (#483)
 
 ## [0.54.1] - 2022-07-01
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -166,6 +166,7 @@ exporters:
 
   {{- if and (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") $clusterReceiver.eventsEnabled }}
   {{- include "splunk-otel-collector.splunkPlatformLogsExporter" . | nindent 2 }}
+    sourcetype: kube:events
   {{- end }}
 
 service:


### PR DESCRIPTION
HEC events without sourcetype field can fail to be parsed on Heavy Forwarder with some specific configuration. This change ensures that sourcetype field is always set on Kubernetes events.