### PR TITLE
Change ordering in _otel_agent.tpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add `logsCollection.containers.maxRecombineLogSize` config option with default 1Mb value which is applied
   to `max_log_size` option of the multiline recombine operators
+- Move `extraOperators` above `multilineConfig` in _otel_agent.tpl, as `extraOperators` gets
+  skipped when we use both `multilineConfig` AND `extraOperators` in values.yaml
 
 ## [0.75.0] - 2023-04-17
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -369,6 +369,9 @@ receivers:
       - type: move
         from: attributes["log.file.path"]
         to: resource["com.splunk.source"]
+      {{- with .Values.logsCollection.containers.extraOperators }}
+      {{ . | toYaml | nindent 6 }}
+      {{- end }}
       {{- if .Values.logsCollection.containers.multilineConfigs }}
       - type: router
         routes:
@@ -386,9 +389,6 @@ receivers:
         is_first_entry: '(attributes.log) matches {{ .firstEntryRegex | quote }}'
         max_log_size: {{ $.Values.logsCollection.containers.maxRecombineLogSize }}
       {{- end }}
-      {{- end }}
-      {{- with .Values.logsCollection.containers.extraOperators }}
-      {{ . | toYaml | nindent 6 }}
       {{- end }}
       # Clean up log record
       - type: move


### PR DESCRIPTION
Fixes: #633 

Bug:
- When we use both `multilineConfig` AND `extraOperators` in values.yaml, `extraOperators` will be skipped because `multilineConfig` will output directly to the `clean-up-log-record` operator. 
- To fix this, move `extraOperators` above `multilineConfig` in _otel_agent.tpl