### PR TITLE
Enable retry mechanism in filelog receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to `max_log_size` option of the multiline recombine operators
 - Move `extraOperators` above `multilineConfig` in _otel_agent.tpl, as `extraOperators` gets
   skipped when we use both `multilineConfig` AND `extraOperators` in values.yaml
+- Enable retry mechanism in filelog receiver to avoid dropping logs on backpressure from the downstream
+  pipeline components [#764](https://github.com/signalfx/splunk-otel-collector-chart/pull/764)
 
 ## [0.75.0] - 2023-04-17
 

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -231,6 +231,8 @@ data:
           to: body
           type: move
         poll_interval: 200ms
+        retry_on_failure:
+          enabled: true
         start_at: beginning
         storage: file_storage
       fluentforward:

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 1f99befa6da7d4fcb75a5de5a2d23cc42fc31ec8171a51306cac9f2e2cee6fbd
+        checksum/config: 2823864857d08201ec8ed14d36f4ff97d7be5cd2a6289262c3f41817990c0396
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -273,6 +273,8 @@ receivers:
     # https://github.com/open-telemetry/opentelemetry-log-collection/issues/292
     force_flush_period: "0"
     storage: file_storage
+    retry_on_failure:
+      enabled: true
     operators:
       {{- if not .Values.logsCollection.containers.containerRuntime }}
       - type: router


### PR DESCRIPTION
Enable retry mechanism in filelog receiver to avoid dropping logs on back pressure from the downstream pipeline components. In such scenario, the file reading will slow down.