### PR TITLE
Remove excessive istio attributes to avoid hitting the dimensions limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   skipped when we use both `multilineConfig` AND `extraOperators` in values.yaml
 - Enable retry mechanism in filelog receiver to avoid dropping logs on backpressure from the downstream
   pipeline components [#764](https://github.com/signalfx/splunk-otel-collector-chart/pull/764)
+- Drop excessive istio attributes to avoid running into the dimensions limit when scraping istio metrics is enabled [765](https://github.com/signalfx/splunk-otel-collector-chart/pull/765)
 
 ## [0.75.0] - 2023-04-17
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -588,7 +588,7 @@ processors:
 
   {{- if or .Values.autodetect.prometheus .Values.autodetect.istio }}
   # This processor is used to remove excessive istio attributes to avoid running into the dimensions limit.
-  # This configuration assumes single cluster istio deployment. If you run istio in multi-cluster scenarios,
+  # This configuration assumes single cluster istio deployment. If you run istio in multi-cluster scenarios or make use of the canonical service and revision labels,
   # you may need to adjust this configuration.
   attributes/istio:
     include:


### PR DESCRIPTION
Add a new processor attributes/istio to drop excessive istio attributes and avoid running into the dimensions limit if scraping istio metrics is enabled.

(OTL-2117)