### PR TITLE
Updated instructions in values.yaml for sending data to Splunk Enterprise/Cloud

### DIFF
--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -24,7 +24,7 @@ clusterName: ""
 # Enterprise.
 splunkPlatform:
   # Required for Splunk Enterprise/Cloud. URL to a Splunk instance to send data
-  # to. e.g. "http://X.X.X.X:8088/services/collector". Setting this parameter
+  # to. e.g. "http://X.X.X.X:8088/services/collector/event". Setting this parameter
   # enables Splunk Platform as a destination.
   endpoint: ""
   # Required for Splunk Enterprise/Cloud (if `endpoint` is specified). Splunk

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -25,7 +25,8 @@ clusterName: ""
 splunkPlatform:
   # Required for Splunk Enterprise/Cloud. URL to a Splunk instance to send data
   # to. e.g. "http://X.X.X.X:8088/services/collector/event". Setting this parameter
-  # enables Splunk Platform as a destination.
+  # enables Splunk Platform as a destination. Use the /services/collector/event
+  # endpoint for proper extraction of fields.
   endpoint: ""
   # Required for Splunk Enterprise/Cloud (if `endpoint` is specified). Splunk
   # Alternatively the token can be provided as a secret.


### PR DESCRIPTION
I updated the commented out instructions for setting the splunkPlatform endpoint to avoid confusion about which HEC endpoint to send to (ie. use /services/collector/event, not /services/collector/raw). 

Thanks!

![Screenshot 2023-03-31 at 9 24 56 AM](https://user-images.githubusercontent.com/13222781/229190615-bfab3cd6-afb4-4121-887a-1b41461cf0f4.png)
