### PR TITLE
add k8s object receiver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,3 +73,15 @@ render:
 		default helm-charts/splunk-otel-collector; \
 	mv "$$dir"/splunk-otel-collector/templates/* "$$dir"; \
 	rm -rf "$$dir"/splunk-otel-collector
+
+	# cluster-receiver objects collection enabled
+	dir=rendered/manifests/cluster-receiver-objects; \
+	mkdir -p "$$dir"; \
+	helm template \
+		--namespace default \
+		--values rendered/values.yaml \
+		--output-dir "$$dir" \
+		--set logsEngine=otel,splunkObservability.logsEnabled=true,clusterReceiver.k8sObjects[0].name=pods,clusterReceiver.k8sObjects[0].mode=pull,clusterReceiver.k8sObjects[0].interval=20,clusterReceiver.k8sObjects[1].name=events,clusterReceiver.k8sObjects[1].mode=watch \
+		default helm-charts/splunk-otel-collector; \
+	mv "$$dir"/splunk-otel-collector/templates/* "$$dir"; \
+	rm -rf "$$dir"/splunk-otel-collector

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://circleci.com/gh/signalfx/splunk-otel-collector-chart">
-    <img alt="Build Status" src="https://img.shields.io/github/workflow/status/signalfx/splunk-otel-collector-chart/Lint%20and%20Test%20Charts?style=for-the-badge">
+    <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/signalfx/splunk-otel-collector-chart/lint-test.yaml?branch=main&style=for-the-badge">
   </a>
   <a href="https://github.com/signalfx/splunk-otel-collector/releases">
     <img alt="GitHub release (latest by date including pre-releases)" src="https://img.shields.io/github/v/release/signalfx/splunk-otel-collector-chart?include_prereleases&style=for-the-badge">

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,38 +1,65 @@
 # Upgrade guidelines
 
-## 0.64.0 to 0.66.0
-Before this change, [k8s events receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver) was used to collect Kubernetes Events.
-Now we utilize [k8s objects receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver) that can pull or watch any object from Kubernetes API server.
-Therefore, `clusterReceiver.eventsEnabled` is now deprecated, and to maintain the same behavior you should set
-`clusterReceiver.objectsEnabled` to `true` and configure `clusterReceiver.k8sObjects` to watch event objects:
+## $CURRENT_VERSION to $NEXT_VERSION
+
+There is a new receiver: [Kubernetes Objects Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver) that can pull or watch any object from Kubernetes API server.
+It will replace the [Kubernetes Events Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver) in the future.
+
+To migrate from Kubernetes Events Receiver to Kubernetes Object Receiver, configure `clusterReceiver` values.yaml section with:
+
 ```yaml
-  objectsEnabled: true
-  k8sObjects:
-    - mode: watch
-      name: events
+k8sObjects:
+  - mode: watch
+    name: events
 ```
-You can monitor more kubernetes objects configuring `clusterReceiver.k8sObjects` according to the instruction from
-[k8s objects receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver).
 
-Remember to define `rbac.customRules` when needed.
+There are differences in the log record formatting between the previous `k8s_events` receiver and the now adopted `k8sobjects` receiver results.
+The `k8s_events` receiver stores event messages their log body, with the following fields added as attributes:
 
-There is a difference in the event formatting between `k8s_events` receiver and `k8sobjects` receiver results.
-`k8s_events` receiver stores event message as a log body, with the following fields added as a resource/attribute:
-* k8s.object.kind
-* k8s.object.name
-* k8s.object.uid
-* k8s.object.fieldpath
-* k8s.object.api_version
-* k8s.object.resource_version
-* k8s.event.reason
-* k8s.event.action
-* k8s.event.start_time
-* k8s.event.name
-* k8s.event.uid
-* k8s.namespace.name
+* `k8s.object.kind`
+* `k8s.object.name`
+* `k8s.object.uid`
+* `k8s.object.fieldpath`
+* `k8s.object.api_version`
+* `k8s.object.resource_version`
+* `k8s.event.reason`
+* `k8s.event.action`
+* `k8s.event.start_time`
+* `k8s.event.name`
+* `k8s.event.uid`
+* `k8s.namespace.name`
 
-In case of `k8sobjects`, the whole payload is stored in the log body and `object.message` refers to the event message.
+Now with the `k8sobjects` receiver, the whole payload is stored in the log body and `object.message` refers to the event message.
 
+
+You can monitor more Kubernetes objects configuring by `clusterReceiver.k8sObjects` according to the instructions from the
+[Kubernetes Objects Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver) documentation.
+
+Remember to define `rbac.customRules` when needed. For example, when configuring:
+
+```yaml
+objectsEnabled: true
+k8sObjects:
+  - name: events
+    mode: watch
+    group: events.k8s.io
+    namespaces: [default]
+```
+
+You should add `events.k8s.io` API group to the `rbac.customRules`:
+
+```yaml
+rbac:
+  customRules:
+    - apiGroups:
+      - "events.k8s.io"
+      resources:
+      - events
+      verbs:
+      - get
+      - list
+      - watch
+```
 
 ## 0.58.0 to 0.59.0
 [receiver/filelogreceiver] Datatype for `force_flush_period` and `poll_interval` were changed from map to string.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,39 @@
 # Upgrade guidelines
 
+## 0.64.0 to 0.66.0
+Before this change, [k8s events receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver) was used to collect Kubernetes Events.
+Now we utilize [k8s objects receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver) that can pull or watch any object from Kubernetes API server.
+Therefore, `clusterReceiver.eventsEnabled` is now deprecated, and to maintain the same behavior you should set
+`clusterReceiver.objectsEnabled` to `true` and configure `clusterReceiver.k8sObjects` to watch event objects:
+```yaml
+  objectsEnabled: true
+  k8sObjects:
+    - mode: watch
+      name: events
+```
+You can monitor more kubernetes objects configuring `clusterReceiver.k8sObjects` according to the instruction from
+[k8s objects receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver).
+
+Remember to define `rbac.customRules` when needed.
+
+There is a difference in the event formatting between `k8s_events` receiver and `k8sobjects` receiver results.
+`k8s_events` receiver stores event message as a log body, with the following fields added as a resource/attribute:
+* k8s.object.kind
+* k8s.object.name
+* k8s.object.uid
+* k8s.object.fieldpath
+* k8s.object.api_version
+* k8s.object.resource_version
+* k8s.event.reason
+* k8s.event.action
+* k8s.event.start_time
+* k8s.event.name
+* k8s.event.uid
+* k8s.namespace.name
+
+In case of `k8sobjects`, the whole payload is stored in the log body and `object.message` refers to the event message.
+
+
 ## 0.58.0 to 0.59.0
 [receiver/filelogreceiver] Datatype for `force_flush_period` and `poll_interval` were changed from map to string.
 

--- a/ci_scripts/sck_otel_values.yaml
+++ b/ci_scripts/sck_otel_values.yaml
@@ -88,3 +88,19 @@ logsCollection:
         priority: info
     # Route journald logs to its own Splunk Index by specifying the index value below, else leave it blank. Please make sure the index exist in Splunk and is configured to receive HEC traffic. Not applicable to Splunk Observability.
     index: ""
+
+clusterReceiver:
+  enabled: true
+  # This flag enables Kubernetes objects collection using OpenTelemetry Kubernetes Object Receiver
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
+  # This option requires `logsEnabled` to be set to `true` for either `splunkObservability` or `splunkPlatform`
+  # depending on where you want to send the events. Otherwise, this option will not have any effect.
+  # The receiver currently is in alpha state which means that events format might change over time.
+  # Once the receiver is stabilized, it'll be enabled by default in this helm chart
+  objectsEnabled: true
+  k8sObjects:
+    - name: pods
+    - name: namespaces
+    - name: nodes
+    - name: events
+      mode: watch

--- a/ci_scripts/sck_otel_values.yaml
+++ b/ci_scripts/sck_otel_values.yaml
@@ -97,7 +97,6 @@ clusterReceiver:
   # depending on where you want to send the events. Otherwise, this option will not have any effect.
   # The receiver currently is in alpha state which means that events format might change over time.
   # Once the receiver is stabilized, it'll be enabled by default in this helm chart
-  objectsEnabled: true
   k8sObjects:
     - name: pods
     - name: namespaces

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -69,3 +69,7 @@ Splunk Network Explorer is installed and configured.
 [WARNING] "clusterReceiver.k8sEventsEnabled" parameter is deprecated. Please use clusterReceiver.eventsEnabled and splunkObservability.infrastructureMonitoringEventsEnabled.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0532-to-0540
 {{ end }}
+{{- if not (eq (toString $clusterReceiver.eventsEnabled) "<nil>") }}
+[WARNING] "clusterReceiver.eventsEnabled" parameter is deprecated. Please use clusterReceiver.objectsEnabled and clusterReceiver.k8sObjects.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0640-to-0660
+{{ end }}

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -70,6 +70,6 @@ Splunk Network Explorer is installed and configured.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0532-to-0540
 {{ end }}
 {{- if not (eq (toString $clusterReceiver.eventsEnabled) "<nil>") }}
-[WARNING] "clusterReceiver.eventsEnabled" parameter is deprecated. Please use clusterReceiver.objectsEnabled and clusterReceiver.k8sObjects.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0640-to-0660
+[WARNING] "clusterReceiver.eventsEnabled" parameter is deprecated. Soon it will be replaced with "clusterReceiver.k8sObjects".
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#$CURRENT_VERSION-to-$NEXT_VERSION
 {{ end }}

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -395,3 +395,12 @@ compatibility with the old config group name: "otelK8sClusterReceiver".
 {{- $clusterReceiver.k8sEventsEnabled }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Whether clusterReceiver should be deployed
+*/}}
+{{- define "splunk-otel-collector.clusterReceiverDeploy" -}}
+{{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
+{{- and $clusterReceiver.enabled (or (eq (include "splunk-otel-collector.metricsEnabled" .) "true") $clusterReceiver.objectsEnabled ) -}}
+{{- end -}}
+

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -396,11 +396,32 @@ compatibility with the old config group name: "otelK8sClusterReceiver".
 {{- end }}
 {{- end -}}
 
+
 {{/*
-Whether clusterReceiver should be deployed
+Whether object collection by k8s object receiver is enabled
 */}}
-{{- define "splunk-otel-collector.clusterReceiverDeploy" -}}
+{{- define "splunk-otel-collector.objectsEnabled" -}}
 {{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{- and $clusterReceiver.enabled (or (eq (include "splunk-otel-collector.metricsEnabled" .) "true") $clusterReceiver.objectsEnabled ) -}}
+{{- if gt (len $clusterReceiver.k8sObjects) 0 }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end -}}
 {{- end -}}
 
+{{/*
+Whether object collection by k8s object receiver or/and event collection by k8s event receiver is enabled
+*/}}
+{{- define "splunk-otel-collector.objectsOrEventsEnabled" -}}
+{{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
+{{- or $clusterReceiver.eventsEnabled ( eq (include "splunk-otel-collector.objectsEnabled" .) "true") -}}
+{{- end -}}
+
+
+{{/*
+Whether clusterReceiver should be enabled
+*/}}
+{{- define "splunk-otel-collector.clusterReceiverEnabled" -}}
+{{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
+{{- and $clusterReceiver.enabled (or (eq (include "splunk-otel-collector.metricsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true")) -}}
+{{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -107,12 +107,11 @@ processors:
   {{- end }}
 
   {{- if and (eq (include "splunk-otel-collector.objectsEnabled" .) "true") (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
-  # TODO: After updating to 0.66.0, change syntax according to
-  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor
   transform/add_sourcetype:
-    logs:
-      statements:
-        - set(resource.attributes["com.splunk.sourcetype"], Concat(["kube:object:", attributes["event.name"]], ""))
+    log_statements:
+      - context: log
+        statements:
+          - set(resource.attributes["com.splunk.sourcetype"], Concat(["kube:object:", attributes["event.name"]], ""))
   {{- end }}
 
   # Resource attributes specific to the collector itself.

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -247,7 +247,7 @@ service:
         {{- end }}
     {{- end }}
 
-    {{- if and $clusterReceiver.eventsEnabled  (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+    {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
     logs:
       receivers:
         - k8s_events

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -35,10 +35,14 @@ receivers:
     {{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
     distribution: openshift
     {{- end }}
-  {{- if and $clusterReceiver.objectsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+  {{- if and (eq (include "splunk-otel-collector.objectsEnabled" .) "true") (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   k8sobjects:
     auth_type: serviceAccount
-    objects: {{ .Values.clusterReceiver.k8sObjects | toJson }}
+    objects: {{ .Values.clusterReceiver.k8sObjects | toYaml | nindent 6 }}
+  {{- end }}
+  {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+  k8s_events:
+    auth_type: serviceAccount
   {{- end }}
   {{- if eq (include "splunk-otel-collector.o11yInfraMonEventsEnabled" .) "true" }}
   smartagent/kubernetes-events:
@@ -90,7 +94,7 @@ processors:
         value: {{ .Values.clusterName }}
   {{- end }}
 
-  {{- if and $clusterReceiver.objectsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+  {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   # Drop high cardinality k8s event attributes
   attributes/drop_event_attrs:
     actions:
@@ -100,6 +104,15 @@ processors:
         action: delete
       - key: k8s.event.uid
         action: delete
+  {{- end }}
+
+  {{- if and (eq (include "splunk-otel-collector.objectsEnabled" .) "true") (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+  # TODO: After updating to 0.66.0, change syntax according to
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor
+  transform/add_sourcetype:
+    logs:
+      statements:
+        - set(resource.attributes["com.splunk.sourcetype"], Concat(["kube:object:", attributes["event.name"]], ""))
   {{- end }}
 
   # Resource attributes specific to the collector itself.
@@ -133,7 +146,8 @@ processors:
         value: {{ .value }}
       {{- end }}
 
-  {{- if and $clusterReceiver.objectsEnabled .Values.environment }}
+
+  {{- if and ( eq ( include "splunk-otel-collector.objectsOrEventsEnabled" . ) "true") .Values.environment }}
   resource/add_environment:
     attributes:
       - action: insert
@@ -159,7 +173,7 @@ exporters:
     timeout: 10s
   {{- end }}
 
-  {{- if and (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") $clusterReceiver.objectsEnabled }}
+  {{- if and (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true") }}
   splunk_hec/o11y:
     endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v1/log
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
@@ -173,9 +187,11 @@ exporters:
   {{- include "splunk-otel-collector.splunkPlatformMetricsExporter" . | nindent 2 }}
   {{- end }}
 
-  {{- if and (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") $clusterReceiver.objectsEnabled }}
+  {{- if and (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true") }}
   {{- include "splunk-otel-collector.splunkPlatformLogsExporter" . | nindent 2 }}
+  {{- if $clusterReceiver.eventsEnabled }}
     sourcetype: kube:events
+  {{- end }}
   {{- end }}
 
 service:
@@ -188,6 +204,7 @@ service:
   extensions: [health_check, memory_ballast]
   {{- end }}
   pipelines:
+    {{- if or (eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true") (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
     # k8s metrics pipeline
     metrics:
       receivers: [k8s_cluster]
@@ -213,7 +230,6 @@ service:
         {{- end }}
     {{- end }}
 
-    {{- if or (eq (include "splunk-otel-collector.splunkO11yEnabled" $) "true") (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
     # Pipeline for metrics collected about the collector pod itself.
     metrics/collector:
       receivers: [prometheus/k8s_cluster_receiver]
@@ -232,16 +248,38 @@ service:
         {{- end }}
     {{- end }}
 
-    {{- if and $clusterReceiver.objectsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+    {{- if and $clusterReceiver.eventsEnabled  (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
     logs:
       receivers:
-        - k8sobjects
+        - k8s_events
       processors:
         - memory_limiter
         - batch
         - attributes/drop_event_attrs
         - resourcedetection
         - resource
+        {{- if .Values.environment }}
+        - resource/add_environment
+        {{- end }}
+      exporters:
+        {{- if (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") }}
+        - splunk_hec/o11y
+        {{- end }}
+        {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
+        - splunk_hec/platform_logs
+        {{- end }}
+    {{- end }}
+
+    {{- if and (eq (include "splunk-otel-collector.objectsEnabled" .) "true") (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+    logs/objects:
+      receivers:
+        - k8sobjects
+      processors:
+        - memory_limiter
+        - batch
+        - resourcedetection
+        - resource
+        - transform/add_sourcetype
         {{- if .Values.environment }}
         - resource/add_environment
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq (include "splunk-otel-collector.clusterReceiverDeploy" . ) "true" ) (eq (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
+{{ if and (eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" ) (eq (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -1,5 +1,4 @@
-{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{ if and $clusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") (eq (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
+{{ if and (eq (include "splunk-otel-collector.clusterReceiverDeploy" . ) "true" ) (eq (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 {{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{ if and $clusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
+{{ if eq (include "splunk-otel-collector.clusterReceiverDeploy" . ) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 {{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{ if eq (include "splunk-otel-collector.clusterReceiverDeploy" . ) "true" }}
+{{ if eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 {{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{ if eq (include "splunk-otel-collector.clusterReceiverDeploy" . ) "true" }}
+{{ if eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" }}
 apiVersion: apps/v1
 {{- /*
 eks/fargate distributions use a two-replica StatefulSet instead of a single node deployment.

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 {{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{- if and $clusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
+{{ if eq (include "splunk-otel-collector.clusterReceiverDeploy" . ) "true" }}
 apiVersion: apps/v1
 {{- /*
 eks/fargate distributions use a two-replica StatefulSet instead of a single node deployment.

--- a/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
@@ -1,5 +1,4 @@
-{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{- if and (and $clusterReceiver.enabled (eq (include "splunk-otel-collector.metricsEnabled" $) "true")) .Values.podDisruptionBudget }}
+{{- if and (eq (include "splunk-otel-collector.clusterReceiverDeploy" . ) "true" ) .Values.podDisruptionBudget }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (include "splunk-otel-collector.clusterReceiverDeploy" . ) "true" ) .Values.podDisruptionBudget }}
+{{- if and (eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" ) .Values.podDisruptionBudget }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -670,7 +670,18 @@
           "deprecated": true
         },
         "eventsEnabled": {
+          "description": "[DEPRECATED] Use objectsEnabled instead.",
+          "type": "boolean",
+          "deprecated": true
+        },
+        "objectsEnabled": {
           "type": "boolean"
+        },
+        "k8sObjects": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
         },
         "podLabels": {
           "type": "object"

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -670,12 +670,9 @@
           "deprecated": true
         },
         "eventsEnabled": {
-          "description": "[DEPRECATED] Use objectsEnabled instead.",
+          "description": "[DEPRECATED] Use k8sObjects instead.",
           "type": "boolean",
           "deprecated": true
-        },
-        "objectsEnabled": {
-          "type": "boolean"
         },
         "k8sObjects": {
           "type": "array",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -423,15 +423,21 @@ clusterReceiver:
   annotations: {}
   podAnnotations: {}
 
-  # This flag enables Kubernetes objects collection using OpenTelemetry Kubernetes Object Receiver
+  # This flag enables Kubernetes events collection using OpenTelemetry Kubernetes Events Receiver
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver
+  # This option requires `logsEnabled` to be set to `true` for either `splunkObservability` or `splunkPlatform`
+  # depending on where you want to send the events. Otherwise this option will not have any effect.
+  # The receiver currently is in alpha state which means that events format might change over time.
+  # Once the receiver is stabilized, it'll be enabled by default in this helm chart
+  eventsEnabled: false
+
+  # Kubernetes objects collection using OpenTelemetry Kubernetes Object Receiver
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
   # This option requires `logsEnabled` to be set to `true` for either `splunkObservability` or `splunkPlatform`
   # depending on where you want to send the events. Otherwise, this option will not have any effect.
   # The receiver currently is in alpha state which means that events format might change over time.
   # Once the receiver is stabilized, it'll be enabled by default in this helm chart
-  objectsEnabled: false
 
-  # k8s objects to collect (pull/watch) from the Kubernetes API server.
   #
   # == Schema ==
   # ```

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -123,10 +123,10 @@ splunkObservability:
   tracesEnabled: true
   logsEnabled: false
 
-  # Option to send Kubernetes objects to Splunk Observability Infrastructure Monitoring as data events:
+  # Option to send Kubernetes events to Splunk Observability Infrastructure Monitoring as data events:
   # https://docs.splunk.com/Observability/alerts-detectors-notifications/view-data-events.html
-  # To send Kubernetes events to Splunk Observability Log Observer, set both clusterReceiver.objectsEnabled and
-  # splunkObservability.logsEnabled to true.
+  # To send Kubernetes events to Splunk Observability Log Observer, configure clusterReceiver.k8sObjects
+  # and set splunkObservability.logsEnabled to true.
   infrastructureMonitoringEventsEnabled: false
 
   # This option just enables the shared pipeline for logs and profiling data.

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -123,9 +123,9 @@ splunkObservability:
   tracesEnabled: true
   logsEnabled: false
 
-  # Option to send Kubernetes events to Splunk Observability Infrastructure Monitoring as data events:
+  # Option to send Kubernetes objects to Splunk Observability Infrastructure Monitoring as data events:
   # https://docs.splunk.com/Observability/alerts-detectors-notifications/view-data-events.html
-  # To send Kubernetes events to Splunk Observability Log Observer, set both clusterReceiver.eventsEnabled and
+  # To send Kubernetes events to Splunk Observability Log Observer, set both clusterReceiver.objectsEnabled and
   # splunkObservability.logsEnabled to true.
   infrastructureMonitoringEventsEnabled: false
 
@@ -423,13 +423,56 @@ clusterReceiver:
   annotations: {}
   podAnnotations: {}
 
-  # This flag enables Kubernetes events collection using OpenTelemetry Kubernetes Events Receiver
-  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver
+  # This flag enables Kubernetes objects collection using OpenTelemetry Kubernetes Object Receiver
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
   # This option requires `logsEnabled` to be set to `true` for either `splunkObservability` or `splunkPlatform`
-  # depending on where you want to send the events. Otherwise this option will not have any effect.
+  # depending on where you want to send the events. Otherwise, this option will not have any effect.
   # The receiver currently is in alpha state which means that events format might change over time.
   # Once the receiver is stabilized, it'll be enabled by default in this helm chart
-  eventsEnabled: false
+  objectsEnabled: false
+
+  # k8s objects to collect (pull/watch) from the Kubernetes API server.
+  #
+  # == Schema ==
+  # ```
+  # k8sObjects:
+  #   - <objectDefinition>
+  # ```
+  # Each `objectDefinition` has the following fields:
+  # * mode:
+  #     define in which way it collects this type of object, either "pull" or "watch".
+  #     - "poll" mode will read all objects of this type use the list API at an interval. Default mode.
+  #     - "watch" mode will setup a long connection using the watch API to just get updates.
+  # * name: [REQUIRED]
+  #     name of the object, e.g. `pods`, `namespaces`.
+  # * namespace:
+  #     only collects objects from the specified namespace, by default it's all namespaces
+  # * labelSelector:
+  #     select objects by label(s)
+  # * fieldSelector:
+  #     select objects by field(s)
+  # * interval:
+  #     the interval at which object is pulled, default 60 seconds.
+  #     Only useful for "pull" mode.
+  #
+  #
+  # == Example ==
+  # ```
+  #  k8sObjects:
+  #    - name: pods
+  #      mode: pull
+  #      label_selector: environment in (production),tier in (frontend)
+  #      field_selector: status.phase=Running
+  #      interval: 15m
+  #    - name: events
+  #      mode: watch
+  #      group: events.k8s.io
+  #      namespaces: [default]
+  # ```
+  #
+  # The configuration format in details is described here:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver
+  k8sObjects: []
 
   # k8s cluster receiver extra pod labels
   podLabels: {}

--- a/rendered/manifests/cluster-receiver-objects/clusterRole.yaml
+++ b/rendered/manifests/cluster-receiver-objects/clusterRole.yaml
@@ -1,0 +1,83 @@
+---
+# Source: splunk-otel-collector/templates/clusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.67.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.67.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.67.0
+    release: default
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/proxy
+  - pods
+  - pods/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - list
+  - watch

--- a/rendered/manifests/cluster-receiver-objects/clusterRoleBinding.yaml
+++ b/rendered/manifests/cluster-receiver-objects/clusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: splunk-otel-collector/templates/clusterRoleBinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.67.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.67.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.67.0
+    release: default
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-splunk-otel-collector
+subjects:
+- kind: ServiceAccount
+  name: default-splunk-otel-collector
+  namespace: default

--- a/rendered/manifests/cluster-receiver-objects/configmap-agent.yaml
+++ b/rendered/manifests/cluster-receiver-objects/configmap-agent.yaml
@@ -183,7 +183,6 @@ data:
           source_identifier: attributes["log.file.path"]
           type: recombine
         - id: parser-docker
-          output: handle_empty_log
           timestamp:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: attributes.time

--- a/rendered/manifests/cluster-receiver-objects/configmap-agent.yaml
+++ b/rendered/manifests/cluster-receiver-objects/configmap-agent.yaml
@@ -1,0 +1,396 @@
+---
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-agent
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.67.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.67.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.67.0
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      sapm:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      signalfx:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        api_url: https://api.CHANGEME.signalfx.com
+        correlation: null
+        ingest_url: https://ingest.CHANGEME.signalfx.com
+        sync_host_metadata: true
+      splunk_hec/o11y:
+        disable_compression: true
+        endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        log_data_enabled: true
+        profiling_data_enabled: false
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+    extensions:
+      file_storage:
+        directory: /var/addon/splunk/otel_pos
+      health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
+      memory_ballast:
+        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+      zpages: null
+    processors:
+      batch: null
+      filter/logs:
+        logs:
+          exclude:
+            match_type: strict
+            resource_attributes:
+            - key: splunk.com/exclude
+              value: "true"
+      k8sattributes:
+        extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: namespace
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          - from: pod
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          labels:
+          - key: app
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: ip
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: host.name
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_agent_k8s:
+        attributes:
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 10s
+    receivers:
+      filelog:
+        encoding: utf-8
+        exclude:
+        - /var/log/pods/default_default-splunk-otel-collector*_*/otel-collector/*.log
+        fingerprint_size: 1kb
+        force_flush_period: "0"
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        max_concurrent_files: 1024
+        max_log_size: 1MiB
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: "2006-01-02T15:04:05.999999999-07:00"
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          output: handle_empty_log
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
+          type: add
+          value: ""
+        - parse_from: attributes["log.file.path"]
+          regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - field: resource["com.splunk.sourcetype"]
+          type: add
+          value: EXPR("kube:container:"+resource["k8s.container.name"])
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes["log.file.path"]
+          to: resource["com.splunk.source"]
+          type: move
+        - from: attributes.log
+          id: clean-up-log-record
+          to: body
+          type: move
+        poll_interval: 200ms
+        start_at: beginning
+        storage: file_storage
+      fluentforward:
+        endpoint: 0.0.0.0:8006
+      hostmetrics:
+        collection_interval: 10s
+        scrapers:
+          cpu: null
+          disk: null
+          filesystem: null
+          load: null
+          memory: null
+          network: null
+          paging: null
+          processes: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:14250
+          thrift_http:
+            endpoint: 0.0.0.0:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 10s
+        endpoint: ${K8S_NODE_IP}:10250
+        extra_metadata_labels:
+        - container.id
+        metric_groups:
+        - container
+        - pod
+        - node
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus/agent:
+        config:
+          scrape_configs:
+          - job_name: otel-agent
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+      receiver_creator:
+        receivers:
+          smartagent/coredns:
+            config:
+              extraDimensions:
+                metric_source: k8s-coredns
+              port: 9153
+              type: coredns
+            rule: type == "pod" && labels["k8s-app"] == "kube-dns"
+          smartagent/kube-controller-manager:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-controller-manager
+              port: 10257
+              skipVerify: true
+              type: kube-controller-manager
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-controller-manager"
+          smartagent/kubernetes-apiserver:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-apiserver
+              skipVerify: true
+              type: kubernetes-apiserver
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
+          smartagent/kubernetes-proxy:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-proxy
+              port: 10249
+              type: kubernetes-proxy
+            rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
+          smartagent/kubernetes-scheduler:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-scheduler
+              port: 10251
+              type: kubernetes-scheduler
+            rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
+        watch_observers:
+        - k8s_observer
+      signalfx:
+        endpoint: 0.0.0.0:9943
+      smartagent/signalfx-forwarder:
+        listenAddress: 0.0.0.0:9080
+        type: signalfx-forwarder
+      zipkin:
+        endpoint: 0.0.0.0:9411
+    service:
+      extensions:
+      - file_storage
+      - health_check
+      - k8s_observer
+      - memory_ballast
+      - zpages
+      pipelines:
+        logs:
+          exporters:
+          - splunk_hec/o11y
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - filter/logs
+          - batch
+          - resource/logs
+          - resourcedetection
+          - resource
+          receivers:
+          - filelog
+          - fluentforward
+          - otlp
+        metrics:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          - resource
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - otlp
+          - receiver_creator
+          - signalfx
+        metrics/agent:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_agent_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/agent
+        traces:
+          exporters:
+          - sapm
+          - signalfx
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - batch
+          - resourcedetection
+          - resource
+          receivers:
+          - otlp
+          - jaeger
+          - smartagent/signalfx-forwarder
+          - zipkin
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/rendered/manifests/cluster-receiver-objects/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/cluster-receiver-objects/configmap-cluster-receiver.yaml
@@ -1,0 +1,137 @@
+---
+# Source: splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.67.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.67.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.67.0
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      signalfx:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        api_url: https://api.CHANGEME.signalfx.com
+        ingest_url: https://ingest.CHANGEME.signalfx.com
+        timeout: 10s
+      splunk_hec/o11y:
+        disable_compression: true
+        endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        log_data_enabled: true
+        profiling_data_enabled: false
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+    extensions:
+      health_check: null
+      memory_ballast:
+        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+    processors:
+      batch: null
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: metric_source
+          value: kubernetes
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_collector_k8s:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/k8s_cluster:
+        attributes:
+        - action: insert
+          key: receiver
+          value: k8scluster
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 10s
+      transform/add_sourcetype:
+        logs:
+          statements:
+          - set(resource.attributes["com.splunk.sourcetype"], Concat(["kube:object:", attributes["event.name"]], ""))
+    receivers:
+      k8s_cluster:
+        auth_type: serviceAccount
+        metadata_exporters:
+        - signalfx
+      k8sobjects:
+        auth_type: serviceAccount
+        objects:
+        - interval: 20
+          mode: pull
+          name: pods
+        - mode: watch
+          name: events
+      prometheus/k8s_cluster_receiver:
+        config:
+          scrape_configs:
+          - job_name: otel-k8s-cluster-receiver
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+    service:
+      extensions:
+      - health_check
+      - memory_ballast
+      pipelines:
+        logs/objects:
+          exporters:
+          - splunk_hec/o11y
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          - resource
+          - transform/add_sourcetype
+          receivers:
+          - k8sobjects
+        metrics:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource
+          - resource/k8s_cluster
+          receivers:
+          - k8s_cluster
+        metrics/collector:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_collector_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/k8s_cluster_receiver
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/rendered/manifests/cluster-receiver-objects/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/cluster-receiver-objects/configmap-cluster-receiver.yaml
@@ -71,7 +71,8 @@ data:
         override: true
         timeout: 10s
       transform/add_sourcetype:
-        logs:
+        log_statements:
+        - context: log
           statements:
           - set(resource.attributes["com.splunk.sourcetype"], Concat(["kube:object:", attributes["event.name"]], ""))
     receivers:

--- a/rendered/manifests/cluster-receiver-objects/daemonset.yaml
+++ b/rendered/manifests/cluster-receiver-objects/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: fedbd501f28c21d2b194e20f8273037c131faa50d6dbed864b0517c117e14139
+        checksum/config: 16f1917e1ecccc792f06762d4c0b793d52987e51e0f772be9cce2bfe986b18a7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/cluster-receiver-objects/daemonset.yaml
+++ b/rendered/manifests/cluster-receiver-objects/daemonset.yaml
@@ -1,0 +1,248 @@
+---
+# Source: splunk-otel-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: default-splunk-otel-collector-agent
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.67.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.67.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.67.0
+    release: default
+    heritage: Helm
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        release: default
+      annotations:
+        checksum/config: fedbd501f28c21d2b194e20f8273037c131faa50d6dbed864b0517c117e14139
+        kubectl.kubernetes.io/default-container: otel-collector
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      initContainers:
+        - name: migrate-checkpoint
+          image: quay.io/signalfx/splunk-otel-collector:0.67.0
+          imagePullPolicy: IfNotPresent
+          command: ["/migratecheckpoint"]
+          securityContext:
+            runAsUser: 0
+          env:
+          - name: CONTAINER_LOG_PATH_FLUENTD
+            value: "/var/log/splunk-fluentd-containers.log.pos"
+          - name: CONTAINER_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_filelog_"
+          - name: CUSTOM_LOG_PATH_FLUENTD
+            value: "/var/log/splunk-fluentd-*.pos"
+          - name: CUSTOM_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_filelog_"
+          - name: CUSTOM_LOG_CAPTURE_REGEX
+            value: '\/var\/log\/splunk\-fluentd\-(?P<name>[\w0-9-_]+)\.pos'
+          - name: JOURNALD_LOG_PATH_FLUENTD
+            value: "/var/log/splunkd-fluentd-journald-*.pos.json"
+          - name: JOURNALD_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_journald_"
+          - name: JOURNALD_LOG_CAPTURE_REGEX
+            value: '\/splunkd\-fluentd\-journald\-(?P<name>[\w0-9-_]+)\.pos\.json'
+          volumeMounts:
+            - name: checkpoint
+              mountPath: /var/addon/splunk/otel_pos
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        ports:
+        - name: fluentforward
+          containerPort: 8006
+          hostPort: 8006
+          protocol: TCP
+        - name: jaeger-grpc
+          containerPort: 14250
+          hostPort: 14250
+          protocol: TCP
+        - name: jaeger-thrift
+          containerPort: 14268
+          hostPort: 14268
+          protocol: TCP
+        - name: otlp
+          containerPort: 4317
+          hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
+          protocol: TCP
+        - name: sfx-forwarder
+          containerPort: 9080
+          hostPort: 9080
+          protocol: TCP
+        - name: signalfx
+          containerPort: 9943
+          hostPort: 9943
+          protocol: TCP
+        - name: zipkin
+          containerPort: 9411
+          hostPort: 9411
+          protocol: TCP
+        image: quay.io/signalfx/splunk-otel-collector:0.67.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NODE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: splunk-otel-collector
+                key: splunk_observability_access_token
+          # Env variables for host metrics receiver
+          - name: HOST_PROC
+            value: /hostfs/proc
+          - name: HOST_SYS
+            value: /hostfs/sys
+          - name: HOST_ETC
+            value: /hostfs/etc
+          - name: HOST_VAR
+            value: /hostfs/var
+          - name: HOST_RUN
+            value: /hostfs/run
+          - name: HOST_DEV
+            value: /hostfs/dev
+          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
+          # is resolved fall back to previous gopsutil mountinfo path:
+          # https://github.com/shirou/gopsutil/issues/1271
+          - name: HOST_PROC_MOUNTINFO
+            value: /proc/self/mountinfo
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-configmap
+        - mountPath: /hostfs/dev
+          name: host-dev
+          readOnly: true
+        - mountPath: /hostfs/etc
+          name: host-etc
+          readOnly: true
+        - mountPath: /hostfs/proc
+          name: host-proc
+          readOnly: true
+        - mountPath: /hostfs/run/udev/data
+          name: host-run-udev-data
+          readOnly: true
+        - mountPath: /hostfs/sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /hostfs/var/run/utmp
+          name: host-var-run-utmp
+          readOnly: true
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: checkpoint
+          mountPath: /var/addon/splunk/otel_pos
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: checkpoint
+        hostPath:
+          path: /var/addon/splunk/otel_pos
+          type: DirectoryOrCreate
+      - name: host-dev
+        hostPath:
+          path: /dev
+      - name: host-etc
+        hostPath:
+          path: /etc
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-var-run-utmp
+        hostPath:
+          path: /var/run/utmp
+      - name: otel-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-agent
+          items:
+            - key: relay
+              path: relay.yaml

--- a/rendered/manifests/cluster-receiver-objects/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/cluster-receiver-objects/deployment-cluster-receiver.yaml
@@ -1,0 +1,96 @@
+---
+# Source: splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: default-splunk-otel-collector-k8s-cluster-receiver
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.67.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.67.0"
+    app: splunk-otel-collector
+    component: otel-k8s-cluster-receiver
+    chart: splunk-otel-collector-0.67.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-k8s-cluster-receiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      component: otel-k8s-cluster-receiver
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        component: otel-k8s-cluster-receiver
+        release: default
+      annotations:
+        checksum/config: 622045e0f46fa2efb4e54003b1aa7e2efecb33342b7121c4f2edf8c58dc92ac2
+    spec:
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+          kubernetes.io/os: linux
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        image: quay.io/signalfx/splunk-otel-collector:0.67.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: splunk-otel-collector
+                key: splunk_observability_access_token
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: collector-configmap
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: collector-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+          items:
+            - key: relay
+              path: relay.yaml

--- a/rendered/manifests/cluster-receiver-objects/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/cluster-receiver-objects/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 622045e0f46fa2efb4e54003b1aa7e2efecb33342b7121c4f2edf8c58dc92ac2
+        checksum/config: 6e518097f80a01eba2b3a46e56c83576baef88d5a877c8361ffcac2d37758906
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/cluster-receiver-objects/secret-splunk.yaml
+++ b/rendered/manifests/cluster-receiver-objects/secret-splunk.yaml
@@ -1,0 +1,19 @@
+---
+# Source: splunk-otel-collector/templates/secret-splunk.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.67.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.67.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.67.0
+    release: default
+    heritage: Helm
+type: Opaque
+data:
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/rendered/manifests/cluster-receiver-objects/serviceAccount.yaml
+++ b/rendered/manifests/cluster-receiver-objects/serviceAccount.yaml
@@ -1,0 +1,16 @@
+---
+# Source: splunk-otel-collector/templates/serviceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.67.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.67.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.67.0
+    release: default
+    heritage: Helm

--- a/test/.pytest.expect
+++ b/test/.pytest.expect
@@ -1,3 +1,0 @@
-pytest-expect file v1
-(3, 7, 9, 'final', 0)
-u'k8s_objects_tests/test_config_objects.py::test_k8s_objects_sourcetype[sourcetype-kube:object:event-1]': FAIL

--- a/test/.pytest.expect
+++ b/test/.pytest.expect
@@ -1,0 +1,3 @@
+pytest-expect file v1
+(3, 7, 9, 'final', 0)
+u'k8s_objects_tests/test_config_objects.py::test_k8s_objects_sourcetype[sourcetype-kube:object:event-1]': FAIL

--- a/test/k8s_objects_tests/test_config_objects.py
+++ b/test/k8s_objects_tests/test_config_objects.py
@@ -1,0 +1,30 @@
+import pytest
+import os
+import logging
+
+from ..common import check_events_from_splunk
+
+@pytest.mark.parametrize("test_key, test_value, expected", [
+    ("object.kind", "event", 1),
+    ("kind", "pod", 1),
+    ("kind", "namespace", 1),
+    ("kind", "node", 1)
+])
+def test_k8s_objects(setup, test_key, test_value, expected):
+    '''
+    Test that user specified index can successfully index the
+    objects stream from k8s.
+    '''
+    logging.getLogger().info("testing test_splunk_index input={0} \
+                 expected={1} event(s)".format(test_value, expected))
+    index_objects = os.environ.get("CI_INDEX_EVENTS", "ci_events")
+
+    search_query = f'index={index_objects} {test_key}={test_value}'
+    events = check_events_from_splunk(start_time="-1h@h",
+                                      url=setup["splunkd_url"],
+                                      user=setup["splunk_user"],
+                                      query=["search {0}".format(search_query)],
+                                      password=setup["splunk_password"])
+    logging.getLogger().info("Splunk received %s events in the last minute",
+                             len(events))
+    assert len(events) >= expected

--- a/test/k8s_objects_tests/test_config_objects.py
+++ b/test/k8s_objects_tests/test_config_objects.py
@@ -30,7 +30,6 @@ def test_k8s_objects(setup, test_key, test_value, expected):
     assert len(events) >= expected
 
 @pytest.mark.parametrize("test_key, test_value, expected", [
-    ("sourcetype", "kube:object:event", 1),
     ("sourcetype", "kube:object:Pod", 1),
     ("sourcetype", "kube:object:namespace", 1),
     ("sourcetype", "kube:object:node", 1)

--- a/test/k8s_objects_tests/test_config_objects.py
+++ b/test/k8s_objects_tests/test_config_objects.py
@@ -28,3 +28,28 @@ def test_k8s_objects(setup, test_key, test_value, expected):
     logging.getLogger().info("Splunk received %s events in the last minute",
                              len(events))
     assert len(events) >= expected
+
+@pytest.mark.parametrize("test_key, test_value, expected", [
+    ("sourcetype", "kube:object:event", 1),
+    ("sourcetype", "kube:object:Pod", 1),
+    ("sourcetype", "kube:object:namespace", 1),
+    ("sourcetype", "kube:object:node", 1)
+])
+def test_k8s_objects_sourcetype(setup, test_key, test_value, expected):
+    '''
+    Test that known k8s objects sourcetypes are present in target index
+    '''
+    logging.getLogger().info("testing test_splunk_index input={0} \
+                 expected={1} event(s)".format(test_value, expected))
+    index_objects = os.environ.get("CI_INDEX_EVENTS", "ci_events")
+
+    search_query = f'index={index_objects} {test_key}={test_value}'
+    events = check_events_from_splunk(start_time="-1h@h",
+                                      url=setup["splunkd_url"],
+                                      user=setup["splunk_user"],
+                                      query=["search {0}".format(search_query)],
+                                      password=setup["splunk_password"])
+    logging.getLogger().info("Splunk received %s events in the last minute",
+                             len(events))
+    assert len(events) >= expected
+

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 requests
 kubernetes
+pytest-expect

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
 pytest
 requests
 kubernetes
-pytest-expect
+


### PR DESCRIPTION
Replacing `k8seventsreceiver` with `k8objectsreceiver`.

As using k8s objects receiver requires creating new rules in `clusterRole.yaml`, the PR contains `splunk-otel-collector.clusterRole.rules` which is the template function that aggregates and renders all the apiGroups rules with "get", "list", "watch" verbs, so there is no duplications.

It requires splunk-otel-collector with https://github.com/signalfx/splunk-otel-collector/pull/2270 to be released.

There are slight indent differences in rendered templates because previously it was not entirely consistent (sometimes with whitespaces after apiGroups, sometimes not). With the change from thsi PR it's handled by the function:

```
- apiGroups:
  - {{ $groupName }}
```

Also, `eventsEnabled` name was changed to `objectsEnabled` so the name reflects better what actually we pull.