### PR TITLE
[DISCUSS] Enable compression by default

### DIFF
--- a/.chloggen/enable-compression-by-default.yaml
+++ b/.chloggen/enable-compression-by-default.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, networkExplorer, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable compression by default.
+# One or more tracking issues related to the change
+issues: [600]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,10 @@ This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk Op
 - Fix for secret name which now respects the same overrides as other resources in the chart [#873](https://github.com/signalfx/splunk-otel-collector-chart/pull/873)
 - Update the secret validation hook pod to use imagePullSecrets instead of possible non-existing serviceAccountName [#888](https://github.com/signalfx/splunk-otel-collector-chart/pull/888)
 
+### Changed
+
+- Set HEC exporter gzip compression enabled by default [#601](https://github.com/signalfx/splunk-otel-collector-chart/pull/601)
+
 ## [0.82.0] - 2023-08-02
 
 This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk OpenTelemetry Collector v0.82.0](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.82.0).

--- a/ci_scripts/sck_otel_values.yaml
+++ b/ci_scripts/sck_otel_values.yaml
@@ -18,8 +18,8 @@ splunkPlatform:
   sourcetype:
   # Maximum HTTP connections to use simultaneously when sending data. Defaults to 200.
   maxConnections: 200
-  # Whether to disable gzip compression over HTTP. Defaults to true.
-  disableCompression: true
+  # Whether to disable gzip compression over HTTP. Defaults to false.
+  disableCompression: false
   # HTTP timeout when sending data. Defaults to 10s.
   timeout: 10s
   # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to true.

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -67,7 +67,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_traces:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: ""

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1ac6bb159cb4e899265ef7db4a8bb1dde9f62446df6e6b16995bcf7d212e09f2
+        checksum/config: f7c80a36a5a84d40560629f3112df75cd512cdad599b0e3854facb217d7913aa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2014df4d79530856fc4c52d10df0cbee831f67b794e53081e3569d1970af9943
+        checksum/config: c564497cea157e0f4cf3524840f7e0db09e48e56123b09bca1d9a1910e2efa31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -67,7 +67,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_traces:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: ""

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 005a69103acb8660014c49e7c37407fda7dd1d2a464dc4faa68d53c3587849be
+        checksum/config: 46ef2313dc179eebbab8963bd4956fb04a6b67a5b42d757aff075ea9b9387528
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2014df4d79530856fc4c52d10df0cbee831f67b794e53081e3569d1970af9943
+        checksum/config: c564497cea157e0f4cf3524840f7e0db09e48e56123b09bca1d9a1910e2efa31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 11b7dc56fc2e8bb7707daea4f680cdcc59af58cb61bcea3e2c433834767e6a04
+        checksum/config: b7b03fbc18053a745de71af7a5e9147e22303a7ba0fba0be492f8f0c176b5d4b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2014df4d79530856fc4c52d10df0cbee831f67b794e53081e3569d1970af9943
+        checksum/config: c564497cea157e0f4cf3524840f7e0db09e48e56123b09bca1d9a1910e2efa31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 08859603cd5746c02d278b0cf2e7ff86384958f35ffd793640cc25602bc93973
+        checksum/config: 1413a4c6559b45795a3bfc22bdf781203c1118d53ae0c3bff0e9bf8fe8b13b08
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -48,8 +48,8 @@ splunkPlatform:
   sourcetype: ""
   # Maximum HTTP connections to use simultaneously when sending data.
   maxConnections: 200
-  # Whether to disable gzip compression over HTTP. Defaults to true.
-  disableCompression: true
+  # Whether to disable gzip compression over HTTP. Defaults to false.
+  disableCompression: false
   # HTTP timeout when sending data. Defaults to 10s.
   timeout: 10s
   # Idle connection timeout. defaults to 10s


### PR DESCRIPTION
See #600 for context.

By default, we don't enable gzip compression when sending HEC data. This change would make compression enabled by default.