### PR TITLE
docs: improve docs for providing token as secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add experimental support for deploying OpenTelemetry Operator as a subchart [#691](https://github.com/signalfx/splunk-otel-collector-chart/pull/691)
+- Improve documentation about providing tokens as Kubernetes secrets [#707](https://github.com/signalfx/splunk-otel-collector-chart/pull/691)
 
 ## [0.72.0] - 2023-03-09
 

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -26,6 +26,16 @@ splunkObservability:
 clusterName: my-k8s-cluster
 ```
 
+## Provide tokens as a secret
+
+Instead of having the tokens as clear text in the values, those can be provided via a secret that is created before deploying the chart. See [secret-splunk.yaml](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml) for the required fields.
+
+```yaml
+secret:
+  create: false
+  name: your-secret
+```
+
 ## Cloud provider
 
 Use the `cloudProvider` parameter to provide information about the cloud

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -54,7 +54,7 @@ splunkPlatform:
   # data over HTTPS.
   insecureSkipVerify: false
   # The PEM-format CA certificate for this client.
-  # Alternatively the clientCert, clientKey and caFile can be provided as a secret. 
+  # Alternatively the clientCert, clientKey and caFile can be provided as a secret.
   # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#provide-tokens-as-a-secret
   # NOTE: The content of the certificate itself should be used here, not the
   #       file path. The certificate will be stored as a secret in kubernetes.

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -28,6 +28,7 @@ splunkPlatform:
   # enables Splunk Platform as a destination.
   endpoint: ""
   # Required for Splunk Enterprise/Cloud (if `endpoint` is specified). Splunk
+  # Alternatively the token can be provided as a secret.
   # HTTP Event Collector token.
   token: ""
 
@@ -52,14 +53,20 @@ splunkPlatform:
   # data over HTTPS.
   insecureSkipVerify: false
   # The PEM-format CA certificate for this client.
+  # Alternatively the certificate can be provided as a secret. 
+  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
   # NOTE: The content of the certificate itself should be used here, not the
   #       file path. The certificate will be stored as a secret in kubernetes.
   clientCert: ""
   # The private key for this client.
+  # Alternatively the key can be provided as a secret.
+  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
   # NOTE: The content of the key itself should be used here, not the file path.
   #       The key will be stored as a secret in kubernetes.
   clientKey: ""
   # The PEM-format CA certificate file.
+  # Alternatively the certficate can be provided as a secret.
+  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
   # NOTE: The content of the file itself should be used here, not the file path.
   #       The file will be stored as a secret in kubernetes.
   caFile: ""
@@ -111,6 +118,8 @@ splunkObservability:
   # destination.
   realm: ""
   # Required for Splunk Observability (if `realm` is specified). Splunk
+  # Alternatively the accessToken can be provided as a secret.
+  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
   # Observability org access token.
   accessToken: ""
 

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -29,6 +29,7 @@ splunkPlatform:
   endpoint: ""
   # Required for Splunk Enterprise/Cloud (if `endpoint` is specified). Splunk
   # Alternatively the token can be provided as a secret.
+  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
   # HTTP Event Collector token.
   token: ""
 
@@ -53,20 +54,16 @@ splunkPlatform:
   # data over HTTPS.
   insecureSkipVerify: false
   # The PEM-format CA certificate for this client.
-  # Alternatively the certificate can be provided as a secret. 
+  # Alternatively the clientCert, clientKey and caFile can be provided as a secret. 
   # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
   # NOTE: The content of the certificate itself should be used here, not the
   #       file path. The certificate will be stored as a secret in kubernetes.
   clientCert: ""
   # The private key for this client.
-  # Alternatively the key can be provided as a secret.
-  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
   # NOTE: The content of the key itself should be used here, not the file path.
   #       The key will be stored as a secret in kubernetes.
   clientKey: ""
   # The PEM-format CA certificate file.
-  # Alternatively the certficate can be provided as a secret.
-  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
   # NOTE: The content of the file itself should be used here, not the file path.
   #       The file will be stored as a secret in kubernetes.
   caFile: ""

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -29,7 +29,7 @@ splunkPlatform:
   endpoint: ""
   # Required for Splunk Enterprise/Cloud (if `endpoint` is specified). Splunk
   # Alternatively the token can be provided as a secret.
-  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
+  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#provide-tokens-as-a-secret
   # HTTP Event Collector token.
   token: ""
 
@@ -55,7 +55,7 @@ splunkPlatform:
   insecureSkipVerify: false
   # The PEM-format CA certificate for this client.
   # Alternatively the clientCert, clientKey and caFile can be provided as a secret. 
-  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
+  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#provide-tokens-as-a-secret
   # NOTE: The content of the certificate itself should be used here, not the
   #       file path. The certificate will be stored as a secret in kubernetes.
   clientCert: ""
@@ -116,7 +116,7 @@ splunkObservability:
   realm: ""
   # Required for Splunk Observability (if `realm` is specified). Splunk
   # Alternatively the accessToken can be provided as a secret.
-  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md
+  # Refer to https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#provide-tokens-as-a-secret
   # Observability org access token.
   accessToken: ""
 


### PR DESCRIPTION
This improves a little the documentation about providing tokens as k8s secrets instead of having them directly in the chart values.