### PR TITLE
Update the port used to monitor the Kubernetes scheduler (10251->10259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Update the port used to monitor the Kubernetes scheduler (10251->10259) [#711](https://github.com/signalfx/splunk-otel-collector-chart/pull/711)
+
 ### Added
 
 - Add experimental support for deploying OpenTelemetry Operator as a subchart [#691](https://github.com/signalfx/splunk-otel-collector-chart/pull/691)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Update the port used to monitor the Kubernetes scheduler (10251->10259) [#711](https://github.com/signalfx/splunk-otel-collector-chart/pull/711)
+- Update the Kubernetes scheduler monitor to stop using insecure port 10251 and start using secure port 10259 with authentication [#711](https://github.com/signalfx/splunk-otel-collector-chart/pull/711)
 
 ### Added
 

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -222,8 +222,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
           smartagent/postgresql:
             config:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f53074c7e6712d30ad31de66add6c3529d16e343e054e73a545906d19111b360
+        checksum/config: a7188a6b6e897ee303bde201d8362c777044809c63bcdb466634db44e8979e78
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -219,8 +219,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 423da53e56d8c91fed1b59203794abea204b1dc3a2c39cd09af8e504d785aec4
+        checksum/config: 33614666c6dc88f8c51c31eb89dfd1326830757d2ff0e84b99ff31110f736c19
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -216,8 +216,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 498afc3c3c738f02ac2cd1f6c810331f61d284a2ad8afded1a8239f0f46dcb0b
+        checksum/config: 52df16f44ae345ce03c4cffdb196869645743a1acaafe611aa3ce5593ac54127
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -216,8 +216,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 498afc3c3c738f02ac2cd1f6c810331f61d284a2ad8afded1a8239f0f46dcb0b
+        checksum/config: 52df16f44ae345ce03c4cffdb196869645743a1acaafe611aa3ce5593ac54127
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -216,8 +216,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 498afc3c3c738f02ac2cd1f6c810331f61d284a2ad8afded1a8239f0f46dcb0b
+        checksum/config: 52df16f44ae345ce03c4cffdb196869645743a1acaafe611aa3ce5593ac54127
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -221,8 +221,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["app"] == "openshift-kube-scheduler" && labels["scheduler"]
               == "true"
         watch_observers:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 4334ae0fef09f4fcc630409f6a0f5e34ffef2a77f1cb335af0c75aed0e2c1781
+        checksum/config: 311e3ef32a07c0a11a9cf8ab1cc199c9c150fb8bc32da47c9c22f8dea7e0d31d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -217,8 +217,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e4268b97683d27ccd517e81dd8ddb1687491898aa4b30901cc342b25bb75f9af
+        checksum/config: 07e22162779b7045ecec161f1ef517814d0f64282be0618f539bc6c07bc2bdce
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/filter-container-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/configmap-agent.yaml
@@ -214,8 +214,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/filter-container-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/filter-container-metrics/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: c12b01c9930dfa52f6c6fda600aa83a870b156e7361f4ec24493b103b18aa682
+        checksum/config: 67a7a537dae3d446076005aea64871f8120e05b9d02f935eb14223e8236a6bb7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -216,8 +216,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 498afc3c3c738f02ac2cd1f6c810331f61d284a2ad8afded1a8239f0f46dcb0b
+        checksum/config: 52df16f44ae345ce03c4cffdb196869645743a1acaafe611aa3ce5593ac54127
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -229,8 +229,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 0316b40b2e151409687b01d3c64bad21f18d25f8bc158e71fb15d1b68fd1f16c
+        checksum/config: ef916ad1204564eb4b7209ffeddf08e7b65292dfb2a0f6dc20835aa4d108f58c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -207,8 +207,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 1e7bf284b1cbc89531b19420d13c9e2c4f46e8f5deee4f9e92ed8be453946104
+        checksum/config: f909703ee5fa4c32e8bba40ca060a20ebf84dd328359140073807c534cee2b41
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -220,8 +220,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5faa8cf715db90c8033aae1080ffc91028e20865defc8f518925c6818860c76a
+        checksum/config: 12f0cafbfee5a9ce73a537e0bc6a2fd40939a92bcf041d67685d398eac4cd26f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -216,8 +216,11 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-scheduler
-              port: 10251
+              port: 10259
+              skipVerify: true
               type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
             rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
         watch_observers:
         - k8s_observer

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 498afc3c3c738f02ac2cd1f6c810331f61d284a2ad8afded1a8239f0f46dcb0b
+        checksum/config: 52df16f44ae345ce03c4cffdb196869645743a1acaafe611aa3ce5593ac54127
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -184,8 +184,11 @@ receivers:
         config:
           extraDimensions:
             metric_source: kubernetes-scheduler
-          port: 10251
+          skipVerify: true
+          port: 10259
           type: kubernetes-scheduler
+          useHTTPS: true
+          useServiceAccount: true
       {{- end }}
       {{- end }}
 


### PR DESCRIPTION
Related Issue: https://github.com/signalfx/splunk-otel-collector-chart/issues/697

The previous port was deprecated in Kubernetes 1.19, it is time to update the out of date port. The new port was tested with Kubernetes 1.25 and Openshift 4.12.