### PR TITLE
Remove high cardinality fields from k8s events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The receiver.k8sclusterreceiver.reportCpuMetricsAsDouble feature gate has been removed (#487)
   - If you are using this feature gate, then see the [upgrade guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0540-to-0550)
+- Remove high cardinality fields from k8s events: (#484)
+  - k8s.event.start_time
+  - k8s.event.name
+  - k8s.event.uid
 
 ### Fixed
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -90,6 +90,16 @@ processors:
         value: {{ .Values.clusterName }}
   {{- end }}
 
+  # Drop high cardinality k8s event attributes
+  attributes/drop_event_attrs:
+    actions:
+      - key: k8s.event.start_time
+        action: delete
+      - key: k8s.event.name
+        action: delete
+      - key: k8s.event.uid
+        action: delete
+
   # Resource attributes specific to the collector itself.
   resource/add_collector_k8s:
     attributes:
@@ -229,6 +239,7 @@ service:
       processors:
         - memory_limiter
         - batch
+        - attributes/drop_event_attrs
         - resourcedetection
         - resource
         {{- if .Values.environment }}

--- a/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
@@ -27,6 +27,14 @@ data:
       memory_ballast:
         size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
+      attributes/drop_event_attrs:
+        actions:
+        - action: delete
+          key: k8s.event.start_time
+        - action: delete
+          key: k8s.event.name
+        - action: delete
+          key: k8s.event.uid
       batch: null
       memory_limiter:
         check_interval: 2s

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4a3d31bd5b5487b3b72919b85adf4a887c7533c466fafcb722a1aa246886be77
+        checksum/config: a610b0c37e1c47ca5ef4b3dcf491cb373b51aa121f3157d51008cfcef8a96819
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
@@ -31,6 +31,14 @@ data:
       memory_ballast:
         size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
+      attributes/drop_event_attrs:
+        actions:
+        - action: delete
+          key: k8s.event.start_time
+        - action: delete
+          key: k8s.event.name
+        - action: delete
+          key: k8s.event.uid
       batch: null
       memory_limiter:
         check_interval: 2s

--- a/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8b2c2f272b1f13ca542bded19b56625dc405edf5bb953be32192c94aa0ed1739
+        checksum/config: a0cd1d4e07fadd33a365f5240b3408ff7f87bedc306ab240f83110a2060a7446
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
@@ -27,6 +27,14 @@ data:
       memory_ballast:
         size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
+      attributes/drop_event_attrs:
+        actions:
+        - action: delete
+          key: k8s.event.start_time
+        - action: delete
+          key: k8s.event.name
+        - action: delete
+          key: k8s.event.uid
       batch: null
       memory_limiter:
         check_interval: 2s

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4a3d31bd5b5487b3b72919b85adf4a887c7533c466fafcb722a1aa246886be77
+        checksum/config: a610b0c37e1c47ca5ef4b3dcf491cb373b51aa121f3157d51008cfcef8a96819
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
@@ -27,6 +27,14 @@ data:
       memory_ballast:
         size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
+      attributes/drop_event_attrs:
+        actions:
+        - action: delete
+          key: k8s.event.start_time
+        - action: delete
+          key: k8s.event.name
+        - action: delete
+          key: k8s.event.uid
       batch: null
       memory_limiter:
         check_interval: 2s

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4a3d31bd5b5487b3b72919b85adf4a887c7533c466fafcb722a1aa246886be77
+        checksum/config: a610b0c37e1c47ca5ef4b3dcf491cb373b51aa121f3157d51008cfcef8a96819
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
Kubernetes events are coming with some attributes that are unique per event. This can blow up Splunk platform indexing and degrade its performance. For now we want to just remove the following high cardinality fields from events:
  - k8s.event.start_time
  - k8s.event.name
  - k8s.event.uid

Long term solution is to make the event structure configurable on k8s events receiver to work better with log backends like Splunk.