### PR TITLE
Prepare release v0.71.0

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -20,8 +20,8 @@ jobs:
       CI_INDEX_EVENTS: ci_events
       CI_INDEX_METRICS: ci_metrics
       CONTAINER_RUNTIME: ${{ matrix.container_runtime }}
-      KUBERNETES_VERSION: v1.21.2
-      MINIKUBE_VERSION: v1.22.0
+      KUBERNETES_VERSION: v1.25.6
+      MINIKUBE_VERSION: v1.29.0
 
     steps:
       - name: Checkout

--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -20,8 +20,8 @@ jobs:
       CI_INDEX_EVENTS: ci_events
       CI_INDEX_METRICS: ci_metrics
       CONTAINER_RUNTIME: ${{ matrix.container_runtime }}
-      KUBERNETES_VERSION: v1.25.6
-      MINIKUBE_VERSION: v1.29.0
+      KUBERNETES_VERSION: v1.21.2
+      MINIKUBE_VERSION: v1.22.0
 
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fix naming convention issues ([#660](https://github.com/signalfx/splunk-otel-collector-chart/pull/660))
+- Translation of `k8s.pod.labels.app` attribute to SCK format ([#660](https://github.com/signalfx/splunk-otel-collector-chart/pull/660))
 
 ## [0.70.0] - 2023-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## [0.71.0] - 2023-03-01
+
 ### Added
 
-- Added examples for supported Kubernetes distributions and Kubernetes clusters with windows nodes ([#663](https://github.com/signalfx/splunk-otel-collector-chart/pull/663)
-- Refactored the examples and rendered directories into one for better usability ([#658](https://github.com/signalfx/splunk-otel-collector-chart/pull/658)
+- Added examples for supported Kubernetes distributions and Kubernetes clusters with windows nodes ([#663](https://github.com/signalfx/splunk-otel-collector-chart/pull/663))
+- Refactored the examples and rendered directories into one for better usability ([#658](https://github.com/signalfx/splunk-otel-collector-chart/pull/658))
 
-## [0.70.0] - 2022-01-31
+### Changed
+
+- Docker metadata turned off by default ([#655](https://github.com/signalfx/splunk-otel-collector-chart/pull/665))
+
+### Fixed
+
+- Fix naming convention issues ([#660](https://github.com/signalfx/splunk-otel-collector-chart/pull/660))
+
+## [0.70.0] - 2023-01-31
 
 ### Added
 
@@ -25,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Limit `clusterReceiver.eventsEnabled` deprecation warning to feature users ([#648](https://github.com/signalfx/splunk-otel-collector-chart/pull/648))
 - Fix noop validation for missing platform info ([#649](https://github.com/signalfx/splunk-otel-collector-chart/pull/649))
 
-## [0.68.0] - 2022-01-25
+## [0.68.0] - 2023-01-25
 
 ### Added
 

--- a/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/add-receiver-creator/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 38479c03e5add2b8a5fec907700bf8dd3649d9aa584dd86280ff9d6f34812316
+        checksum/config: 5a9aa4bb98acaff2f983f7946c2524c4dec667981bf7d5849540bcfaa3897dd5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-receiver-creator/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/add-receiver-creator/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/add-sampler/rendered_manifests/clusterRole.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/add-sampler/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: fb7b212cc914fce0178fb811a13ec32be64b73489d87cef5249462f9b9d29e2b
+        checksum/config: cd9c92667b7fae85b2274893f2793c42251b115c8ace97dcbc48436ce29d00b3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-sampler/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-sampler/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/add-sampler/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-sampler/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/collector-agent-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f24285909af0884c7557482977a7a54aa1294e3a121a5cf78d7572a19fc5bafd
+        checksum/config: f9caec88f9726beb6d37778103b5ca2069abb3d2f6c9f03b19464ccf3513c721
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-agent-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-agent-only/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/collector-agent-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-agent-only/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c4743fac640a0ee010545732c3252ea72f78ec092f66f614314e541eb8687a3d
+        checksum/config: 0f34f8fc2ec6f5c4409297d6cdf151cce6055d682d5eb306664f314cc0c7968a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-cluster-receiver-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/collector-cluster-receiver-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/collector-gateway-only-advanced/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-only-advanced/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/collector-gateway-only-advanced/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-gateway-only-advanced/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/collector-gateway-only-advanced/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only-advanced/rendered_manifests/configmap-gateway.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/collector-gateway-only-advanced/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only-advanced/rendered_manifests/deployment-gateway.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 0a71c96ab49070efbab9792ac6bd2a7fd6c79456ffbd8742ee2dda17103c2ae6
+        checksum/config: b388f071255a2f26a3b63b0c38087dd540b24cd86b514fba494b90e32a13a398
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-gateway-only-advanced/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-gateway-only-advanced/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/collector-gateway-only-advanced/rendered_manifests/service.yaml
+++ b/examples/collector-gateway-only-advanced/rendered_manifests/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector

--- a/examples/collector-gateway-only-advanced/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-gateway-only-advanced/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/collector-gateway-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 0a71c96ab49070efbab9792ac6bd2a7fd6c79456ffbd8742ee2dda17103c2ae6
+        checksum/config: b388f071255a2f26a3b63b0c38087dd540b24cd86b514fba494b90e32a13a398
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-gateway-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/collector-gateway-only/rendered_manifests/service.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector

--- a/examples/collector-gateway-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/crio-logging/rendered_manifests/clusterRole.yaml
+++ b/examples/crio-logging/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/crio-logging/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/crio-logging/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f24285909af0884c7557482977a7a54aa1294e3a121a5cf78d7572a19fc5bafd
+        checksum/config: f9caec88f9726beb6d37778103b5ca2069abb3d2f6c9f03b19464ccf3513c721
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/crio-logging/rendered_manifests/secret-splunk.yaml
+++ b/examples/crio-logging/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/crio-logging/rendered_manifests/serviceAccount.yaml
+++ b/examples/crio-logging/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/default/rendered_manifests/clusterRole.yaml
+++ b/examples/default/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/default/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/default/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f24285909af0884c7557482977a7a54aa1294e3a121a5cf78d7572a19fc5bafd
+        checksum/config: f9caec88f9726beb6d37778103b5ca2069abb3d2f6c9f03b19464ccf3513c721
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/default/rendered_manifests/secret-splunk.yaml
+++ b/examples/default/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/default/rendered_manifests/serviceAccount.yaml
+++ b/examples/default/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/distribution-aks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/distribution-aks/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d1fd269e6b17d6b8512868f27e54053bc88559066e638d0f15b4e4f273d8ebd1
+        checksum/config: 1cc5b4a7172498092d8052a35659a314ef053fc91fea88bd03202b6091b6988f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 921dc0fdb922c7db0d923f8bd0716f97b4609c76b11b740043f3d305d4d8112c
+        checksum/config: bf8e67c5dec42a31b3ba743cb3528900fd3648a2bfe4168038afd1331a5b2032
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-aks/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-aks/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/distribution-aks/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-aks/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-cr-node-discoverer-script
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3d3f127636ca0e5fc74df736ee6a5a09fe58d1fdea833b73ecfd7b7264858122
+        checksum/config: 19a9d3fac3cca63e0975f1958e09468730658a04b3f187f250b6ce2e6e64fa1d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -73,7 +73,7 @@ spec:
         command:
         - /otelcol
         - --config=/splunk-messages/config.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 4bfe8002d655d77fd9c91437a5fdfa6b21f8d1a6888dffc8bd352a18f10b0204
+        checksum/config: 8ee7904004c05d7ee379397170bd0233cda09387fb2a212f5b8401299db4ecc7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks-fargate/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/distribution-eks-fargate/rendered_manifests/service.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector

--- a/examples/distribution-eks-fargate/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/distribution-eks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/distribution-eks/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 1efc378d2d2ed6fb8abb84d3e308e27b921f750e04c9649e8084aa6f2412a6f8
+        checksum/config: 49be5459fec38af11b17aa52a010b5bab3a26a4bfb9f9630190d985c3e17e965
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: cc8e0ec167fd5c4f92b6650c413ad6dc90cf4c0fad2cf88dedc45666a6e796ce
+        checksum/config: 093ff7fcd6d2cd1c53776aa41a48f1936bdf4bb3cd4521236e241f922d49f2ed
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-eks/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/distribution-eks/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-eks/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 2d85ffa1cf2e4750b3e39183d515f1ab969eff9d7bd0800704488c56dc66a278
+        checksum/config: b53ca09214a4503c529050222aea50870fda47ee0be4112022a96946f1187e41
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -78,7 +78,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0992f278bded8f2a0b7f16476122884a779c1fa4fb468d95cc78d2db826a3c8f
+        checksum/config: d647863d2ca69ec66985f9275484f242db9ee0372d705062da5de9a9622da866
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke-autopilot/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/distribution-gke-autopilot/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/distribution-gke/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/distribution-gke/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5df6ee669d36b2d8c9040a9d928406cd60663246479f52373b5d5f72416980aa
+        checksum/config: 5ae7555189677c98515351485c2ed0994fd857ce7931867a95e9a5f31a7e1be5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0992f278bded8f2a0b7f16476122884a779c1fa4fb468d95cc78d2db826a3c8f
+        checksum/config: d647863d2ca69ec66985f9275484f242db9ee0372d705062da5de9a9622da866
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-gke/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/distribution-gke/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-gke/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/distribution-openshift/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: cbd318d73ff14d3e055da8fdd43f8a992621242e6f5a9dc378ac967c840a8bf8
+        checksum/config: 71099ae3766f36662c88f8ba8c4bd54a6ba3b6dea40ef9b8254b72916e9436bf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a718608b6795ba91603a1b3d3be137a8cd6364aa79f58161c72d1150ccedc49c
+        checksum/config: 1ab5800f7bcdc725006ee1adb246cf9b44144665d79513ec648b6dc16f0f40f4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-openshift/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-openshift/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
+++ b/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 users:

--- a/examples/distribution-openshift/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-openshift/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/enable-network-explorer/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/enable-network-explorer/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/enable-network-explorer/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/enable-network-explorer/rendered_manifests/configmap-gateway.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/configmap-gateway.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/enable-network-explorer/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-network-explorer/rendered_manifests/deployment-gateway.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/deployment-gateway.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 0a71c96ab49070efbab9792ac6bd2a7fd6c79456ffbd8742ee2dda17103c2ae6
+        checksum/config: b388f071255a2f26a3b63b0c38087dd540b24cd86b514fba494b90e32a13a398
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-network-explorer/rendered_manifests/network-explorer/k8s-collector-clusterrole.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/network-explorer/k8s-collector-clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: default-splunk-otel-collector-k8s-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     heritage: Helm
     release: default
   name: default-splunk-otel-collector-k8s-collector

--- a/examples/enable-network-explorer/rendered_manifests/network-explorer/k8s-collector-clusterrolebinding.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/network-explorer/k8s-collector-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: default-splunk-otel-collector-k8s-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     heritage: Helm
     release: default
   name: default-splunk-otel-collector-k8s-collector

--- a/examples/enable-network-explorer/rendered_manifests/network-explorer/k8s-collector-deployment.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/network-explorer/k8s-collector-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   name: default-splunk-otel-collector-k8s-collector
   labels:
     app.kubernetes.io/name: default-splunk-otel-collector-k8s-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/instance: default
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
       annotations:
         # This is here to allow us to do "zero-downtime" updates without an image change.
         rollingUpdateVersion: "1"
-        charts.flowmill.com/version: 0.70.0
+        charts.flowmill.com/version: 0.71.0
       labels:
         app.kubernetes.io/name: default-splunk-otel-collector-k8s-collector
         app.kubernetes.io/instance: default

--- a/examples/enable-network-explorer/rendered_manifests/network-explorer/kernel-collector-clusterrole.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/network-explorer/kernel-collector-clusterrole.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: default-splunk-otel-collector-kernel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     heritage: Helm
     release: default
   name: default-splunk-otel-collector-kernel-collector

--- a/examples/enable-network-explorer/rendered_manifests/network-explorer/kernel-collector-clusterrolebinding.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/network-explorer/kernel-collector-clusterrolebinding.yaml
@@ -5,7 +5,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: default-splunk-otel-collector-kernel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     heritage: Helm
     release: default
   name: default-splunk-otel-collector-kernel-collector

--- a/examples/enable-network-explorer/rendered_manifests/network-explorer/kernel-collector-daemonset.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/network-explorer/kernel-collector-daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
   labels:
     app.kubernetes.io/name: default-splunk-otel-collector-kernel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/instance: default
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -23,7 +23,7 @@ spec:
     metadata:
       annotations:
         release_number: "3"
-        charts.flowmill.com/version: 0.70.0
+        charts.flowmill.com/version: 0.71.0
       labels:
         app.kubernetes.io/name: default-splunk-otel-collector-kernel-collector
         app.kubernetes.io/instance: default

--- a/examples/enable-network-explorer/rendered_manifests/network-explorer/reducer-deployment.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/network-explorer/reducer-deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: default-splunk-otel-collector-reducer
   labels:
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/name: default-splunk-otel-collector-reducer
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1

--- a/examples/enable-network-explorer/rendered_manifests/network-explorer/reducer-service.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/network-explorer/reducer-service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: default-splunk-otel-collector-reducer
   labels:
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/name: default-splunk-otel-collector-reducer
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/examples/enable-network-explorer/rendered_manifests/secret-splunk.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/enable-network-explorer/rendered_manifests/service.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/service.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector

--- a/examples/enable-network-explorer/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ab13703d5dd5ac2341d3f122a1b80e2775536c7f7abb85f2b05e7de113881c1e
+        checksum/config: ea1e164ce6bba846ae11a8efeb7f6052f4915c690b2893be7521b9d52c53629b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,7 +73,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-trace-sampling/rendered_manifests/secret-splunk.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/enable-trace-sampling/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 02cc42a814faa44ce25d6ede2fb23032bda87d1146e74979751c29788e270110
+        checksum/config: 9a16ac4239b2e0cb7a532fba7d02ead3502ce2c7eef69071d368fdf779b3e5f6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enabled-pprof-extension/rendered_manifests/secret-splunk.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/enabled-pprof-extension/rendered_manifests/serviceAccount.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/filter-container-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/filter-container-metrics/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/filter-container-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/filter-container-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/filter-container-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 57ada3cba700545e990efc1d8c7edd2a249116a93973ebbef4c74faef73c09e6
+        checksum/config: 1033935dba9c10ede53b9a00950c76dde370cbfcebdda864906ab7b0b14930c3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -61,7 +61,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/filter-container-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 137d211d21eccc48e4268e12c29c811e0546677ab867f2cd2898978b836ad496
+        checksum/config: 80624a61c52aeaf89092927e0f0228dc9e290f44c4a8f94715451ed893fa8815
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/filter-container-metrics/rendered_manifests/secret-splunk.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/filter-container-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f24285909af0884c7557482977a7a54aa1294e3a121a5cf78d7572a19fc5bafd
+        checksum/config: f9caec88f9726beb6d37778103b5ca2069abb3d2f6c9f03b19464ccf3513c721
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/secret-splunk.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-fluentd-json.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-fluentd.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: cac82800ded432062648f452c76ef29b6d1032da473a2a5dd4e6e77cddf5359e
+        checksum/config: 28444767a368c1eff1e5b52065ab7071691b8143e372f9ee81565beb846db2bb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet
@@ -122,7 +122,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -42,7 +42,7 @@ spec:
         - -command
         - .\otelcol.exe
         - --config=C:\\conf\relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/kubernetes-windows-nodes/rendered_manifests/secret-splunk.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/kubernetes-windows-nodes/rendered_manifests/serviceAccount.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/only-logs-fluentd/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/only-logs-fluentd/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd-json.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: c72a5536ce2ddd9792af9317f7d0f7b61e52a9f46c9e1819f79075f3da4c0311
+        checksum/config: b605989081fbce7b9f5a61c054059acafaa8b2ddd37bbc355d6189b5d0f815e5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -126,7 +126,7 @@ spec:
         - name: otlp-http-old
           containerPort: 55681
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-logs-fluentd/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/only-logs-fluentd/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/only-logs-otel/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-otel/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/only-logs-otel/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-otel/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3248106e33590fd0e8b4b44a6dab21c89107ed723dd47f5cdc68f5e98928d2e7
+        checksum/config: a3352dac704ad0ceb21623f9e2c837580ea1a6f82da4e416122b31fe90eaadf1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -43,7 +43,7 @@ spec:
           key: node-role.kubernetes.io/master
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.70.0
+          image: quay.io/signalfx/splunk-otel-collector:0.71.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -92,7 +92,7 @@ spec:
         - name: otlp-http-old
           containerPort: 55681
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/only-logs-otel/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-otel/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/only-logs-otel/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-otel/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/only-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/only-metrics/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 59819d366b1050061720f5fdd77ca4b47469bb212e45a875f610857d0e2f426f
+        checksum/config: 8a561c739f9fe6613768cf9ec843fe82690ae26ee3c10aee0cc57d952e45be05
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -61,7 +61,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-metrics/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/only-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-metrics/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/only-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/only-traces/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f2cfc1fa5ccc8fe78d3a9cab38b1004a993cd130974dd47b9e49ad6b8bd4b168
+        checksum/config: 444cd885c458989614735403726d8f7cbb3671cc9cb542da64160b3e37f9463a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,7 +73,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-traces/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-traces/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/only-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-traces/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: bc1bf4fa0fa13665c3106a5521c612939752c8ad3428faf5c93de02967ffcc7e
+        checksum/config: 76305b5944b2b0e9be0823101ac1cbece9e8d687e867cd266a37347e1101a174
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 189de116b86b7c5d9f55fa4647c8627b9aa6946291023e229498778b74404a17
+        checksum/config: 5b92852776504a8d12a73352ded0896d879e85624b7d229e74a19c4d4eb594f1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/secret-splunk.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/serviceAccount.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:
@@ -34,7 +34,7 @@ data:
           queue_size: 5000
         source: kubernetes
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.70.0
+        splunk_app_version: 0.71.0
         timeout: 10s
         tls:
           insecure_skip_verify: false

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-fluentd-json.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd-json
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-fluentd.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-fluentd
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 8ac5436b5288b63f3fd36651cdac742c6e722ed0b62349349718ff0824611e09
+        checksum/config: 54f3e21c9ae0880bd35b2275d60408defa750bbfb71269889993c337071ea90a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -126,7 +126,7 @@ spec:
         - name: otlp-http-old
           containerPort: 55681
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/secret-splunk.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/serviceAccount.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/examples/use-proxy/rendered_manifests/clusterRole.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 rules:

--- a/examples/use-proxy/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 data:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f24285909af0884c7557482977a7a54aa1294e3a121a5cf78d7572a19fc5bafd
+        checksum/config: f9caec88f9726beb6d37778103b5ca2069abb3d2f6c9f03b19464ccf3513c721
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -77,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -6,13 +6,13 @@ metadata:
   name: default-splunk-otel-collector-k8s-cluster-receiver
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94371fe9c8062ad6c2eb9da843086ee092b3d1ddc2753b9f8198e6a422c5a20c
+        checksum/config: aca155ba170fe83d13a5684e8bc94072c8bcdcf6b73cf3006712abaf954a0f49
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +40,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.70.0
+        image: quay.io/signalfx/splunk-otel-collector:0.71.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/use-proxy/rendered_manifests/secret-splunk.yaml
+++ b/examples/use-proxy/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/use-proxy/rendered_manifests/serviceAccount.yaml
+++ b/examples/use-proxy/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.70.0
+    helm.sh/chart: splunk-otel-collector-0.71.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.70.0"
+    app.kubernetes.io/version: "0.71.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.70.0
+    chart: splunk-otel-collector-0.71.0
     release: default
     heritage: Helm

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.70.0
-appVersion: 0.70.0
+version: 0.71.0
+appVersion: 0.71.0
 description: Splunk OpenTelemetry Collector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application


### PR DESCRIPTION
Updates chart to reference Splunk Collector `v0.71.0` as well as updating functional tests to use kubernetes `v1.25.6` and minikube `v1.29.0`.

Tested on kOps and EKS.