### PR TITLE
[docs] Remove Journald limitation from the native otel logs docs

### DIFF
--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -400,7 +400,6 @@ There are following known limitations of native OTel logs collection:
 - `service.name` attribute will not be automatically constructed in istio environment.
   This means that correlation between logs and traces will not work in Splunk Observability.
   Logs collection with fluentd is still recommended if chart deployed with `autodetect.istio=true`.
-- Journald logs cannot be collected natively by Splunk OTel Collector yet.
 - Not yet supported in GKE Autopilot.
 
 ### Add log files from Kubernetes host machines/volumes


### PR DESCRIPTION
Journald support was added to native OTel logs collection a year ago. Docs need to be updated