### PR TITLE
Allow to overwrite default SCC with values.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Allow to overwrite default SecurityContextConstraints rules with values.yaml file (#643)
+
 ### Fixed
 
 - Default recombine operator for the docker container engine (#627)

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -1,16 +1,7 @@
-{{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
-kind: SecurityContextConstraints
-apiVersion: security.openshift.io/v1
-metadata:
-  name: {{ template "splunk-otel-collector.serviceAccountName" . }}
-  labels:
-    {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
-    app: {{ template "splunk-otel-collector.name" . }}
-    chart: {{ template "splunk-otel-collector.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-users:
-- system:serviceaccount:{{ .Release.Namespace }}:{{ template "splunk-otel-collector.serviceAccountName" . }}
+{{/*
+Default values for SecurityContextConstraints
+*/}}
+{{- define "splunk-otel-collector.defaultSecurityContextConstraints" -}}
 priority: 10
 allowHostNetwork: true
 allowHostPorts: true
@@ -44,4 +35,21 @@ supplementalGroups:
   type: RunAsAny
 requiredDropCapabilities:
 - ALL
+{{- end -}}
+
+{{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: {{ template "splunk-otel-collector.serviceAccountName" . }}
+  labels:
+    {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
+    app: {{ template "splunk-otel-collector.name" . }}
+    chart: {{ template "splunk-otel-collector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ template "splunk-otel-collector.serviceAccountName" . }}
+{{- $config := include "splunk-otel-collector.defaultSecurityContextConstraints" . | fromYaml }}
+{{- .Values.securityContextConstraintsOverwrite | mustMergeOverwrite $config | toYaml }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1133,6 +1133,10 @@
       "description": "Apply for k8s cluster with windows worker node.",
       "type": "boolean"
     },
+    "securityContextConstraintsOverwrite": {
+      "description": "Openshift SecurityContextConstraints can be overriden in this field.",
+      "type": "object"
+    },
     "gateway": {
       "description": "Splunk OpenTelemetry Collector gateway deployment configuration.",
       "type": "object",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -964,6 +964,10 @@ livenessProbe:
 # Specifies whether to apply for k8s cluster with windows worker node.
 isWindows: false
 
+# Openshift SecurityContextConstraints can be overriden in this field.
+# NOTE: This config will only be used when distribution=openshift
+securityContextConstraintsOverwrite: {}
+
 ################################################################################
 # OpenTelemetry "collector" k8s deployment configuration.
 # This is an additional deployment of Open-telemetry collector that can be used

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -965,6 +965,8 @@ livenessProbe:
 isWindows: false
 
 # Openshift SecurityContextConstraints can be overriden in this field.
+# This fields will be merged into the default config that can be found at
+# https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
 # NOTE: This config will only be used when distribution=openshift
 securityContextConstraintsOverwrite: {}
 


### PR DESCRIPTION
When using `openshift` distribution, helm chart creates SecurityContextConstraints object, but it's content cannot be modified. With this PR, user can for example add `seccompProfiles` to the SCC with following config:

```yaml
securityContextConstraintsOverwrite:
  seccompProfiles:
  - runtime/default
```