### PR TITLE
Increase number of queue consumers in gateway default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Increase number of queue consumers in the gateway configuration (#554)
+
 ## [0.59.0] - 2022-09-17
 
 ### Added

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -134,10 +134,14 @@ exporters:
     ingest_url: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+    sending_queue:
+      num_consumers: 32
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
   {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
+    sending_queue:
+      num_consumers: 32
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.o11yLogsOrProfilingEnabled" .) "true") }}
@@ -146,6 +150,8 @@ exporters:
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
     log_data_enabled: {{ .Values.splunkObservability.logsEnabled }}
     profiling_data_enabled: {{ .Values.splunkObservability.profilingEnabled }}
+    sending_queue:
+      num_consumers: 32
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}

--- a/rendered/manifests/eks-fargate/configmap-gateway.yaml
+++ b/rendered/manifests/eks-fargate/configmap-gateway.yaml
@@ -20,10 +20,14 @@ data:
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+        sending_queue:
+          num_consumers: 32
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        sending_queue:
+          num_consumers: 32
     extensions:
       health_check: null
       http_forwarder:

--- a/rendered/manifests/eks-fargate/deployment-gateway.yaml
+++ b/rendered/manifests/eks-fargate/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9c15ff266c83f17f5f5f50f5ef12879c5bb47d1fb46f91c0d217a973029f8682
+        checksum/config: b09d5224f249bfa873542dc0f7b4e4b73961d7f9279f5e0c0a8ddd6228285fee
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -20,10 +20,14 @@ data:
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+        sending_queue:
+          num_consumers: 32
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        sending_queue:
+          num_consumers: 32
     extensions:
       health_check: null
       http_forwarder:

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2a72a17d9aa3079c37b9b44d73c66e103edb0d735013c1450ecc2a215daa55ff
+        checksum/config: 70e6926416f65fa63c433b79732df02c66fcbb183c07ba306b46c7c159b0e535
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
Given that collector is supposed to handle higher data volume in gateway mode, we want to increase default numer of queue consumers.

Related issue: https://github.com/signalfx/splunk-otel-collector/issues/2082