### PR TITLE
Remove invalid output from the filelog operators sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Docker default recombine operator is skipped (#627)
+
 ## [0.67.0] - 2022-12-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Docker default recombine operator is skipped (#627)
+### Fixed
+
+- Default recombine operator for the docker container engine (#627)
 
 ## [0.67.0] - 2022-12-19
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -306,7 +306,6 @@ receivers:
       # Parse Docker format
       - type: json_parser
         id: parser-docker
-        output: handle_empty_log
         timestamp:
           parse_from: attributes.time
           layout: '%Y-%m-%dT%H:%M:%S.%LZ'

--- a/rendered/manifests/otel-logs/configmap-agent.yaml
+++ b/rendered/manifests/otel-logs/configmap-agent.yaml
@@ -183,7 +183,6 @@ data:
           source_identifier: attributes["log.file.path"]
           type: recombine
         - id: parser-docker
-          output: handle_empty_log
           timestamp:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: attributes.time

--- a/rendered/manifests/otel-logs/daemonset.yaml
+++ b/rendered/manifests/otel-logs/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: fedbd501f28c21d2b194e20f8273037c131faa50d6dbed864b0517c117e14139
+        checksum/config: 16f1917e1ecccc792f06762d4c0b793d52987e51e0f772be9cce2bfe986b18a7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
This change removes an output directive that makes the filelog receiver ignore the next recombine rule which is necessary to recombine long lines in docker logs.

Fixes #627 