### PR TITLE
limit clusterReceiver.eventsEnabled deprecation warning to non-default use

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -69,7 +69,8 @@ Splunk Network Explorer is installed and configured.
 [WARNING] "clusterReceiver.k8sEventsEnabled" parameter is deprecated. Please use clusterReceiver.eventsEnabled and splunkObservability.infrastructureMonitoringEventsEnabled.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0532-to-0540
 {{ end }}
-{{- if not (eq (toString $clusterReceiver.eventsEnabled) "<nil>") }}
+{{- $crEventsEnabled := toString $clusterReceiver.eventsEnabled }}
+{{- if not (or (eq $crEventsEnabled "<nil>") (eq $crEventsEnabled "false")) }}
 [WARNING] "clusterReceiver.eventsEnabled" parameter is deprecated. Soon it will be replaced with "clusterReceiver.k8sObjects".
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0670-to-0680
 {{ end }}


### PR DESCRIPTION
The current warning will be reported with the false value. We should only log if this is enabled.