### PR TITLE
Require specified platform at startup

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -1,3 +1,8 @@
+{{/* Current jsonschema doesn't enforce below requirement while `splunkRealm` not provided as (an undesired) default value. */}}
+{{- if and (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "false") (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "false") -}}
+{{ fail "[ERROR] Please set at least one of required `splunkObservability.realm` or `splunkPlatform.endpoint` and corresponding token values to specify the platform(s) to send data." }}
+{{- end -}}
+
 {{- if eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true" }}
 Splunk OpenTelemetry Collector is installed and configured to send data to Splunk Platform endpoint "{{ .Values.splunkPlatform.endpoint }}".
 {{ end }}


### PR DESCRIPTION
Currently if neither platform is explicitly set, the chart installation will proceed with a broken configuration causing agent pods to crashloop:

```
Error: invalid configuration: no exporter configuration specified in config
2023/01/30 23:47:44 main.go:112: application run finished with error: invalid configuration: no exporter configuration specified in config
```

This occurs because the deprecated `splunkRealm` value was removed from the defaults and [the jsonschema validation passes](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/values.schema.json#L1478). Perhaps unexpectedly but the dep is unmaintained and [likely being replaced](https://github.com/helm/helm/pull/11340)*.

These changes add a final validator in the user notes to fail the installation if the runtime platform vars aren't set:

```
Error: INSTALLATION FAILED: execution error at (splunk-otel-collector/templates/NOTES.txt:3:3): [ERROR] Please set at least one of required `splunkObservability.realm` or `splunkPlatform.endpoint` and corresponding token values to specify the platform(s) to send data.
```

I opted for this approach over obsoleting splunkRealm to minimize the changeset, though it should probably be removed before v1.
