### PR TITLE
Migrate to the new GCP detector

### DIFF
--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -132,8 +132,7 @@ data:
       resourcedetection:
         detectors:
         - env
-        - gke
-        - gce
+        - gcp
         - system
         override: true
         timeout: 10s

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -62,8 +62,7 @@ data:
       resourcedetection:
         detectors:
         - env
-        - gke
-        - gce
+        - gcp
         - system
         override: true
         timeout: 10s

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5d2a1b4289837dc64c1c8d563468806b5b5652e88ddfc7c6f745edd1adf74b9e
+        checksum/config: 070373dc99c6cadaa99fe9343d5a7f0fc239a8e25861587912c5634ffaf7c9d4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: edff2f87eb06da7a8d63a49efa9d6e5d1e6014136cd978bf6479c7e28874e512
+        checksum/config: 99d08de9fd9eccbf41d7e68109e009e38ff8a4c3099f06742c63dab29886487e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -132,8 +132,7 @@ data:
       resourcedetection:
         detectors:
         - env
-        - gke
-        - gce
+        - gcp
         - system
         override: true
         timeout: 10s

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -62,8 +62,7 @@ data:
       resourcedetection:
         detectors:
         - env
-        - gke
-        - gce
+        - gcp
         - system
         override: true
         timeout: 10s

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 63de2233ea741780ea88d6575a71e77ca6cbbedf5d74dbb5de63567f526c9591
+        checksum/config: 877ebfcabbe98eabe1caba9c4467f097830717909cb5973d6d639fdd24c396c6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: edff2f87eb06da7a8d63a49efa9d6e5d1e6014136cd978bf6479c7e28874e512
+        checksum/config: 99d08de9fd9eccbf41d7e68109e009e38ff8a4c3099f06742c63dab29886487e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -65,16 +65,14 @@ resourcedetection:
     # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
     # before it gets set later by the cloud provider detector.
     - env
-    {{- if hasPrefix "gke" (include "splunk-otel-collector.distribution" .) }}
-    - gke
+    {{- if or (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (eq (include "splunk-otel-collector.cloudProvider" .) "gcp") }}
+    - gcp
     {{- else if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
     - eks
     {{- else if eq (include "splunk-otel-collector.distribution" .) "aks" }}
     - aks
     {{- end }}
-    {{- if eq (include "splunk-otel-collector.cloudProvider" .) "gcp" }}
-    - gce
-    {{- else if eq (include "splunk-otel-collector.cloudProvider" .) "aws" }}
+    {{- if eq (include "splunk-otel-collector.cloudProvider" .) "aws" }}
     - ec2
     {{- else if eq (include "splunk-otel-collector.cloudProvider" .) "azure" }}
     - azure


### PR DESCRIPTION
`gke` and `gce` detectors in `resourcedetection` processor were merged into `gcp` some time ago. The Splunk OTel collector image keeps the backward compatibility, but throws a warning. This change updates the default configuration to use the new `gcp` detector.