### PR TITLE
Temporary disable compression in Splunk logs exporter until 0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Make sure the daemonset can start in GKE Autopiot (#608)
 - Make containerd engine default in for fluentd logs and use always use it in GKE Autopiot (#609)
+- Temporary disable compression in Splunk Observability logs exporter until
+  0.68.0 to workaround a compression bug (#610)
 
 ## [0.66.1] - 2022-12-08
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -579,6 +579,8 @@ exporters:
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
     log_data_enabled: {{ .Values.splunkObservability.logsEnabled }}
     profiling_data_enabled: {{ .Values.splunkObservability.profilingEnabled }}
+    # Temporary disable compression until 0.68.0 to workaround a compression bug
+    disable_compression: true
   {{- end }}
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
   {{- include "splunk-otel-collector.splunkPlatformLogsExporter" . | nindent 2 }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -152,6 +152,8 @@ exporters:
     profiling_data_enabled: {{ .Values.splunkObservability.profilingEnabled }}
     sending_queue:
       num_consumers: 32
+    # Temporary disable compression until 0.68.0 to workaround a compression bug
+    disable_compression: true
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -164,6 +164,8 @@ exporters:
     token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
     log_data_enabled: true
     profiling_data_enabled: false
+    # Temporary disable compression until 0.68.0 to workaround a compression bug
+    disable_compression: true
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" .) "true") }}

--- a/rendered/manifests/logs-only/configmap-agent.yaml
+++ b/rendered/manifests/logs-only/configmap-agent.yaml
@@ -24,6 +24,7 @@ data:
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
       splunk_hec/o11y:
+        disable_compression: true
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
         log_data_enabled: true
         profiling_data_enabled: false

--- a/rendered/manifests/logs-only/daemonset.yaml
+++ b/rendered/manifests/logs-only/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 0dd2001a5452e85b22ed2a419f03895f9b0a0382fb9d035be838299393f6080b
+        checksum/config: 6ec60fb5f051a41efb84465b07fd45a0b086efcc46c2d1ab2d791b9d1c7f8dc7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -27,6 +27,7 @@ data:
         ingest_url: https://ingest.CHANGEME.signalfx.com
         sync_host_metadata: true
       splunk_hec/o11y:
+        disable_compression: true
         endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
         log_data_enabled: true
         profiling_data_enabled: false

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 8d58214e201cd190b4f1eadfc34a0baba2efe9ca5b16e1efe158e5ed2f30b2e2
+        checksum/config: af8cd684d7e9d2b64258ed6a0995fa489141434f635ab4391c436cf42fc56a80
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
to workaround a compression bug fixed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17084