### PR TITLE
add allowedCapabilities to the openshift scc

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -33,6 +33,7 @@ seLinuxContext:
     type: "spc_t"
     level: "s0"
 allowedFlexVolumes: []
+allowedCapabilities: []
 defaultAddCapabilities: []
 fsGroup:
   type: MustRunAs


### PR DESCRIPTION
The current chart is resulting of this error when deployed on Azure openshift


```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(SecurityContextConstraints): missing required field "allowedCapabilities" in com.github.openshift.api.security.v1.SecurityContextConstraints
```
Adding the below should fix it

```
allowedCapabilities: []
```

Note: I still need to validate the fix on Axure Openshift
Signed-off-by: Dani Louca <dlouca@splunk.com>