### PR TITLE
Make SCC more restrictive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Make SCC more restrictive (#513)
+- Make Openshift SecurityContextConstraints more restrictive (#513)
 
 ## [0.57.1] - 2022-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Make SCC more restrictive (#513)
+
 ## [0.57.1] - 2022-08-05
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -207,6 +207,8 @@ spec:
           readOnly: true
         - name: fluentd-config
           mountPath: /fluentd/etc
+        - name: tmp
+          mountPath: /tmp
       {{- end }}
       - name: otel-collector
         command:
@@ -415,6 +417,8 @@ spec:
       - name: fluentd-config-json
         configMap:
           name: {{ template "splunk-otel-collector.fullname" . }}-fluentd-json
+      - name: tmp
+        emptyDir: {}
       {{- end}}
       {{- if eq .Values.logsEngine "otel" }}
       {{- if .Values.isWindows }}

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -41,7 +41,7 @@ runAsUser:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
-requiredDropCapabilities: 
+requiredDropCapabilities:
 - CHOWN
 - DAC_OVERRIDE
 - FSETID

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -42,13 +42,5 @@ runAsUser:
 supplementalGroups:
   type: RunAsAny
 requiredDropCapabilities:
-- CHOWN
-- DAC_OVERRIDE
-- FSETID
-- FOWNER
-- SETGID
-- SETUID
-- SETPCAP
-- NET_BIND_SERVICE
-- KILL
+- ALL
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -36,10 +36,19 @@ allowedFlexVolumes: []
 defaultAddCapabilities: []
 fsGroup:
   type: MustRunAs
-readOnlyRootFilesystem: false
+readOnlyRootFilesystem: true
 runAsUser:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
-requiredDropCapabilities: []
+requiredDropCapabilities: 
+- CHOWN
+- DAC_OVERRIDE
+- FSETID
+- FOWNER
+- SETGID
+- SETUID
+- SETPCAP
+- NET_BIND_SERVICE
+- KILL
 {{- end }}

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -111,6 +111,8 @@ spec:
           readOnly: true
         - name: fluentd-config
           mountPath: /fluentd/etc
+        - name: tmp
+          mountPath: /tmp
       - name: otel-collector
         command:
         - /otelcol
@@ -204,6 +206,8 @@ spec:
       - name: fluentd-config-json
         configMap:
           name: default-splunk-otel-collector-fluentd-json
+      - name: tmp
+        emptyDir: {}
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent


### PR DESCRIPTION
https://github.com/signalfx/splunk-otel-collector-chart/discussions/509

The agent doesn't write in the root directory. So it makes sense to enable `readOnlyRootFilesystem`.
By default, CRI-O will add the following capabilities. That can be dropped as well.
- CHOWN
- DAC_OVERRIDE
- FSETID
- FOWNER
- SETGID
- SETUID
- SETPCAP
- NET_BIND_SERVICE
- KILL 

You can checked current capabilities using:
```
$oc rsh sck-otel-splunk-otel-collector-agent-pgg77 bash
bash-4.4# cat /proc/1/status | grep Cap
CapInh: 0000000000000000
CapPrm: 00000000000005fb
CapEff: 00000000000005fb
CapBnd: 00000000000005fb
CapAmb: 0000000000000000
```

```
capsh --decode=00000000000005fb
0x00000000000005fb=cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service
```