### PR TITLE
Remove the Chart.lock file and add it to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Helm
 **/charts/*.tgz
+helm-charts/splunk-otel-collector/Chart.lock

--- a/helm-charts/splunk-otel-collector/Chart.lock
+++ b/helm-charts/splunk-otel-collector/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: cert-manager
-  repository: https://charts.jetstack.io
-  version: v1.11.0
-- name: opentelemetry-operator
-  repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.26.2
-digest: sha256:4fe4e9be0ee8be75e70276910dcb00767ee6394452c20ac01f56095ff1bdd3ba
-generated: "2023-04-11T16:23:01.179775-06:00"


### PR DESCRIPTION
We don't use this Chart.lock file at the moment and our subchart is pinned to a specific version.