### PR TITLE
Template-ise Namespace Parameter In Manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Add namespace parameter templating to manifests (#538)
+- Add namespace parameter templating to manifests (#540)
 
 ## [0.59.0] - 2022-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add namespace parameter templating to manifests (#538)
+
 ## [0.59.0] - 2022-09-17
 
 ### Added

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -33,6 +33,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Kubernetes namespace to deploy into.
+*/}}
+{{- define "splunk-otel-collector.namespace" -}}
+{{- default (default .Release.Namespace .Values.namespace) "default" -}}
+{{- end -}}
+
+{{/*
 Whether to send data to Splunk Platform endpoint
 */}}
 {{- define "splunk-otel-collector.splunkPlatformEnabled" -}}

--- a/helm-charts/splunk-otel-collector/templates/clusterRoleBinding.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRoleBinding.yaml
@@ -16,5 +16,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "splunk-otel-collector.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-agent
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.clusterReceiverNodeDiscovererScript" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.clusterReceiverNodeDiscovererScript" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-k8s-cluster-receiver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-k8s-cluster-receiver
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-cri.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-cri.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-fluentd-cri
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-cri.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-cri.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-fluentd-cri
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-fluentd-json
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-fluentd-json
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-fluentd
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-fluentd
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-collector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-collector
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -7,7 +7,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-agent
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -7,6 +7,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-agent
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ kind: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }
 metadata:
   {{- /* StatefulSet names must be truncated or the `statefulset.kubernetes.io/pod-name` label value will be too long */}}
   name: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }} {{ template "splunk-otel-collector.clusterReceiverTruncatedName" . }} {{- else }} {{ template "splunk-otel-collector.fullname" . }}-k8s-cluster-receiver {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -10,6 +10,7 @@ kind: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }
 metadata:
   {{- /* StatefulSet names must be truncated or the `statefulset.kubernetes.io/pod-name` label value will be too long */}}
   name: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }} {{ template "splunk-otel-collector.clusterReceiverTruncatedName" . }} {{- else }} {{ template "splunk-otel-collector.fullname" . }}-k8s-cluster-receiver {{- end }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-k8s-cluster-receiver
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-k8s-cluster-receiver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/secret-etcd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-etcd.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "splunk-otel-collector.etcdSecret" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/secret-etcd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-etcd.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "splunk-otel-collector.etcdSecret" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-validate-secret
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
   annotations:

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-validate-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
   annotations:

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "splunk-otel-collector.secret" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "splunk-otel-collector.secret" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -3,7 +3,7 @@ kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
   name: {{ template "splunk-otel-collector.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -3,6 +3,7 @@ kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
   name: {{ template "splunk-otel-collector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/service-cluster-receiver-stateful-set.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service-cluster-receiver-stateful-set.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "splunk-otel-collector.clusterReceiverServiceName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "splunk-otel-collector.name" . }}
 spec:

--- a/helm-charts/splunk-otel-collector/templates/service-cluster-receiver-stateful-set.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service-cluster-receiver-stateful-set.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "splunk-otel-collector.clusterReceiverServiceName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     app: {{ template "splunk-otel-collector.name" . }}
 spec:

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml
+++ b/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml
@@ -9,6 +9,7 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-otel-collector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml
+++ b/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml
@@ -9,7 +9,7 @@ imagePullSecrets:
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-otel-collector.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-otel-collector.namespace" }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -20,6 +20,10 @@
       "description": "Override fully qualified app name.",
       "type": "string"
     },
+    "namespace": {
+      "description": "Kubernetes namespace to use for components, overrides any namespace given at rendering time",
+      "type": "string"
+    },
     "clusterName": {
       "description": "Cluster name that will be used as metadata attributes for all telemetry data",
       "type": "string",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -16,6 +16,10 @@ fullnameOverride: ""
 
 clusterName: ""
 
+# Kubernetes namespace to use for all components, will override the given namespace
+# on rendering if set here. If not set at rendering time or here, will set to `default`.
+namespace: ""
+
 ################################################################################
 # Splunk Data-to-Everything Platform configuration.
 ################################################################################

--- a/rendered/manifests/agent-only/configmap-agent.yaml
+++ b/rendered/manifests/agent-only/configmap-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/configmap-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/agent-only/daemonset.yaml
+++ b/rendered/manifests/agent-only/daemonset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: default-splunk-otel-collector-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -29,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6127c8202ccd5423b9659494eb0e2f6c8c7997e325a534740db946b69b33a1ab
+        checksum/config: 4562d6afa153497c964e988a537ce2c1d1019dc751b99697ef88949d0a7afb4f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/agent-only/deployment-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -30,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 685d7edf7b6621d94561f94fc6913e9aec36b31a924dd51e97f87958c30be3bc
+        checksum/config: 6668c359f10e827d377d2b9ff6bc46bf0b9ffd2547104b11c1981d9e63824fb5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/agent-only/secret-splunk.yaml
+++ b/rendered/manifests/agent-only/secret-splunk.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/agent-only/serviceAccount.yaml
+++ b/rendered/manifests/agent-only/serviceAccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-cr-node-discoverer-script
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/configmap-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/eks-fargate/configmap-gateway.yaml
+++ b/rendered/manifests/eks-fargate/configmap-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/eks-fargate/deployment-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -32,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: cc187e80eac774a4a97ba13d88ed1f194396e659c24ce1af1699b29142af1e08
+        checksum/config: 6ad77f5ffadf010c822c6a091b97f3ea9f81433a82192d8301967a16a357b200
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/deployment-gateway.yaml
+++ b/rendered/manifests/eks-fargate/deployment-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -30,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9c15ff266c83f17f5f5f50f5ef12879c5bb47d1fb46f91c0d217a973029f8682
+        checksum/config: f6a4fe90007d43b7b563cfd4ebb9a098c0544be289670af0caaaee85337b984c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/eks-fargate/secret-splunk.yaml
+++ b/rendered/manifests/eks-fargate/secret-splunk.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/eks-fargate/service-cluster-receiver-stateful-set.yaml
+++ b/rendered/manifests/eks-fargate/service-cluster-receiver-stateful-set.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
+  namespace: default
   labels:
     app: splunk-otel-collector
 spec:

--- a/rendered/manifests/eks-fargate/service.yaml
+++ b/rendered/manifests/eks-fargate/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/eks-fargate/serviceAccount.yaml
+++ b/rendered/manifests/eks-fargate/serviceAccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -30,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2a72a17d9aa3079c37b9b44d73c66e103edb0d735013c1450ecc2a215daa55ff
+        checksum/config: d0b2653a649c7cb1a627cc7f623df252bdcbcd72418402ec2bc5692afc5aa88d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/secret-splunk.yaml
+++ b/rendered/manifests/gateway-only/secret-splunk.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/gateway-only/service.yaml
+++ b/rendered/manifests/gateway-only/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/gateway-only/serviceAccount.yaml
+++ b/rendered/manifests/gateway-only/serviceAccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-cri.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-fluentd-cri
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/logs-only/configmap-fluentd-json.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd-json.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-fluentd-json
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/logs-only/configmap-fluentd.yaml
+++ b/rendered/manifests/logs-only/configmap-fluentd.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-fluentd
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: default-splunk-otel-collector-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -30,7 +31,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5f945a11e700035f7c902a4777159f917cde0ece8d0dcf70800e98f4c80cc14b
+        checksum/config: f74f2242b460c4b9841a818e265bdc6339c826f268de204d04609166daad7a9e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/logs-only/secret-splunk.yaml
+++ b/rendered/manifests/logs-only/secret-splunk.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/logs-only/serviceAccount.yaml
+++ b/rendered/manifests/logs-only/serviceAccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/metrics-only/configmap-agent.yaml
+++ b/rendered/manifests/metrics-only/configmap-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/configmap-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/metrics-only/daemonset.yaml
+++ b/rendered/manifests/metrics-only/daemonset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: default-splunk-otel-collector-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -29,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 247f3b08e2391991357ebb172bd842256624df595e798777ae2e8e32ecfaa7c2
+        checksum/config: c443c21c215e5e80d696344cf6f062a61a3186acca8c5c67d15d24f8eb5d4e02
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/metrics-only/deployment-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -30,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 685d7edf7b6621d94561f94fc6913e9aec36b31a924dd51e97f87958c30be3bc
+        checksum/config: 6668c359f10e827d377d2b9ff6bc46bf0b9ffd2547104b11c1981d9e63824fb5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/metrics-only/secret-splunk.yaml
+++ b/rendered/manifests/metrics-only/secret-splunk.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/metrics-only/serviceAccount.yaml
+++ b/rendered/manifests/metrics-only/serviceAccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/configmap-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: default-splunk-otel-collector-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -29,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 0389d36ffa8bdd550c7ff6293d2db05de9972825e84271eccb11c90cbdd8fa38
+        checksum/config: 6840f2f92cbe98243a89387231d2549f79579a26d6700a5b5b72edb4637d7c88
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/otel-logs/deployment-cluster-receiver.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -30,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 685d7edf7b6621d94561f94fc6913e9aec36b31a924dd51e97f87958c30be3bc
+        checksum/config: 6668c359f10e827d377d2b9ff6bc46bf0b9ffd2547104b11c1981d9e63824fb5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/otel-logs/secret-splunk.yaml
+++ b/rendered/manifests/otel-logs/secret-splunk.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/otel-logs/serviceAccount.yaml
+++ b/rendered/manifests/otel-logs/serviceAccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/traces-only/configmap-agent.yaml
+++ b/rendered/manifests/traces-only/configmap-agent.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: default-splunk-otel-collector-otel-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/traces-only/daemonset.yaml
+++ b/rendered/manifests/traces-only/daemonset.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: default-splunk-otel-collector-agent
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0
@@ -29,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 23d7112d396605fb4489307c204a5145d9411dafeca9cae2878dae2e8cc2815b
+        checksum/config: ee70a06789ff446e1eb2718db70a1967363a4ef74ceed85086155a365f9eb757
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/traces-only/secret-splunk.yaml
+++ b/rendered/manifests/traces-only/secret-splunk.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0

--- a/rendered/manifests/traces-only/serviceAccount.yaml
+++ b/rendered/manifests/traces-only/serviceAccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: default-splunk-otel-collector
+  namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.59.0


### PR DESCRIPTION
Allow setting the namespace parameter, which is useful for various GitOps flows that perform declarative rendering of manifests.

Follows from https://github.com/signalfx/splunk-otel-collector-chart/issues/539

