### PR TITLE
Fix a bug where collector internal metrics (pipeline: metrics/agent) are always exported even if metricsEnabled=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+Fix a bug where collector internal metrics (pipeline: metrics/agent) are always exported even if metricsEnabled=false (#521)
+
 ### Changed
 
 - Make Openshift SecurityContextConstraints more restrictive (#513)

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -743,8 +743,6 @@ service:
         - splunk_hec/platform_metrics
         {{- end }}
         {{- end }}
-    {{- end }}
-
     {{- if or (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") (eq (include "splunk-otel-collector.platformMetricsEnabled" .) "true") }}
     # Pipeline for metrics collected about the agent pod itself.
     metrics/agent:
@@ -768,5 +766,6 @@ service:
         - splunk_hec/platform_metrics
         {{- end }}
         {{- end }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -176,17 +176,6 @@ data:
           receivers:
           - fluentforward
           - otlp
-        metrics/agent:
-          exporters:
-          - signalfx
-          processors:
-          - memory_limiter
-          - batch
-          - resource/add_agent_k8s
-          - resourcedetection
-          - resource
-          receivers:
-          - prometheus/agent
       telemetry:
         metrics:
           address: 0.0.0.0:8889

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 70890139c5bdd66096745aea9a1605d1e134fefc65e8d4bafffcf2f9ddf22540
+        checksum/config: c8affb8c18e7226b7d16f1644dbe675047e0ca70f49937773e9982394c31808b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/traces-only/configmap-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-agent.yaml
@@ -168,17 +168,6 @@ data:
       - memory_ballast
       - zpages
       pipelines:
-        metrics/agent:
-          exporters:
-          - signalfx
-          processors:
-          - memory_limiter
-          - batch
-          - resource/add_agent_k8s
-          - resourcedetection
-          - resource
-          receivers:
-          - prometheus/agent
         traces:
           exporters:
           - sapm

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: a8a87d051a10e76c45a2c007c575cefc17abbda272af4aee320be0229d28a51f
+        checksum/config: 8aa446ae4cabc14b85e895912988f1f6740f69dfffb1e59d250d72413dc6cb99
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
We always include the internal collector metrics pipeline even if metricsEnabled=false.
Addresses https://github.com/signalfx/splunk-otel-collector-chart/issues/520