### PR TITLE
re-order k8sattributes processor to precede batch processor

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -188,8 +188,8 @@ service:
       receivers: [otlp, jaeger, zipkin]
       processors:
         - memory_limiter
-        - batch
         - k8sattributes
+        - batch
         - resource/add_cluster_name
         {{- if .Values.extraAttributes.custom }}
         - resource/add_custom_attrs

--- a/rendered/manifests/eks-fargate/configmap-gateway.yaml
+++ b/rendered/manifests/eks-fargate/configmap-gateway.yaml
@@ -190,8 +190,8 @@ data:
           - sapm
           processors:
           - memory_limiter
-          - batch
           - k8sattributes
+          - batch
           - resource/add_cluster_name
           receivers:
           - otlp

--- a/rendered/manifests/eks-fargate/deployment-gateway.yaml
+++ b/rendered/manifests/eks-fargate/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 11254bff3d4b4d3edc9e230185300d53a12000182b7b5b5939ecd980d4c5401c
+        checksum/config: 4bfe8002d655d77fd9c91437a5fdfa6b21f8d1a6888dffc8bd352a18f10b0204
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/gateway-only/configmap-gateway.yaml
+++ b/rendered/manifests/gateway-only/configmap-gateway.yaml
@@ -188,8 +188,8 @@ data:
           - sapm
           processors:
           - memory_limiter
-          - batch
           - k8sattributes
+          - batch
           - resource/add_cluster_name
           receivers:
           - otlp

--- a/rendered/manifests/gateway-only/deployment-gateway.yaml
+++ b/rendered/manifests/gateway-only/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 4afa46bd88f2cf7121863db10251a7840a761fed6d88b12dc2a8b9512b89b9c1
+        checksum/config: 0a71c96ab49070efbab9792ac6bd2a7fd6c79456ffbd8742ee2dda17103c2ae6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/rendered/manifests/network-explorer/configmap-gateway.yaml
+++ b/rendered/manifests/network-explorer/configmap-gateway.yaml
@@ -188,8 +188,8 @@ data:
           - sapm
           processors:
           - memory_limiter
-          - batch
           - k8sattributes
+          - batch
           - resource/add_cluster_name
           receivers:
           - otlp

--- a/rendered/manifests/network-explorer/deployment-gateway.yaml
+++ b/rendered/manifests/network-explorer/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 4afa46bd88f2cf7121863db10251a7840a761fed6d88b12dc2a8b9512b89b9c1
+        checksum/config: 0a71c96ab49070efbab9792ac6bd2a7fd6c79456ffbd8742ee2dda17103c2ae6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
based on this https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor#traces , `k8sattributes` should precede `batch` processor, otherwise the `from: connection` will be missing the IP info

Signed-off-by: Dani Louca <dlouca@splunk.com>