### PR TITLE
Add an option to use lightprometheus receiver through a feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+
+- Option to use lightprometheus receiver through a feature gate for metrics collection from discovered Prometheus endpoints [757](https://github.com/signalfx/splunk-otel-collector-chart/pull/757)
+
 ### Changed
 
 - Add `logsCollection.containers.maxRecombineLogSize` config option with default 1Mb value which is applied

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -63,7 +63,11 @@ receivers:
     watch_observers: [k8s_observer]
     receivers:
       {{- if or .Values.autodetect.prometheus .Values.autodetect.istio }}
+      {{- if .Values.featureGates.useLightPrometheusReceiver }}
+      lightprometheus:
+      {{- else }}
       prometheus_simple:
+      {{- end }}
         {{- if .Values.autodetect.prometheus }}
         # Enable prometheus scraping for pods with standard prometheus annotations
         rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
@@ -72,8 +76,12 @@ receivers:
         rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && "istio.io/rev" in labels
         {{- end }}
         config:
+          {{- if .Values.featureGates.useLightPrometheusReceiver }}
+          endpoint: 'http://`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090``"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+          {{- else }}
           metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
           endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+          {{- end }}
       {{- end }}
 
       # Receivers for collecting k8s control plane metrics.

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1460,6 +1460,11 @@
       "description": "cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.",
       "type": "object",
       "additionalProperties": true
+    },
+    "featureGates": {
+      "description": "Helm Chart Feature Gates.",
+      "type": "object",
+      "additionalProperties": true
     }
   },
   "allOf": [

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1344,6 +1344,7 @@ networkExplorer:
       # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
       # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 
+
 ################################################################################
 # Notice: Operator related features should be considered to have an alpha
 # maturity level and be experimental. There may be breaking changes or Operator
@@ -1383,3 +1384,18 @@ operator:
 certmanager:
   enabled: false
   installCRDs: true
+
+
+################################################################################
+# Helm Chart Feature Gates.
+# The following feature gates are used to enable/disable features in the Helm chart
+# that are not yet ready for general availability.
+# Options in this section are not guaranteed to be stable and may change at any time.
+################################################################################
+
+featureGates:
+  # Use Light Prometheus Receiver for metrics collection from discovered Prometheus endpoints.
+  # https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/lightprometheusreceiver
+  # Light Prometheus Receiver is optimized for performance and reduced memory footprint.
+  # From the other hand, it does not support all Prometheus configuration options.
+  useLightPrometheusReceiver: false


### PR DESCRIPTION
Add an option to use experimental light prometheus receiver for metrics collection from discovered Prometheus endpoints.

Light Prometheus Receiver is optimized for performance and reduced memory footprint, but it does not support all Prometheus configuration options and not considered stable at this point.