### PR TITLE
extraFileLogs example should show storage param and com.splunk.source…

### DIFF
--- a/docs/migration-from-sck.md
+++ b/docs/migration-from-sck.md
@@ -274,10 +274,11 @@ logsCollection:
       start_at: beginning
       include_file_path: true
       include_file_name: false
+      storage: file_storage
       resource:
-        service.name: /var/log/kube-apiserver-audit.log
         host.name: 'EXPR(env("K8S_NODE_NAME"))'
         com.splunk.sourcetype: kube:apiserver-audit
+        com.splunk.source: /var/log/kube-apiserver-audit.log
 ```
 
 Use the `kube-audit` keyword to continue reading from the translated checkpoint data.


### PR DESCRIPTION
… attribute

If `storage: file_storage` param is not configured, the migrated fluentd position file won't be used and cursor won't ever be persisted to disk.

Also the Splunk `source` field is currently missing. This is read by the splunkhec exporter from the `com.splunk.source` attribute.

See:
* https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/filelogreceiver/README.md
* https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/splunkhecexporter/README.md
* #567