### PR TITLE
Make sure filelog receiver uses file_storage for checkpointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Make sure filelog receiver uses file_storage for checkpointing (#567)
+
 ## [0.62.0] - 2022-10-28
 
 ### Changed

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -255,6 +255,7 @@ receivers:
     # Disable force flush until this issue is fixed:
     # https://github.com/open-telemetry/opentelemetry-log-collection/issues/292
     force_flush_period: "0"
+    storage: file_storage
     operators:
       {{- if not .Values.logsCollection.containers.containerRuntime }}
       - type: router

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -232,6 +232,7 @@ data:
           type: move
         poll_interval: 200ms
         start_at: beginning
+        storage: file_storage
       fluentforward:
         endpoint: 0.0.0.0:8006
       hostmetrics:

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 80bcec2a6da99668578b6aab5edbeeff588954fb73096787c0b71e9ce2a5cd75
+        checksum/config: 430f0a00ab87eeb44d982c337a8b5461c3f78b1152d4f7cf4657b1d60b155365
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
Fixes https://github.com/signalfx/splunk-otel-collector-chart/issues/564

`storage` parameter wasn't configured. So, it wasn't reading the checkpoint at all.