### PR TITLE
Expose idle_conn_timeout setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add experimental support for deploying OpenTelemetry Operator as a subchart [#691](https://github.com/signalfx/splunk-otel-collector-chart/pull/691)
 - Improve documentation about providing tokens as Kubernetes secrets [#707](https://github.com/signalfx/splunk-otel-collector-chart/pull/691)
+- Expose idle_conn_timeout on the splunk HEC exporters [#728](https://github.com/signalfx/splunk-otel-collector-chart/pull/728)
 
 ## [0.72.0] - 2023-03-09
 

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -20,6 +20,7 @@ data:
       splunk_hec/platform_logs:
         disable_compression: true
         endpoint: http://localhost:8088/services/collector
+        idle_conn_timeout: 10s
         index: main
         max_connections: 200
         profiling_data_enabled: false

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 9c4ff38095c4806b06b7a7dfa3d91953a5818b0c1361ae86993fd0cc6c239f53
+        checksum/config: 04779bf3e3c53f71e16b76d2eb59d0bbf075648bee7d7dabc396d3b3cb118c94
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -190,6 +190,7 @@ splunk_hec/platform_logs:
   max_connections: {{ .Values.splunkPlatform.maxConnections }}
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
+  idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}
   splunk_app_name: {{ .Chart.Name }}
   splunk_app_version: {{ .Chart.Version }}
   profiling_data_enabled: false
@@ -227,6 +228,7 @@ splunk_hec/platform_metrics:
   max_connections: {{ .Values.splunkPlatform.maxConnections }}
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
+  idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}
   splunk_app_name: {{ .Chart.Name }}
   splunk_app_version: {{ .Chart.Version }}
   tls:
@@ -263,6 +265,7 @@ splunk_hec/platform_traces:
   max_connections: {{ .Values.splunkPlatform.maxConnections }}
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
+  idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}
   splunk_app_name: {{ .Chart.Name }}
   splunk_app_version: {{ .Chart.Version }}
   tls:

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -64,6 +64,9 @@
         "timeout": {
           "type": "string"
         },
+        "idleConnTimeout": {
+          "type": "string"
+        },
         "insecureSkipVerify": {
           "type": "boolean"
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -50,6 +50,8 @@ splunkPlatform:
   disableCompression: true
   # HTTP timeout when sending data. Defaults to 10s.
   timeout: 10s
+  # Idle connection timeout. defaults to 10s
+  idleConnTimeout: 10s
   # Whether to skip checking the certificate of the HEC endpoint when sending
   # data over HTTPS.
   insecureSkipVerify: false


### PR DESCRIPTION
Expose idle_conn_timeout on the splunk HEC exporters created as part of the helm chart.