### PR TITLE
add k8sobject receiver

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -457,7 +457,7 @@ it creates:
 
 {{- define "splunk-otel-collector.clusterRole.clusterReceiver.objects" }}
 {{- $groupedObjects := dict }}
-{{ if and .Values.clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+{{ if and .Values.clusterReceiver.objectsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
 {{/* create a map for generating the rules */}}
 {{- range $apiGroup, $objects := .Values.clusterReceiver.objects }}
 {{- $groupedObjects = set $groupedObjects $apiGroup list }}
@@ -503,7 +503,7 @@ it creates:
 
 
 */}}
-{{- define "splunk-otel-collector.eventsObjects"}}
+{{- define "splunk-otel-collector.objectsEnabled"}}
 {{/* create a map for generating the rules */}}
 {{- $listObjects := list }}
 {{- range $apiGroup, $objects := .Values.clusterReceiver.objects }}

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -570,15 +570,18 @@ duplicated apiGroups keys.
 generate clusterRole.rules template
  */}}
 {{- range $apiGroup, $object := $allObjects -}}
-{{- $groupName := ((eq $apiGroup "v1") | ternary "" $apiGroup ) | quote -}}
+{{- $groupName := ((eq $apiGroup "v1") | ternary ("" | quote) $apiGroup ) -}}
 {{- if $object }}
 - apiGroups:
   - {{ $groupName }}
   resources:
   {{- range $object }}
-  - {{ . | quote }}
+  - {{ . }}
   {{- end }}
-  verbs: ["get", "list", "watch"]
+  verbs:
+  - get
+  - list
+  - watch
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -369,8 +369,6 @@ compatibility with the old config group name: "otelK8sClusterReceiver".
 {{ printf "%s-cr-node-discoverer-script" ( include "splunk-otel-collector.fullname" . ) | trunc 63 | trimSuffix "-" }}
 {{- end -}}
 
-
-
 {{/*
 "o11yInfraMonEventsEnabled" helper defines whether Observability Infrastructure monitoring events are enabled
 */}}

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -1,5 +1,4 @@
 {{ if .Values.rbac.create -}}
-{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -11,79 +10,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-{{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
-{{- include "splunk-otel-collector.eventsObjects.clusterRole" . }}
-{{- end }}
-{{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
-- apiGroups:
-  - quota.openshift.io
-  resources:
-  - clusterresourcequotas
-  verbs:
-  - get
-  - list
-  - watch
-{{- end }}
-- apiGroups:
-  - ""
-  resources:
-  - events
-  - namespaces
-  - namespaces/status
-  - nodes
-  - nodes/spec
-  - nodes/stats
-  - nodes/proxy
-  - pods
-  - pods/status
-  - persistentvolumeclaims
-  - persistentvolumes
-  - replicationcontrollers
-  - replicationcontrollers/status
-  - resourcequotas
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
+{{- include "splunk-otel-collector.clusterRole.rules" . }}
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.rbac.create -}}
+{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,6 +11,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
+{{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+{{- include "splunk-otel-collector.eventsObjects.clusterRole" . }}
+{{- end }}
 {{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
 - apiGroups:
   - quota.openshift.io

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -38,7 +38,8 @@ receivers:
   {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   k8sobjects:
     auth_type: serviceAccount
-    objects: {{ toYaml $clusterReceiver.eventsObjects | nindent 6 }}
+    objects:
+{{ include "splunk-otel-collector.eventsObjects" . | nindent 6 }}
   {{- end }}
   {{- if eq (include "splunk-otel-collector.o11yInfraMonEventsEnabled" .) "true" }}
   smartagent/kubernetes-events:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -36,8 +36,9 @@ receivers:
     distribution: openshift
     {{- end }}
   {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
-  k8s_events:
+  k8sobjects:
     auth_type: serviceAccount
+    objects: {{ toYaml $clusterReceiver.eventsObjects | nindent 6 }}
   {{- end }}
   {{- if eq (include "splunk-otel-collector.o11yInfraMonEventsEnabled" .) "true" }}
   smartagent/kubernetes-events:
@@ -232,7 +233,7 @@ service:
     {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
     logs:
       receivers:
-        - k8s_events
+        - k8sobjects
       processors:
         - memory_limiter
         - batch

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -35,11 +35,11 @@ receivers:
     {{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
     distribution: openshift
     {{- end }}
-  {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+  {{- if and $clusterReceiver.objectsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   k8sobjects:
     auth_type: serviceAccount
     objects:
-{{ include "splunk-otel-collector.eventsObjects" . | nindent 6 }}
+{{ include "splunk-otel-collector.objectsEnabled" . | nindent 6 }}
   {{- end }}
   {{- if eq (include "splunk-otel-collector.o11yInfraMonEventsEnabled" .) "true" }}
   smartagent/kubernetes-events:

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -672,11 +672,8 @@
         "eventsEnabled": {
           "type": "boolean"
         },
-        "eventsObjects": {
-          "type": "array",
-          "items": {
-            "type": "object"
-          }
+        "objects": {
+          "type": "object"
         },
         "podLabels": {
           "type": "object"

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -669,7 +669,7 @@
           "type": "boolean",
           "deprecated": true
         },
-        "eventsEnabled": {
+        "objectsEnabled": {
           "type": "boolean"
         },
         "objects": {

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -672,6 +672,12 @@
         "eventsEnabled": {
           "type": "boolean"
         },
+        "eventsObjects": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "podLabels": {
           "type": "object"
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -447,8 +447,6 @@ clusterReceiver:
   #     - "watch" mode will setup a long connection using the watch API to just get updates.
   # * name: [REQUIRED]
   #     name of the object, e.g. `pods`, `namespaces`.
-  #     Note that for resource names that contains multiple words, like `daemonsets`,
-  #     words need to be separated with `_`, so `daemonsets` becomes `daemon_sets`.
   # * namespace:
   #     only collects objects from the specified namespace, by default it's all namespaces
   # * labelSelector:
@@ -470,7 +468,7 @@ clusterReceiver:
   #       interval: 60m
   #     - name: events
   #       mode: watch
-  #   apps/v1:
+  #   apps:
   #     - name: daemon_sets
   #       labelSelector: environment=production
   # ```

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -432,8 +432,49 @@ clusterReceiver:
   eventsEnabled: false
 
   # Define what objects to collect (pull/watch) from the Kubernetes API server. Examples are here:
-  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
-  eventsObjects: []
+  #
+  # == Schema ==
+  # ```
+  # objects:
+  #   <apiGroup>:
+  #     - <objectDefinition>
+  # ```
+  #
+  # Each `objectDefinition` has the following fields:
+  # * mode:
+  #     define in which way it collects this type of object, either "pull" or "watch".
+  #     - "poll" mode will read all objects of this type use the list API at an interval.
+  #     - "watch" mode will setup a long connection using the watch API to just get updates.
+  # * name: [REQUIRED]
+  #     name of the object, e.g. `pods`, `namespaces`.
+  #     Note that for resource names that contains multiple words, like `daemonsets`,
+  #     words need to be separated with `_`, so `daemonsets` becomes `daemon_sets`.
+  # * namespace:
+  #     only collects objects from the specified namespace, by default it's all namespaces
+  # * labelSelector:
+  #     select objects by label(s)
+  # * fieldSelector:
+  #     select objects by field(s)
+  # * interval:
+  #     the interval at which object is pulled, default 15 minutes.
+  #     Only useful for "pull" mode.
+  #
+  #
+  # == Example ==
+  # ```
+  # objects:
+  #   v1:
+  #     - name: pods
+  #       namespace: default
+  #       mode: pull
+  #       interval: 60m
+  #     - name: events
+  #       mode: watch
+  #   apps/v1:
+  #     - name: daemon_sets
+  #       labelSelector: environment=production
+  # ```
+  objects: {}
 
   # k8s cluster receiver extra pod labels
   podLabels: {}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -469,7 +469,7 @@ clusterReceiver:
   #     - name: events
   #       mode: watch
   #   apps:
-  #     - name: daemon_sets
+  #     - name: daemonsets
   #       labelSelector: environment=production
   # ```
   objects: {}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -429,7 +429,7 @@ clusterReceiver:
   # depending on where you want to send the events. Otherwise, this option will not have any effect.
   # The receiver currently is in alpha state which means that events format might change over time.
   # Once the receiver is stabilized, it'll be enabled by default in this helm chart
-  eventsEnabled: false
+  objectsEnabled: false
 
   # Define what objects to collect (pull/watch) from the Kubernetes API server. Examples are here:
   #

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -424,12 +424,16 @@ clusterReceiver:
   podAnnotations: {}
 
   # This flag enables Kubernetes events collection using OpenTelemetry Kubernetes Events Receiver
-  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
   # This option requires `logsEnabled` to be set to `true` for either `splunkObservability` or `splunkPlatform`
-  # depending on where you want to send the events. Otherwise this option will not have any effect.
+  # depending on where you want to send the events. Otherwise, this option will not have any effect.
   # The receiver currently is in alpha state which means that events format might change over time.
   # Once the receiver is stabilized, it'll be enabled by default in this helm chart
   eventsEnabled: false
+
+  # Define what objects to collect (pull/watch) from the Kubernetes API server. Examples are here:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
+  eventsObjects: []
 
   # k8s cluster receiver extra pod labels
   podLabels: {}

--- a/rendered/manifests/agent-only/clusterRole.yaml
+++ b/rendered/manifests/agent-only/clusterRole.yaml
@@ -16,6 +16,44 @@ metadata:
     heritage: Helm
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -37,44 +75,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/rendered/manifests/eks-fargate/clusterRole.yaml
+++ b/rendered/manifests/eks-fargate/clusterRole.yaml
@@ -16,6 +16,44 @@ metadata:
     heritage: Helm
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -37,44 +75,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/rendered/manifests/gateway-only/clusterRole.yaml
+++ b/rendered/manifests/gateway-only/clusterRole.yaml
@@ -16,6 +16,44 @@ metadata:
     heritage: Helm
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -37,44 +75,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/rendered/manifests/logs-only/clusterRole.yaml
+++ b/rendered/manifests/logs-only/clusterRole.yaml
@@ -16,6 +16,44 @@ metadata:
     heritage: Helm
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -37,44 +75,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/rendered/manifests/metrics-only/clusterRole.yaml
+++ b/rendered/manifests/metrics-only/clusterRole.yaml
@@ -16,6 +16,44 @@ metadata:
     heritage: Helm
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -37,44 +75,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/rendered/manifests/otel-logs/clusterRole.yaml
+++ b/rendered/manifests/otel-logs/clusterRole.yaml
@@ -16,6 +16,44 @@ metadata:
     heritage: Helm
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -37,44 +75,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/rendered/manifests/traces-only/clusterRole.yaml
+++ b/rendered/manifests/traces-only/clusterRole.yaml
@@ -16,6 +16,44 @@ metadata:
     heritage: Helm
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -37,44 +75,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
 - nonResourceURLs:
   - /metrics
   verbs:


### PR DESCRIPTION
Replacing `k8seventsreceiver` with `k8objectsreceiver`.

As using k8s objects receiver requires creating new rules in `clusterRole.yaml`, the PR contains `splunk-otel-collector.clusterRole.rules` which is the template function that aggregates and renders all the apiGroups rules with "get", "list", "watch" verbs, so there is no duplications.

It requires splunk-otel-collector with https://github.com/signalfx/splunk-otel-collector/pull/2270 to be released.

There are slight indent differences in rendered templates because previously it was not entirely consistent (sometimes with whitespaces after apiGroups, sometimes not). With the change from thsi PR it's handled by the  function: