### PR TITLE
Make journald receiver cursors persistent

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -393,6 +393,7 @@ receivers:
     directory: {{ $.Values.logsCollection.journald.directory }}
     units: [{{ $unit.name }}]
     priority: {{ $unit.priority }}
+    storage: file_storage
     operators:
     - type: add
       field: resource["com.splunk.source"]


### PR DESCRIPTION
Currently migrated fluentd checkpoint files are not used due to missing storage param to the journald

According docs cursors/positions/checkpoints are only persisted on disk, if storage param is given. See https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/journaldreceiver/README.md

Equivalent to filelog change in #567