### PR TITLE
Update Kubernetes to 1.26 in our functional tests

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -20,8 +20,8 @@ jobs:
       CI_INDEX_EVENTS: ci_events
       CI_INDEX_METRICS: ci_metrics
       CONTAINER_RUNTIME: ${{ matrix.container_runtime }}
-      KUBERNETES_VERSION: v1.21.2
-      MINIKUBE_VERSION: v1.22.0
+      KUBERNETES_VERSION: v1.26.0
+      MINIKUBE_VERSION: v1.29.0
 
     steps:
       - name: Checkout
@@ -46,7 +46,7 @@ jobs:
           sudo sysctl fs.protected_regular=0
           # Start Minikube and Wait
           minikube start --container-runtime=${CONTAINER_RUNTIME} --cpus 2 --memory 4096 --kubernetes-version=${KUBERNETES_VERSION} --no-vtx-check
-          kubectl apply -f https://docs.projectcalico.org/v3.14/manifests/calico.yaml
+          kubectl apply -f https://docs.projectcalico.org/v3.23/manifests/calico.yaml
           export JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
           until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do
             sleep 1;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Update Kubernetes to 1.26 in our functional tests ([#678](https://github.com/signalfx/splunk-otel-collector-chart/pull/678)
 - Added examples for supported Kubernetes distributions and Kubernetes clusters with windows nodes ([#663](https://github.com/signalfx/splunk-otel-collector-chart/pull/663)
 - Refactored the examples and rendered directories into one for better usability ([#658](https://github.com/signalfx/splunk-otel-collector-chart/pull/658)
 


### PR DESCRIPTION
Updating our tests to use the latest Kubernetes (1.26). 

I've been trying to figure ot how we can have Dependabot handle these updates for this project, however, I don't have a solution for this yet. Updating this dependency manually for now.