### PR TITLE
add storage to filelog receiver for extraFileLog

### DIFF
--- a/examples/only-logs-with-extra-file-logs/README.md
+++ b/examples/only-logs-with-extra-file-logs/README.md
@@ -1,0 +1,6 @@
+# Example of chart configuration
+
+## Add extraFileLogs
+
+This example shows how you can configure files of your choice to be collected with Splunk OTel Collector for Kubernetes.
+

--- a/examples/only-logs-with-extra-file-logs/only-logs-with-extra-file-logs-values.yaml
+++ b/examples/only-logs-with-extra-file-logs/only-logs-with-extra-file-logs-values.yaml
@@ -1,0 +1,56 @@
+clusterName: CHANGEME
+splunkObservability:
+  realm: CHANGEME
+  accessToken: CHANGEME
+  metricsEnabled: false
+  logsEnabled: true
+  tracesEnabled: false
+
+logsEngine: otel
+agent:
+  config:
+    extensions:
+      another_file_storage:
+        directory: /var/addon/splunk/otel_another
+logsCollection:
+  extraFileLogs:
+    filelog/example-with-storage:
+      include:
+      - /tmp/*/*/*/kubernetes.io~empty-dir/emptydir/*.log
+      start_at: beginning
+      storage: file_storage
+      include_file_path: true
+      include_file_name: false
+      resource:
+        com.splunk.index: otel_events
+        com.splunk.source: /var/log/emptydir/emptydir-mario
+        host.name: 'EXPR(env("K8S_NODE_NAME"))'
+        com.splunk.sourcetype: example
+      operators:
+      - from: attributes.volume_name
+        to: resource["k8s.volume.name"]
+        type: move
+    filelog/example-without-storage:
+      include:
+        - /tmp/*/*/*/kubernetes.io~empty-dir/emptydir/catalina*.log
+      start_at: beginning
+      include_file_path: true
+      include_file_name: false
+      resource:
+        com.splunk.index: otel_events
+        com.splunk.source: /var/log/emptydir/example-without-storage
+        host.name: 'EXPR(env("K8S_NODE_NAME"))'
+        com.splunk.sourcetype: example
+    filelog/example-with-another-storage:
+      include:
+        - /tmp/*/*/*/kubernetes.io~empty-dir/*/*.log
+      start_at: beginning
+      include_file_path: true
+      include_file_name: false
+      resource:
+        com.splunk.index: otel_events
+        com.splunk.source: /var/log/emptydir/example-with-another-storage
+        host.name: 'EXPR(env("K8S_NODE_NAME"))'
+        com.splunk.sourcetype: example
+      storage: another_file_storage
+

--- a/examples/only-logs-with-extra-file-logs/only-logs-with-extra-file-logs-values.yaml
+++ b/examples/only-logs-with-extra-file-logs/only-logs-with-extra-file-logs-values.yaml
@@ -8,22 +8,30 @@ splunkObservability:
 
 logsEngine: otel
 agent:
-  config:
-    extensions:
-      another_file_storage:
-        directory: /var/addon/splunk/otel_another
+  extraVolumes:
+    - name: example-with-storage-logs
+      hostPath:
+        path: /tmp/directory_one
+    - name: example-without-storage
+      hostPath:
+        path: /var/log/catalina
+  extraVolumeMounts:
+    - name: example-with-storage-logs
+      mountPath: /tmp/directory_one
+    - name: example-without-storage
+      mountPath: /var/log/catalina
 logsCollection:
   extraFileLogs:
     filelog/example-with-storage:
       include:
-      - /tmp/*/*/*/kubernetes.io~empty-dir/emptydir/*.log
+      - /tmp/directory_one/*.log
       start_at: beginning
       storage: file_storage
       include_file_path: true
       include_file_name: false
       resource:
         com.splunk.index: otel_events
-        com.splunk.source: /var/log/emptydir/emptydir-mario
+        com.splunk.source: /tmp/directory_one
         host.name: 'EXPR(env("K8S_NODE_NAME"))'
         com.splunk.sourcetype: example
       operators:
@@ -32,25 +40,12 @@ logsCollection:
         type: move
     filelog/example-without-storage:
       include:
-        - /tmp/*/*/*/kubernetes.io~empty-dir/emptydir/catalina*.log
+        - /var/log/catalina/catalina*.log
       start_at: beginning
       include_file_path: true
       include_file_name: false
       resource:
         com.splunk.index: otel_events
-        com.splunk.source: /var/log/emptydir/example-without-storage
+        com.splunk.source: /var/log/catalina
         host.name: 'EXPR(env("K8S_NODE_NAME"))'
         com.splunk.sourcetype: example
-    filelog/example-with-another-storage:
-      include:
-        - /tmp/*/*/*/kubernetes.io~empty-dir/*/*.log
-      start_at: beginning
-      include_file_path: true
-      include_file_name: false
-      resource:
-        com.splunk.index: otel_events
-        com.splunk.source: /var/log/emptydir/example-with-another-storage
-        host.name: 'EXPR(env("K8S_NODE_NAME"))'
-        com.splunk.sourcetype: example
-      storage: another_file_storage
-

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
@@ -1,0 +1,83 @@
+---
+# Source: splunk-otel-collector/templates/clusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.75.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.75.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.75.0
+    release: default
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/proxy
+  - pods
+  - pods/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.75.0
+    helm.sh/chart: splunk-otel-collector-0.76.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.75.0"
+    app.kubernetes.io/version: "0.76.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.75.0
+    chart: splunk-otel-collector-0.76.0
     release: default
     heritage: Helm
 rules:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.75.0
+    helm.sh/chart: splunk-otel-collector-0.76.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.75.0"
+    app.kubernetes.io/version: "0.76.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.75.0
+    chart: splunk-otel-collector-0.76.0
     release: default
     heritage: Helm
 roleRef:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: splunk-otel-collector/templates/clusterRoleBinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.75.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.75.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.75.0
+    release: default
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-splunk-otel-collector
+subjects:
+- kind: ServiceAccount
+  name: default-splunk-otel-collector
+  namespace: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -1,0 +1,341 @@
+---
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-agent
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.75.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.75.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.75.0
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      signalfx:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        api_url: https://api.CHANGEME.signalfx.com
+        correlation: null
+        ingest_url: https://ingest.CHANGEME.signalfx.com
+        sync_host_metadata: true
+      splunk_hec/o11y:
+        disable_compression: true
+        endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        log_data_enabled: true
+        profiling_data_enabled: false
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+    extensions:
+      another_file_storage:
+        directory: /var/addon/splunk/otel_another
+      file_storage:
+        directory: /var/addon/splunk/otel_pos
+      health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
+      memory_ballast:
+        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+      zpages: null
+    processors:
+      batch: null
+      filter/logs:
+        logs:
+          exclude:
+            match_type: strict
+            resource_attributes:
+            - key: splunk.com/exclude
+              value: "true"
+      k8sattributes:
+        extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: namespace
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          - from: pod
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          labels:
+          - key: app
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: ip
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: host.name
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_agent_k8s:
+        attributes:
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 10s
+    receivers:
+      filelog:
+        encoding: utf-8
+        exclude:
+        - /var/log/pods/default_default-splunk-otel-collector*_*/otel-collector/*.log
+        fingerprint_size: 1kb
+        force_flush_period: "0"
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        max_concurrent_files: 1024
+        max_log_size: 1MiB
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: "2006-01-02T15:04:05.999999999-07:00"
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
+          type: add
+          value: ""
+        - parse_from: attributes["log.file.path"]
+          regex: ^\/var\/log\/pods\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - field: resource["com.splunk.sourcetype"]
+          type: add
+          value: EXPR("kube:container:"+resource["k8s.container.name"])
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes["log.file.path"]
+          to: resource["com.splunk.source"]
+          type: move
+        - from: attributes.log
+          id: clean-up-log-record
+          to: body
+          type: move
+        poll_interval: 200ms
+        start_at: beginning
+        storage: file_storage
+      filelog/example-with-another-storage:
+        include:
+        - /tmp/*/*/*/kubernetes.io~empty-dir/*/*.log
+        include_file_name: false
+        include_file_path: true
+        resource:
+          com.splunk.index: otel_events
+          com.splunk.source: /var/log/emptydir/example-with-another-storage
+          com.splunk.sourcetype: example
+          host.name: EXPR(env("K8S_NODE_NAME"))
+        start_at: beginning
+        storage: another_file_storage
+      filelog/example-with-storage:
+        include:
+        - /tmp/*/*/*/kubernetes.io~empty-dir/emptydir/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - from: attributes.volume_name
+          to: resource["k8s.volume.name"]
+          type: move
+        resource:
+          com.splunk.index: otel_events
+          com.splunk.source: /var/log/emptydir/emptydir-mario
+          com.splunk.sourcetype: example
+          host.name: EXPR(env("K8S_NODE_NAME"))
+        start_at: beginning
+        storage: file_storage
+      filelog/example-without-storage:
+        include:
+        - /tmp/*/*/*/kubernetes.io~empty-dir/emptydir/catalina*.log
+        include_file_name: false
+        include_file_path: true
+        resource:
+          com.splunk.index: otel_events
+          com.splunk.source: /var/log/emptydir/example-without-storage
+          com.splunk.sourcetype: example
+          host.name: EXPR(env("K8S_NODE_NAME"))
+        start_at: beginning
+        storage: file_storage
+      fluentforward:
+        endpoint: 0.0.0.0:8006
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus/agent:
+        config:
+          scrape_configs:
+          - job_name: otel-agent
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+    service:
+      extensions:
+      - file_storage
+      - health_check
+      - k8s_observer
+      - memory_ballast
+      - zpages
+      pipelines:
+        logs:
+          exporters:
+          - splunk_hec/o11y
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - filter/logs
+          - batch
+          - resource
+          - resource/logs
+          - resourcedetection
+          receivers:
+          - filelog
+          - fluentforward
+          - otlp
+        logs/host:
+          exporters:
+          - splunk_hec/o11y
+          processors:
+          - memory_limiter
+          - batch
+          - resource
+          receivers:
+          - filelog/example-with-another-storage
+          - filelog/example-with-storage
+          - filelog/example-without-storage
+        metrics/agent:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_agent_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/agent
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -30,8 +30,6 @@ data:
         profiling_data_enabled: false
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
-      another_file_storage:
-        directory: /var/addon/splunk/otel_another
       file_storage:
         directory: /var/addon/splunk/otel_pos
       health_check: null
@@ -237,21 +235,9 @@ data:
           enabled: true
         start_at: beginning
         storage: file_storage
-      filelog/example-with-another-storage:
-        include:
-        - /tmp/*/*/*/kubernetes.io~empty-dir/*/*.log
-        include_file_name: false
-        include_file_path: true
-        resource:
-          com.splunk.index: otel_events
-          com.splunk.source: /var/log/emptydir/example-with-another-storage
-          com.splunk.sourcetype: example
-          host.name: EXPR(env("K8S_NODE_NAME"))
-        start_at: beginning
-        storage: another_file_storage
       filelog/example-with-storage:
         include:
-        - /tmp/*/*/*/kubernetes.io~empty-dir/emptydir/*.log
+        - /tmp/directory_one/*.log
         include_file_name: false
         include_file_path: true
         operators:
@@ -260,19 +246,19 @@ data:
           type: move
         resource:
           com.splunk.index: otel_events
-          com.splunk.source: /var/log/emptydir/emptydir-mario
+          com.splunk.source: /tmp/directory_one
           com.splunk.sourcetype: example
           host.name: EXPR(env("K8S_NODE_NAME"))
         start_at: beginning
         storage: file_storage
       filelog/example-without-storage:
         include:
-        - /tmp/*/*/*/kubernetes.io~empty-dir/emptydir/catalina*.log
+        - /var/log/catalina/catalina*.log
         include_file_name: false
         include_file_path: true
         resource:
           com.splunk.index: otel_events
-          com.splunk.source: /var/log/emptydir/example-without-storage
+          com.splunk.source: /var/log/catalina
           com.splunk.sourcetype: example
           host.name: EXPR(env("K8S_NODE_NAME"))
         start_at: beginning
@@ -324,7 +310,6 @@ data:
           - batch
           - resource
           receivers:
-          - filelog/example-with-another-storage
           - filelog/example-with-storage
           - filelog/example-without-storage
         metrics/agent:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-otel-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.75.0
+    helm.sh/chart: splunk-otel-collector-0.76.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.75.0"
+    app.kubernetes.io/version: "0.76.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.75.0
+    chart: splunk-otel-collector-0.76.0
     release: default
     heritage: Helm
 data:
@@ -233,6 +233,8 @@ data:
           to: body
           type: move
         poll_interval: 200ms
+        retry_on_failure:
+          enabled: true
         start_at: beginning
         storage: file_storage
       filelog/example-with-another-storage:
@@ -307,9 +309,9 @@ data:
           - k8sattributes
           - filter/logs
           - batch
+          - resourcedetection
           - resource
           - resource/logs
-          - resourcedetection
           receivers:
           - filelog
           - fluentforward

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -1,0 +1,178 @@
+---
+# Source: splunk-otel-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: default-splunk-otel-collector-agent
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.75.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.75.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.75.0
+    release: default
+    heritage: Helm
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        release: default
+      annotations:
+        checksum/config: 6a8bee8c84b59e76a728181d8a48ecb796c7faf114a5336217936ca01a90ac29
+        kubectl.kubernetes.io/default-container: otel-collector
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      initContainers:
+        - name: migrate-checkpoint
+          image: quay.io/signalfx/splunk-otel-collector:0.75.0
+          imagePullPolicy: IfNotPresent
+          command: ["/migratecheckpoint"]
+          securityContext:
+            runAsUser: 0
+          env:
+          - name: CONTAINER_LOG_PATH_FLUENTD
+            value: "/var/log/splunk-fluentd-containers.log.pos"
+          - name: CONTAINER_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_filelog_"
+          - name: CUSTOM_LOG_PATH_FLUENTD
+            value: "/var/log/splunk-fluentd-*.pos"
+          - name: CUSTOM_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_filelog_"
+          - name: CUSTOM_LOG_CAPTURE_REGEX
+            value: '\/var\/log\/splunk\-fluentd\-(?P<name>[\w0-9-_]+)\.pos'
+          - name: JOURNALD_LOG_PATH_FLUENTD
+            value: "/var/log/splunkd-fluentd-journald-*.pos.json"
+          - name: JOURNALD_LOG_PATH_OTEL
+            value: "/var/addon/splunk/otel_pos/receiver_journald_"
+          - name: JOURNALD_LOG_CAPTURE_REGEX
+            value: '\/splunkd\-fluentd\-journald\-(?P<name>[\w0-9-_]+)\.pos\.json'
+          resources:
+            limits:
+              cpu: 200m
+              memory: 500Mi
+          volumeMounts:
+            - name: checkpoint
+              mountPath: /var/addon/splunk/otel_pos
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        ports:
+        - name: fluentforward
+          containerPort: 8006
+          hostPort: 8006
+          protocol: TCP
+        - name: otlp
+          containerPort: 4317
+          hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
+          protocol: TCP
+        image: quay.io/signalfx/splunk-otel-collector:0.75.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NODE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: splunk-otel-collector
+                key: splunk_observability_access_token
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-configmap
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: checkpoint
+          mountPath: /var/addon/splunk/otel_pos
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: checkpoint
+        hostPath:
+          path: /var/addon/splunk/otel_pos
+          type: DirectoryOrCreate
+      - name: otel-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-agent
+          items:
+            - key: relay
+              path: relay.yaml

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 803763cc1e4021de0da232ecd68e792bd01a6a0d7d446bd0d4ea94eba85f323c
+        checksum/config: 57704101d2accd76aa3664fe80510b3e9df81516be24a482ea9cf797e93870b0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -158,6 +158,10 @@ spec:
           readOnly: true
         - name: checkpoint
           mountPath: /var/addon/splunk/otel_pos
+        - mountPath: /tmp/directory_one
+          name: example-with-storage-logs
+        - mountPath: /var/log/catalina
+          name: example-without-storage
       terminationGracePeriodSeconds: 600
       volumes:
       - name: varlog
@@ -176,3 +180,9 @@ spec:
           items:
             - key: relay
               path: relay.yaml
+      - hostPath:
+          path: /tmp/directory_one
+        name: example-with-storage-logs
+      - hostPath:
+          path: /var/log/catalina
+        name: example-without-storage

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.75.0
+    helm.sh/chart: splunk-otel-collector-0.76.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.75.0"
+    app.kubernetes.io/version: "0.76.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.75.0
+    chart: splunk-otel-collector-0.76.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6a8bee8c84b59e76a728181d8a48ecb796c7faf114a5336217936ca01a90ac29
+        checksum/config: 803763cc1e4021de0da232ecd68e792bd01a6a0d7d446bd0d4ea94eba85f323c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -43,7 +43,7 @@ spec:
           key: node-role.kubernetes.io/master
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.75.0
+          image: quay.io/signalfx/splunk-otel-collector:0.76.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -96,7 +96,7 @@ spec:
         - name: otlp-http-old
           containerPort: 55681
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.75.0
+        image: quay.io/signalfx/splunk-otel-collector:0.76.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/secret-splunk.yaml
@@ -1,0 +1,19 @@
+---
+# Source: splunk-otel-collector/templates/secret-splunk.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.75.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.75.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.75.0
+    release: default
+    heritage: Helm
+type: Opaque
+data:
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/secret-splunk.yaml
@@ -6,12 +6,12 @@ metadata:
   name: splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.75.0
+    helm.sh/chart: splunk-otel-collector-0.76.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.75.0"
+    app.kubernetes.io/version: "0.76.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.75.0
+    chart: splunk-otel-collector-0.76.0
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
@@ -1,0 +1,16 @@
+---
+# Source: splunk-otel-collector/templates/serviceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.75.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.75.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.75.0
+    release: default
+    heritage: Helm

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
@@ -6,11 +6,11 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.75.0
+    helm.sh/chart: splunk-otel-collector-0.76.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.75.0"
+    app.kubernetes.io/version: "0.76.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.75.0
+    chart: splunk-otel-collector-0.76.0
     release: default
     heritage: Helm

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -405,7 +405,14 @@ receivers:
   {{- end }}
 
   {{- if .Values.logsCollection.extraFileLogs }}
-  {{- toYaml .Values.logsCollection.extraFileLogs | nindent 2 }}
+  {{- $extraFileLogsList := .Values.logsCollection.extraFileLogs }}
+  {{- range $extraFileLogKey, $extraFileLogValue := $extraFileLogsList }}
+  {{- printf "%s:" $extraFileLogKey | nindent 2 }}
+  {{- if not $extraFileLogValue.storage }}
+    storage: file_storage
+  {{- end }}
+  {{- $extraFileLogValue | toYaml | nindent 4 }}
+  {{- end }}
   {{- end }}
 
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver


### PR DESCRIPTION
This PR adds a `storage` field for `extraFileLog` if it wasn't provided in the `values.yaml`.
Fix for: https://github.com/signalfx/splunk-otel-collector-chart/issues/692