### PR TITLE
Add persistent queues

### DIFF
--- a/examples/persistent-queue-enabled/README.md
+++ b/examples/persistent-queue-enabled/README.md
@@ -1,0 +1,6 @@
+# Example of chart configuration
+
+## Enable persistent queues
+
+This example shows how you can enable persistent queues. This setting works only when `logsEngine` is set
+as `otel`.

--- a/examples/persistent-queue-enabled/persistent-queue-enabled.yaml
+++ b/examples/persistent-queue-enabled/persistent-queue-enabled.yaml
@@ -1,0 +1,18 @@
+clusterName: CHANGEME
+splunkPlatform:
+  endpoint: CHANGEME
+  token: CHANGEME
+  logsEnabled: true
+  metricsEnabled: true
+  metricsIndex: em_metrics
+  sendingQueue:
+    persistentQueueEnabled:
+      logs: true
+agent:
+  resources:
+    limits:
+      memory: 1Gi
+  securityContext:
+    runAsUser: 20000
+    runAsGroup: 20000
+logsEngine: otel

--- a/examples/persistent-queue-enabled/rendered_manifests/clusterRole.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/clusterRole.yaml
@@ -1,0 +1,83 @@
+---
+# Source: splunk-otel-collector/templates/clusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.70.0
+    release: default
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/proxy
+  - pods
+  - pods/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/persistent-queue-enabled/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/clusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: splunk-otel-collector/templates/clusterRoleBinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.70.0
+    release: default
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-splunk-otel-collector
+subjects:
+- kind: ServiceAccount
+  name: default-splunk-otel-collector
+  namespace: default

--- a/examples/persistent-queue-enabled/rendered_manifests/configmap-agent.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/configmap-agent.yaml
@@ -1,0 +1,401 @@
+---
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-agent
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.70.0
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      splunk_hec/platform_logs:
+        disable_compression: true
+        endpoint: CHANGEME
+        index: main
+        max_connections: 200
+        profiling_data_enabled: false
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 300s
+          max_interval: 30s
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+          storage: file_storage/persistent_queue
+        source: kubernetes
+        splunk_app_name: splunk-otel-collector
+        splunk_app_version: 0.70.0
+        timeout: 10s
+        tls:
+          insecure_skip_verify: false
+        token: ${SPLUNK_PLATFORM_HEC_TOKEN}
+      splunk_hec/platform_metrics:
+        disable_compression: true
+        endpoint: CHANGEME
+        index: em_metrics
+        max_connections: 200
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 300s
+          max_interval: 30s
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+        source: kubernetes
+        splunk_app_name: splunk-otel-collector
+        splunk_app_version: 0.70.0
+        timeout: 10s
+        tls:
+          insecure_skip_verify: false
+        token: ${SPLUNK_PLATFORM_HEC_TOKEN}
+    extensions:
+      file_storage:
+        directory: /var/addon/splunk/otel_pos
+      file_storage/persistent_queue:
+        directory: /var/addon/splunk/persist/agent
+      health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
+      memory_ballast:
+        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+      zpages: null
+    processors:
+      batch: null
+      filter/logs:
+        logs:
+          exclude:
+            match_type: strict
+            resource_attributes:
+            - key: splunk.com/exclude
+              value: "true"
+      k8sattributes:
+        extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: namespace
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          - from: pod
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          labels:
+          - key: app
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: ip
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: host.name
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_agent_k8s:
+        attributes:
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 10s
+    receivers:
+      filelog:
+        encoding: utf-8
+        exclude:
+        - /var/log/pods/default_default-splunk-otel-collector*_*/otel-collector/*.log
+        fingerprint_size: 1kb
+        force_flush_period: "0"
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        max_concurrent_files: 1024
+        max_log_size: 1MiB
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: "2006-01-02T15:04:05.999999999-07:00"
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
+          type: add
+          value: ""
+        - parse_from: attributes["log.file.path"]
+          regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - field: resource["com.splunk.sourcetype"]
+          type: add
+          value: EXPR("kube:container:"+resource["k8s.container.name"])
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes["log.file.path"]
+          to: resource["com.splunk.source"]
+          type: move
+        - from: attributes.log
+          id: clean-up-log-record
+          to: body
+          type: move
+        poll_interval: 200ms
+        start_at: beginning
+        storage: file_storage
+      fluentforward:
+        endpoint: 0.0.0.0:8006
+      hostmetrics:
+        collection_interval: 10s
+        scrapers:
+          cpu: null
+          disk: null
+          filesystem: null
+          load: null
+          memory: null
+          network: null
+          paging: null
+          processes: null
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 10s
+        endpoint: ${K8S_NODE_IP}:10250
+        extra_metadata_labels:
+        - container.id
+        metric_groups:
+        - container
+        - pod
+        - node
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus/agent:
+        config:
+          scrape_configs:
+          - job_name: otel-agent
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+      receiver_creator:
+        receivers:
+          smartagent/coredns:
+            config:
+              extraDimensions:
+                metric_source: k8s-coredns
+              port: 9153
+              type: coredns
+            rule: type == "pod" && labels["k8s-app"] == "kube-dns"
+          smartagent/kube-controller-manager:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-controller-manager
+              port: 10257
+              skipVerify: true
+              type: kube-controller-manager
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-controller-manager"
+          smartagent/kubernetes-apiserver:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-apiserver
+              skipVerify: true
+              type: kubernetes-apiserver
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
+          smartagent/kubernetes-proxy:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-proxy
+              port: 10249
+              type: kubernetes-proxy
+            rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
+          smartagent/kubernetes-scheduler:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-scheduler
+              port: 10251
+              type: kubernetes-scheduler
+            rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
+        watch_observers:
+        - k8s_observer
+      signalfx:
+        endpoint: 0.0.0.0:9943
+    service:
+      extensions:
+      - file_storage
+      - file_storage/persistent_queue
+      - health_check
+      - k8s_observer
+      - memory_ballast
+      - zpages
+      pipelines:
+        logs:
+          exporters:
+          - splunk_hec/platform_logs
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - filter/logs
+          - batch
+          - resource
+          - resource/logs
+          - resourcedetection
+          receivers:
+          - filelog
+          - fluentforward
+          - otlp
+        metrics:
+          exporters:
+          - splunk_hec/platform_metrics
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          - resource
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - otlp
+          - receiver_creator
+          - signalfx
+        metrics/agent:
+          exporters:
+          - splunk_hec/platform_metrics
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_agent_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/agent
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/examples/persistent-queue-enabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -1,0 +1,125 @@
+---
+# Source: splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.70.0
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      splunk_hec/platform_metrics:
+        disable_compression: true
+        endpoint: CHANGEME
+        index: em_metrics
+        max_connections: 200
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 300s
+          max_interval: 30s
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 5000
+        source: kubernetes
+        splunk_app_name: splunk-otel-collector
+        splunk_app_version: 0.70.0
+        timeout: 10s
+        tls:
+          insecure_skip_verify: false
+        token: ${SPLUNK_PLATFORM_HEC_TOKEN}
+    extensions:
+      file_storage/persistent_queue:
+        directory: /var/addon/splunk/persist/clusterReceiver
+      health_check: null
+      memory_ballast:
+        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+    processors:
+      batch: null
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: metric_source
+          value: kubernetes
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_collector_k8s:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/k8s_cluster:
+        attributes:
+        - action: insert
+          key: receiver
+          value: k8scluster
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 10s
+    receivers:
+      k8s_cluster:
+        auth_type: serviceAccount
+      prometheus/k8s_cluster_receiver:
+        config:
+          scrape_configs:
+          - job_name: otel-k8s-cluster-receiver
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+    service:
+      extensions:
+      - health_check
+      - memory_ballast
+      - file_storage/persistent_queue
+      pipelines:
+        metrics:
+          exporters:
+          - splunk_hec/platform_metrics
+          processors:
+          - memory_limiter
+          - batch
+          - resource
+          - resource/k8s_cluster
+          receivers:
+          - k8s_cluster
+        metrics/collector:
+          exporters:
+          - splunk_hec/platform_metrics
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_collector_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/k8s_cluster_receiver
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/examples/persistent-queue-enabled/rendered_manifests/daemonset.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/daemonset.yaml
@@ -1,0 +1,273 @@
+---
+# Source: splunk-otel-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: default-splunk-otel-collector-agent
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.70.0
+    release: default
+    heritage: Helm
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        release: default
+      annotations:
+        checksum/config: 7d9bec6cfa2e5ff6b20c70ae6efaf461cacdcb267c947fc66f786c04ef4a7da0
+        kubectl.kubernetes.io/default-container: otel-collector
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      initContainers:
+        - name: migrate-checkpoint
+          image: quay.io/signalfx/splunk-otel-collector:0.70.0
+          imagePullPolicy: IfNotPresent
+          command: ["/migratecheckpoint"]
+          securityContext:
+            runAsUser: 0
+          env:
+          - name: CONTAINER_LOG_PATH_FLUENTD
+            value: "/var/log/splunk-fluentd-containers.log.pos"
+          - name: CONTAINER_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_filelog_"
+          - name: CUSTOM_LOG_PATH_FLUENTD
+            value: "/var/log/splunk-fluentd-*.pos"
+          - name: CUSTOM_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_filelog_"
+          - name: CUSTOM_LOG_CAPTURE_REGEX
+            value: '\/var\/log\/splunk\-fluentd\-(?P<name>[\w0-9-_]+)\.pos'
+          - name: JOURNALD_LOG_PATH_FLUENTD
+            value: "/var/log/splunkd-fluentd-journald-*.pos.json"
+          - name: JOURNALD_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_journald_"
+          - name: JOURNALD_LOG_CAPTURE_REGEX
+            value: '\/splunkd\-fluentd\-journald\-(?P<name>[\w0-9-_]+)\.pos\.json'
+          volumeMounts:
+            - name: checkpoint
+              mountPath: /var/addon/splunk/otel_pos
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+        - name: patch-log-dirs
+          image: registry.access.redhat.com/ubi9/ubi
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', '
+          mkdir -p /var/addon/splunk/otel_pos;
+          chown -Rv 20000:20000 /var/addon/splunk/otel_pos;
+          chmod -v g+rwxs /var/addon/splunk/otel_pos;
+          if [ -d "/var/lib/docker/containers" ];
+          then
+              setfacl -n -Rm d:m::rx,m::rx,d:g:20000:rx,g:20000:rx /var/lib/docker/containers;
+          fi;
+          if [ -d "/var/log/crio/pods" ];
+          then
+              setfacl -n -Rm d:m::rx,m::rx,d:g:20000:rx,g:20000:rx /var/log/crio/pods;
+          fi;
+          if [ -d "/var/log/pods" ];
+          then
+              setfacl -n -Rm d:m::rx,m::rx,d:g:20000:rx,g:20000:rx /var/log/pods;
+          fi;
+          mkdir -p /var/addon/splunk/persist/agent;
+          chown -Rv 20000:20000 /var/addon/splunk/persist/agent;
+          chmod -v g+rwxs /var/addon/splunk/persist/agent;
+          setfacl -n -Rm d:m::rx,m::rx,d:g:20000:rx,g:20000:rx /var/addon/splunk/persist/agent;']
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: checkpoint
+              mountPath: /var/addon/splunk/otel_pos
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+            - name: persistent-queue
+              mountPath: /var/addon/splunk/persist/agent
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        ports:
+        - name: fluentforward
+          containerPort: 8006
+          hostPort: 8006
+          protocol: TCP
+        - name: otlp
+          containerPort: 4317
+          hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
+          protocol: TCP
+        - name: signalfx
+          containerPort: 9943
+          hostPort: 9943
+          protocol: TCP
+        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsGroup: 20000
+          runAsUser: 20000
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "1024"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NODE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_PLATFORM_HEC_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: splunk-otel-collector
+                key: splunk_platform_hec_token
+          # Env variables for host metrics receiver
+          - name: HOST_PROC
+            value: /hostfs/proc
+          - name: HOST_SYS
+            value: /hostfs/sys
+          - name: HOST_ETC
+            value: /hostfs/etc
+          - name: HOST_VAR
+            value: /hostfs/var
+          - name: HOST_RUN
+            value: /hostfs/run
+          - name: HOST_DEV
+            value: /hostfs/dev
+          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
+          # is resolved fall back to previous gopsutil mountinfo path:
+          # https://github.com/shirou/gopsutil/issues/1271
+          - name: HOST_PROC_MOUNTINFO
+            value: /proc/self/mountinfo
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1Gi
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-configmap
+        - mountPath: /hostfs/dev
+          name: host-dev
+          readOnly: true
+        - mountPath: /hostfs/etc
+          name: host-etc
+          readOnly: true
+        - mountPath: /hostfs/proc
+          name: host-proc
+          readOnly: true
+        - mountPath: /hostfs/run/udev/data
+          name: host-run-udev-data
+          readOnly: true
+        - mountPath: /hostfs/sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /hostfs/var/run/utmp
+          name: host-var-run-utmp
+          readOnly: true
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: checkpoint
+          mountPath: /var/addon/splunk/otel_pos
+        - name: persistent-queue
+          mountPath: /var/addon/splunk/persist/agent
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: checkpoint
+        hostPath:
+          path: /var/addon/splunk/otel_pos
+          type: DirectoryOrCreate
+      - name: persistent-queue
+        hostPath:
+          path: /var/addon/splunk/persist/agent
+          type: DirectoryOrCreate
+      - name: host-dev
+        hostPath:
+          path: /dev
+      - name: host-etc
+        hostPath:
+          path: /etc
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-var-run-utmp
+        hostPath:
+          path: /var/run/utmp
+      - name: otel-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-agent
+          items:
+            - key: relay
+              path: relay.yaml

--- a/examples/persistent-queue-enabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -1,0 +1,116 @@
+---
+# Source: splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: default-splunk-otel-collector-k8s-cluster-receiver
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+    app: splunk-otel-collector
+    component: otel-k8s-cluster-receiver
+    chart: splunk-otel-collector-0.70.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-k8s-cluster-receiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      component: otel-k8s-cluster-receiver
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        component: otel-k8s-cluster-receiver
+        release: default
+      annotations:
+        checksum/config: 95f8c67d62dd6c5e67013ca89c37ad90515abac102325798592bc0ccf301ddb9
+    spec:
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+          kubernetes.io/os: linux
+      initContainers:
+        - name: patch-log-dirs
+          image: registry.access.redhat.com/ubi9/ubi
+          imagePullPolicy: IfNotPresent
+          command: ['sh', '-c', '
+          mkdir -p /var/addon/splunk/persist/clusterReceiver;
+          chown -Rv 20000:20000 /var/addon/splunk/persist/clusterReceiver;
+          chmod -v g+rwxs /var/addon/splunk/persist/clusterReceiver;
+          setfacl -n -Rm d:m::rx,m::rx,d:g:20000:rx,g:20000:rx /var/addon/splunk/persist/clusterReceiver;']
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: persistent-queue
+              mountPath: /var/addon/splunk/persist/clusterReceiver
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_PLATFORM_HEC_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: splunk-otel-collector
+                key: splunk_platform_hec_token
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - name: persistent-queue
+          mountPath: /var/addon/splunk/persist/clusterReceiver
+        - mountPath: /conf
+          name: collector-configmap
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: collector-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+          items:
+            - key: relay
+              path: relay.yaml
+      - name: persistent-queue
+        hostPath:
+          path: /var/addon/splunk/persist/clusterReceiver
+          type: DirectoryOrCreate

--- a/examples/persistent-queue-enabled/rendered_manifests/revert-patch-log-dirs-hook.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/revert-patch-log-dirs-hook.yaml
@@ -1,0 +1,90 @@
+---
+# Source: splunk-otel-collector/templates/revert-patch-log-dirs-hook.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: default-splunk-otel-collector-revert-patch-log-dir
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+  - name: revert-patch-log-dirs
+    image: registry.access.redhat.com/ubi9/ubi
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      runAsUser: 0
+    command: ['sh', '-c', '
+    setfacl --recursive --remove-all  /var/addon/splunk/otel_pos;
+    setfacl --recursive --remove-all  /var/log;
+    if [ -d "/var/lib/docker/containers" ];
+    then
+        setfacl --recursive --remove-all  /var/lib/docker/containers;
+    fi;
+    if [ -d "/var/log/crio/pods" ];
+    then
+        setfacl --recursive --remove-all  /var/log/crio/pods;
+    fi;
+    if [ -d "/var/log/pods" ];
+    then
+        setfacl --recursive --remove-all  /var/log/pods;
+    fi;
+    if [ -d "/var/addon/splunk/persist/agent" ];
+    then
+      setfacl --recursive --remove-all /var/addon/splunk/persist/agent;
+    fi;
+    if [ -d "/var/addon/splunk/persist/gateway" ];
+    then
+      setfacl --recursive --remove-all /var/addon/splunk/persist/gateway;
+    fi;
+    if [ -d "/var/addon/splunk/persist/clusterReceiver" ];
+    then
+      setfacl --recursive --remove-all /var/addon/splunk/persist/clusterReceiver;
+    fi;']
+    volumeMounts:
+      - name: checkpoint
+        mountPath: /var/addon/splunk/otel_pos
+      - name: fluentd-checkpoint-dir
+        mountPath: /var/log
+      - name: varlog-crio-pods
+        mountPath: /var/log/crio/pods
+      - name: varlog-pods
+        mountPath: /var/log/pods
+      - name: varlibdockercontainers
+        mountPath: /var/lib/docker/containers
+      - name: persistent-queue-agent
+        mountPath: /var/addon/splunk/persist/agent
+      - name: persistent-queue-cluster-receiver
+        mountPath: /var/addon/splunk/persist/clusterReceiver
+  volumes:
+    - name: checkpoint
+      hostPath:
+        path: /var/addon/splunk/otel_pos
+    - name: varlog-crio-pods
+      hostPath:
+        path: /var/log/crio/pods
+    - name: varlog-pods
+      hostPath:
+        path: /var/log/pods
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+    - name: fluentd-checkpoint-dir
+      hostPath:
+        path: /var/log
+        type: DirectoryOrCreate
+    - name: persistent-queue-agent
+      hostPath:
+          path: /var/addon/splunk/persist/agent
+          type: DirectoryOrCreate
+    - name: persistent-queue-cluster-receiver
+      hostPath:
+          path: /var/addon/splunk/persist/clusterReceiver
+          type: DirectoryOrCreate

--- a/examples/persistent-queue-enabled/rendered_manifests/secret-splunk.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/secret-splunk.yaml
@@ -1,0 +1,19 @@
+---
+# Source: splunk-otel-collector/templates/secret-splunk.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.70.0
+    release: default
+    heritage: Helm
+type: Opaque
+data:
+  splunk_platform_hec_token: Q0hBTkdFTUU=

--- a/examples/persistent-queue-enabled/rendered_manifests/serviceAccount.yaml
+++ b/examples/persistent-queue-enabled/rendered_manifests/serviceAccount.yaml
@@ -1,0 +1,16 @@
+---
+# Source: splunk-otel-collector/templates/serviceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.70.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.70.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.70.0
+    release: default
+    heritage: Helm

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -428,3 +428,11 @@ Whether clusterReceiver should be enabled
 {{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
 {{- and $clusterReceiver.enabled (or (eq (include "splunk-otel-collector.metricsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true")) -}}
 {{- end -}}
+
+
+{{/*
+Whether persistentQueue should be enabled
+*/}}
+{{- define "splunk-otel-collector.persistentQueueEnabled" -}}
+{{- or .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.logs .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.metrics  -}}
+{{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -213,6 +213,10 @@ splunk_hec/platform_logs:
     enabled:  {{ .Values.splunkPlatform.sendingQueue.enabled }}
     num_consumers: {{ .Values.splunkPlatform.sendingQueue.numConsumers }}
     queue_size: {{ .Values.splunkPlatform.sendingQueue.queueSize }}
+    {{- if .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.logs }}
+    storage: file_storage/persistent_queue
+    {{- end }}
+
 {{- end }}
 
 {{/*
@@ -249,6 +253,9 @@ splunk_hec/platform_metrics:
     enabled:  {{ .Values.splunkPlatform.sendingQueue.enabled }}
     num_consumers: {{ .Values.splunkPlatform.sendingQueue.numConsumers }}
     queue_size: {{ .Values.splunkPlatform.sendingQueue.queueSize }}
+    {{- if .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.metrics }}
+    storage: file_storage/persistent_queue
+    {{- end }}
 {{- end }}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -11,6 +11,11 @@ extensions:
     directory: {{ .Values.logsCollection.checkpointPath }}
   {{- end }}
 
+  {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+  file_storage/persistent_queue:
+    directory: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent
+  {{- end }}
+
   memory_ballast:
     size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
@@ -620,6 +625,9 @@ service:
   extensions:
     {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (eq .Values.logsEngine "otel") }}
     - file_storage
+    {{- end }}
+    {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+    - file_storage/persistent_queue
     {{- end }}
     - health_check
     - k8s_observer

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -12,6 +12,11 @@ extensions:
       endpoint: {{ include "splunk-otel-collector.o11yApiUrl" . }}
   {{- end }}
 
+  {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+  file_storage/persistent_queue:
+    directory: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway
+  {{- end }}
+
   memory_ballast:
     size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
@@ -172,6 +177,9 @@ service:
     metrics:
       address: 0.0.0.0:8889
   extensions:
+    {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+    - file_storage/persistent_queue
+    {{- end }}
     - health_check
     - memory_ballast
     - zpages

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -18,6 +18,11 @@ extensions:
     observe_nodes: true
   {{- end }}
 
+  {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+  file_storage/persistent_queue:
+    directory: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver
+  {{- end }}
+
 receivers:
   # Prometheus receiver scraping metrics from the pod itself, both otel and fluentd
   prometheus/k8s_cluster_receiver:
@@ -197,11 +202,15 @@ service:
   telemetry:
     metrics:
       address: 0.0.0.0:8889
-  {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
-  extensions: [health_check, memory_ballast, k8s_observer]
-  {{- else }}
-  extensions: [health_check, memory_ballast]
-  {{- end }}
+  extensions:
+    - health_check
+    - memory_ballast
+    {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+    - k8s_observer
+    {{- end }}
+    {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+    - file_storage/persistent_queue
+    {{- end }}
   pipelines:
     {{- if or (eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true") (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
     # k8s metrics pipeline

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -135,27 +135,39 @@ spec:
           imagePullPolicy: {{ .Values.image.initPatchLogDirs.pullPolicy }}
           command: ['sh', '-c', '
           mkdir -p {{ .Values.logsCollection.checkpointPath }};
-          chown -Rv {{ $agent.securityContext.runAsUser | default 20000 }}:{{ $agent.securityContext.runAsGroup | default 20000 }} {{ .Values.logsCollection.checkpointPath }};
+          chown -Rv {{ $agent.securityContext.runAsUser | default 999 }}:{{ $agent.securityContext.runAsGroup | default 999 }} {{ .Values.logsCollection.checkpointPath }};
           chmod -v g+rwxs {{ .Values.logsCollection.checkpointPath }};
           {{ if .Values.logsCollection.containers.enabled -}}
           if [ -d "/var/lib/docker/containers" ];
           then
-              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/lib/docker/containers;
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx /var/lib/docker/containers;
           fi;
           if [ -d "/var/log/crio/pods" ];
           then
-              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/log/crio/pods;
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx /var/log/crio/pods;
           fi;
           if [ -d "/var/log/pods" ];
           then
-              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx /var/log/pods;
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx /var/log/pods;
           fi;
           {{- end }}
           {{- if .Values.logsCollection.journald.enabled }}
           if [ -d "{{ .Values.logsCollection.journald.directory }}" ];
           then
-              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 20000 }}:rx {{ .Values.logsCollection.journald.directory }};
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx {{ .Values.logsCollection.journald.directory }};
           fi;
+          {{- end }}
+          {{- if .Values.logsCollection.journald.enabled }}
+          if [ -d "{{ .Values.logsCollection.journald.directory }}" ];
+          then
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx {{ .Values.logsCollection.journald.directory }};
+          fi;
+          {{- end }}
+          {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+          mkdir -p {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent;
+          chown -Rv {{ $agent.securityContext.runAsUser | default 999 }}:{{ $agent.securityContext.runAsGroup | default 999 }} {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent;
+          chmod -v g+rwxs {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent;
+          setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent;
           {{- end }}']
           securityContext:
             runAsUser: 0
@@ -167,6 +179,10 @@ spec:
               mountPath: /var/log
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
+            {{- end }}
+            {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+            - name: persistent-queue
+              mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent
             {{- end }}
         {{- end }}
         {{- end }}
@@ -390,6 +406,10 @@ spec:
         {{- end }}
         - name: checkpoint
           mountPath: {{ .Values.logsCollection.checkpointPath }}
+        {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+        - name: persistent-queue
+          mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent
+        {{- end }}
         {{- if .Values.logsCollection.journald.enabled}}
         - mountPath: {{.Values.logsCollection.journald.directory}}
           name: journaldlogs
@@ -448,6 +468,12 @@ spec:
         hostPath:
           path: {{ .Values.logsCollection.checkpointPath }}
           type: DirectoryOrCreate
+      {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+      - name: persistent-queue
+        hostPath:
+          path: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent
+          type: DirectoryOrCreate
+      {{- end }}
       {{- if .Values.logsCollection.journald.enabled}}
       - name: journaldlogs
         hostPath:

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -81,8 +81,9 @@ spec:
       securityContext:
         {{ toYaml $clusterReceiver.securityContext | nindent 8 }}
       {{- end }}
-      {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+      {{- if or (eq (include "splunk-otel-collector.distribution" .) "eks/fargate") (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
       initContainers:
+        {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
         - name: cluster-receiver-node-discoverer
           image: public.ecr.aws/amazonlinux/amazonlinux:latest
           imagePullPolicy: IfNotPresent
@@ -103,6 +104,22 @@ spec:
               mountPath: /splunk-messages
             - mountPath: /conf
               name: collector-configmap
+        {{- end }}
+        {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+        - name: patch-log-dirs
+          image: {{ template "splunk-otel-collector.image.initPatchLogDirs" . }}
+          imagePullPolicy: {{ .Values.image.initPatchLogDirs.pullPolicy }}
+          command: ['sh', '-c', '
+          mkdir -p {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver;
+          chown -Rv {{ $clusterReceiver.securityContext.runAsUser | default 20000 }}:{{ $clusterReceiver.securityContext.runAsGroup | default 20000 }} {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver;
+          chmod -v g+rwxs {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver;
+          setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $clusterReceiver.securityContext.runAsGroup | default 20000 }}:rx,g:{{ $clusterReceiver.securityContext.runAsGroup | default 20000 }}:rx {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver;']
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: persistent-queue
+              mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver
+        {{- end }}
       {{- end }}
       containers:
       - name: otel-collector
@@ -188,6 +205,10 @@ spec:
           mountPath: /otel/etc
           readOnly: true
         {{- end }}
+        {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+        - name: persistent-queue
+          mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver
+        {{- end }}
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: collector-configmap
         {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
@@ -205,6 +226,12 @@ spec:
           items:
             - key: relay
               path: relay.yaml
+      {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+      - name: persistent-queue
+        hostPath:
+          path: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver
+          type: DirectoryOrCreate
+      {{- end }}
       {{- if or .Values.splunkPlatform.clientCert .Values.splunkPlatform.clientKey .Values.splunkPlatform.caFile }}
       - name: secret
         secret:

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -61,6 +61,22 @@ spec:
       securityContext:
         {{ toYaml $gateway.securityContext | nindent 8 }}
       {{- end }}
+      {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+      initContainers:
+        - name: patch-log-dirs
+          image: {{ template "splunk-otel-collector.image.initPatchLogDirs" . }}
+          imagePullPolicy: {{ .Values.image.initPatchLogDirs.pullPolicy }}
+          command: ['sh', '-c', '
+          mkdir -p {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway;
+          chown -Rv {{ $gateway.securityContext.runAsUser | default 999 }}:{{ $gateway.securityContext.runAsGroup | default 999 }} {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway;
+          chmod -v g+rwxs {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway;
+          setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $gateway.securityContext.runAsGroup | default 999 }}:rx,g:{{ $gateway.securityContext.runAsGroup | default 999 }}:rx {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway;']
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: persistent-queue
+              mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway
+      {{- end }}
       containers:
       - name: otel-collector
         command:
@@ -148,6 +164,10 @@ spec:
           mountPath: /otel/etc
           readOnly: true
         {{- end }}
+        {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+        - name: persistent-queue
+          mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway
+        {{- end }}
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: collector-configmap
         {{- if $gateway.extraVolumeMounts }}
@@ -161,6 +181,12 @@ spec:
           items:
             - key: relay
               path: relay.yaml
+      {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+      - name: persistent-queue
+        hostPath:
+          path: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway
+          type: DirectoryOrCreate
+      {{- end }}
       {{- if or .Values.splunkPlatform.clientCert .Values.splunkPlatform.clientKey .Values.splunkPlatform.caFile }}
       - name: secret
         secret:

--- a/helm-charts/splunk-otel-collector/templates/revert-patch-log-dirs-hook.yaml
+++ b/helm-charts/splunk-otel-collector/templates/revert-patch-log-dirs-hook.yaml
@@ -1,0 +1,135 @@
+{{- if or (and (.Values.fluentd.securityContext.runAsUser) (.Values.fluentd.securityContext.runAsGroup)) (and (.Values.agent.securityContext.runAsUser) (.Values.agent.securityContext.runAsGroup)) (.Values.splunkPlatform.sendingQueue.persistentQueueEnabled.logs) (.Values.splunkPlatform.sendingQueue.persistentQueueEnabled.metrics) }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ template "splunk-otel-collector.fullname" . }}-revert-patch-log-dir
+  labels:
+    {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+  - name: revert-patch-log-dirs
+    image: {{ template "splunk-otel-collector.image.initPatchLogDirs" . }}
+    imagePullPolicy: {{ .Values.image.initPatchLogDirs.pullPolicy }}
+    securityContext:
+      runAsUser: 0
+    command: ['sh', '-c', '
+    {{- if or (and (.Values.fluentd.securityContext.runAsUser) (.Values.fluentd.securityContext.runAsGroup)) (and (.Values.agent.securityContext.runAsUser) (.Values.agent.securityContext.runAsGroup)) }}
+    setfacl --recursive --remove-all  {{ .Values.logsCollection.checkpointPath }};
+    setfacl --recursive --remove-all  {{ dir .Values.fluentd.config.posFilePrefix }};
+    {{ if .Values.logsCollection.containers.enabled -}}
+    if [ -d "/var/lib/docker/containers" ];
+    then
+        setfacl --recursive --remove-all  /var/lib/docker/containers;
+    fi;
+    if [ -d "/var/log/crio/pods" ];
+    then
+        setfacl --recursive --remove-all  /var/log/crio/pods;
+    fi;
+    if [ -d "/var/log/pods" ];
+    then
+        setfacl --recursive --remove-all  /var/log/pods;
+    fi;
+    {{- end }}
+    {{- if .Values.logsCollection.journald.enabled }}
+    if [ -d "{{ .Values.logsCollection.journald.directory }}" ];
+    then
+        setfacl --recursive --remove-all d:m::rx,m::rx,d:g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx {{ .Values.logsCollection.journald.directory }};
+    fi;
+    {{- end }}
+    {{- end }}
+    {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+    if [ -d "{{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent" ];
+    then
+      setfacl --recursive --remove-all {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent;
+    fi;
+    if [ -d "{{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway" ];
+    then
+      setfacl --recursive --remove-all {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway;
+    fi;
+    if [ -d "{{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver" ];
+    then
+      setfacl --recursive --remove-all {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver;
+    fi;
+    {{- end }}']
+    volumeMounts:
+      {{- if or (and (.Values.fluentd.securityContext.runAsUser) (.Values.fluentd.securityContext.runAsGroup)) (and (.Values.agent.securityContext.runAsUser) (.Values.agent.securityContext.runAsGroup)) }}
+      - name: checkpoint
+        mountPath: {{ .Values.logsCollection.checkpointPath }}
+      - name: fluentd-checkpoint-dir
+        mountPath: {{ dir .Values.fluentd.config.posFilePrefix }}
+      {{- if .Values.logsCollection.containers.enabled }}
+      - name: varlog-crio-pods
+        mountPath: /var/log/crio/pods
+      - name: varlog-pods
+        mountPath: /var/log/pods
+      - name: varlibdockercontainers
+        mountPath: /var/lib/docker/containers
+      {{- end }}
+      {{- if .Values.logsCollection.journald.enabled }}
+      - name: journaldlogs
+        mountPath: {{.Values.logsCollection.journald.directory}}
+      {{- end }}
+      {{- end }}
+      {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+      {{- if .Values.agent.enabled }}
+      - name: persistent-queue-agent
+        mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent
+      {{- end }}
+      {{- if .Values.gateway.enabled }}
+      - name: persistent-queue-gateway
+        mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway
+      {{- end }}
+      {{- if .Values.clusterReceiver.enabled }}
+      - name: persistent-queue-cluster-receiver
+        mountPath: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver
+      {{- end }}
+      {{- end }}
+  volumes:
+    {{- if or (and (.Values.fluentd.securityContext.runAsUser) (.Values.fluentd.securityContext.runAsGroup)) (and (.Values.agent.securityContext.runAsUser) (.Values.agent.securityContext.runAsGroup)) }}
+    - name: checkpoint
+      hostPath:
+        path: {{ .Values.logsCollection.checkpointPath }}
+    - name: varlog-crio-pods
+      hostPath:
+        path: /var/log/crio/pods
+    - name: varlog-pods
+      hostPath:
+        path: /var/log/pods
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+    - name: fluentd-checkpoint-dir
+      hostPath:
+        path: {{ dir .Values.fluentd.config.posFilePrefix }}
+        type: DirectoryOrCreate
+    {{- if .Values.logsCollection.journald.enabled}}
+    - name: journaldlogs
+      hostPath:
+        path: {{.Values.logsCollection.journald.directory}}
+    {{- end}}
+    {{- end }}
+    {{- if (eq (include "splunk-otel-collector.persistentQueueEnabled" .) "true") }}
+    {{- if .Values.agent.enabled }}
+    - name: persistent-queue-agent
+      hostPath:
+          path: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/agent
+          type: DirectoryOrCreate
+    {{- end }}
+    {{- if .Values.gateway.enabled }}
+    - name: persistent-queue-gateway
+      hostPath:
+          path: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/gateway
+          type: DirectoryOrCreate
+    {{- end }}
+    {{- if .Values.clusterReceiver.enabled }}
+    - name: persistent-queue-cluster-receiver
+      hostPath:
+          path: {{ .Values.splunkPlatform.sendingQueue.persistentQueueEnabled.storagePath }}/clusterReceiver
+          type: DirectoryOrCreate
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -132,6 +132,20 @@
             },
             "queueSize": {
               "type": "integer"
+            },
+            "persistentQueueEnabled": {
+              "type": "object",
+              "properties": {
+                "logs": {
+                  "type": "boolean"
+                },
+                "metrics": {
+                  "type": "boolean"
+                },
+                "storagePath": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -99,6 +99,18 @@ splunkPlatform:
     #   requests_per_second is the average number of requests per seconds.
     queueSize: 5000
 
+    # When enabled, it uses file_storage extension to persist the queue data.
+    # This can be used to prevent data-loss during restart
+    # NOTE: The File Storage extension will persist state to the node's local file system.
+    # While using the persistent queue it is advised to increase memory limit for agent (agent.resources.limits.memory)
+    # to 1Gi.
+    persistentQueueEnabled:
+      # Specifies whether to persist log data.
+      logs: false
+      # Specifies whether to persist metric data.
+      metrics: false
+      storagePath: "/var/addon/splunk/persist"
+
 ################################################################################
 # Splunk Observability configuration
 ################################################################################


### PR DESCRIPTION
Things included in this PR:

1. enable persistent queues configuration in the helm chart
2. post delete hook which deletes ACLs set for directories used by agent, gateway and clusterReceiver while those pods run as non-root users

Continuation of this PR: https://github.com/signalfx/splunk-otel-collector-chart/pull/668