### PR TITLE
dropping experimental label for OTel native logging

### DIFF
--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -139,7 +139,7 @@ splunkObservability:
 # Logs collection engine:
 # - `fluentd`: deploy a fluentd sidecar that will collect logs and send them to
 #   otel-collector agent for further processing.
-# - `otel`: utilize native OpenTelemetry log collection (experimental).
+# - `otel`: utilize native OpenTelemetry log collection.
 #
 # Change it to `otel` to get higher throughput performance and avoid installing
 # an extra container for fluentd.
@@ -453,7 +453,7 @@ clusterReceiver:
 #################################################################
 # Native OtelTelemetry logs collection using
 # https://github.com/open-telemetry/opentelemetry-log-collection.
-# Status: Experimental / disabled by default in favor of fluentd.
+# Disabled by default in favor of fluentd.
 #################################################################
 
 logsCollection:


### PR DESCRIPTION
The experimental tag for OTel logging is causing friction with adoption on the Splunk platform customer side (eg. Abercrombie). Based on [feedback](https://splunk.slack.com/archives/CPEKXHXLH/p1666220729712919?thread_ts=1666186271.942499&cid=CPEKXHXLH) so far, this removes the label in our helm chart.

