### PR TITLE
add max_batch_size to recombine instructions

### DIFF
--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -163,7 +163,7 @@ data:
           combine_with: ""
           id: crio-recombine
           is_last_entry: attributes.logtag == 'F'
-          max_batch_size: 16
+          max_batch_size: 8
           output: handle_empty_log
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -177,7 +177,7 @@ data:
           combine_with: ""
           id: containerd-recombine
           is_last_entry: attributes.logtag == 'F'
-          max_batch_size: 8
+          max_batch_size: 16
           output: handle_empty_log
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -190,7 +190,7 @@ data:
           combine_with: ""
           id: docker-recombine
           is_last_entry: attributes.log endsWith "\n"
-          max_batch_size: 8
+          max_batch_size: 16
           output: handle_empty_log
           source_identifier: attributes["log.file.path"]
           type: recombine

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -163,6 +163,7 @@ data:
           combine_with: ""
           id: crio-recombine
           is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 16
           output: handle_empty_log
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -176,6 +177,7 @@ data:
           combine_with: ""
           id: containerd-recombine
           is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 8
           output: handle_empty_log
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -188,6 +190,7 @@ data:
           combine_with: ""
           id: docker-recombine
           is_last_entry: attributes.log endsWith "\n"
+          max_batch_size: 8
           output: handle_empty_log
           source_identifier: attributes["log.file.path"]
           type: recombine

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d84c006f64809b632ab9530e36cf4f32e98935a6ed6bcfb2804cd2124821b4b5
+        checksum/config: 5a8dc5e7a719553c60d6a9cf767f3277c412a579038e24de2018476bff596859
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 664949a4d833c1a4b2a30964878c4e57c7029b9af1375b61097ecea125658b19
+        checksum/config: d84c006f64809b632ab9530e36cf4f32e98935a6ed6bcfb2804cd2124821b4b5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -288,6 +288,7 @@ receivers:
         source_identifier: attributes["log.file.path"]
         is_last_entry: "attributes.logtag == 'F'"
         combine_with: ""
+        max_batch_size: 16
       {{- end }}
       {{- if or (not .Values.logsCollection.containers.containerRuntime) (eq .Values.logsCollection.containers.containerRuntime "containerd") }}
       # Parse CRI-Containerd format
@@ -304,6 +305,7 @@ receivers:
         source_identifier: attributes["log.file.path"]
         is_last_entry: "attributes.logtag == 'F'"
         combine_with: ""
+        max_batch_size: 8
       {{- end }}
       {{- if or (not .Values.logsCollection.containers.containerRuntime) (eq .Values.logsCollection.containers.containerRuntime "docker") }}
       # Parse Docker format
@@ -319,6 +321,7 @@ receivers:
         source_identifier: attributes["log.file.path"]
         is_last_entry: attributes.log endsWith "\n"
         combine_with: ""
+        max_batch_size: 8
       {{- end }}
       - type: add
         id: handle_empty_log

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -288,7 +288,7 @@ receivers:
         source_identifier: attributes["log.file.path"]
         is_last_entry: "attributes.logtag == 'F'"
         combine_with: ""
-        max_batch_size: 16
+        max_batch_size: 8
       {{- end }}
       {{- if or (not .Values.logsCollection.containers.containerRuntime) (eq .Values.logsCollection.containers.containerRuntime "containerd") }}
       # Parse CRI-Containerd format
@@ -305,7 +305,7 @@ receivers:
         source_identifier: attributes["log.file.path"]
         is_last_entry: "attributes.logtag == 'F'"
         combine_with: ""
-        max_batch_size: 8
+        max_batch_size: 16
       {{- end }}
       {{- if or (not .Values.logsCollection.containers.containerRuntime) (eq .Values.logsCollection.containers.containerRuntime "docker") }}
       # Parse Docker format
@@ -321,7 +321,7 @@ receivers:
         source_identifier: attributes["log.file.path"]
         is_last_entry: attributes.log endsWith "\n"
         combine_with: ""
-        max_batch_size: 8
+        max_batch_size: 16
       {{- end }}
       - type: add
         id: handle_empty_log


### PR DESCRIPTION
Sets values for max_batch_size (default is 1000) for crio to 8, containerd and docker to 16 respectively.