### PR TITLE
update CI pre-commit step with the new Helm version

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v3.5
       with:
-        version: v3.5.4
+        version: v3.10.3
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Setup Python

--- a/rendered/manifests/cluster-receiver-objects/configmap-cluster-receiver.yaml
+++ b/rendered/manifests/cluster-receiver-objects/configmap-cluster-receiver.yaml
@@ -74,7 +74,8 @@ data:
         log_statements:
         - context: log
           statements:
-          - set(resource.attributes["com.splunk.sourcetype"], Concat(["kube:object:", attributes["event.name"]], ""))
+          - set(resource.attributes["com.splunk.sourcetype"], Concat(["kube:object:",
+            attributes["event.name"]], ""))
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/rendered/manifests/cluster-receiver-objects/deployment-cluster-receiver.yaml
+++ b/rendered/manifests/cluster-receiver-objects/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 6e518097f80a01eba2b3a46e56c83576baef88d5a877c8361ffcac2d37758906
+        checksum/config: 44fd9d8ff79a081f4b7c4fd0ca3eac315a8641eb33f8b68887f856e95480f55f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
Currently we use `3.5.4` version of pre-commit in the CI. 
It's quite old at this point, and most of the people (including me) typically will have helm installed of version ~3.10.
https://github.com/signalfx/splunk-otel-collector-chart/pull/588 PR provided rendered templates that differ depending on the version, and to match the CI I needed to downgrade to `3.5.4`. Now I observe `pre-commit` step failing for other people (as they probably have new helm). 
Maybe we can upgrade it and get rid of this problem?