### PR TITLE
Add a temporary argument required to run collector on GKE Autopilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Make sure the daemonset can start in GKE Autopiot (#602)
+
 ## [0.66.1] - 2022-12-08
 
 ### Fixed

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -221,6 +221,10 @@ spec:
         {{- else }}
         - /otelcol
         - --config=/conf/relay.yaml
+        {{- if eq .Values.distribution "gke/autopilot" }}
+        {{- /* Temporary no-op argument required to run collector on GKE Autopilot */}}
+        - --metrics-addr=0.0.0.0:8889
+        {{- end }}
         {{- end }}
         {{- if .Values.agent.featureGates }}
         - --feature-gates={{ .Values.agent.featureGates }}


### PR DESCRIPTION
The argument is a no-op but required to run in GKE/Autopilot