### PR TITLE
Fix `k8s.cluster.name` resource attribute for logs in GCP

### DIFF
--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -260,9 +260,9 @@ data:
           - k8sattributes
           - filter/logs
           - batch
+          - resourcedetection
           - resource
           - resource/logs
-          - resourcedetection
           - resource/add_environment
           receivers:
           - fluentforward

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d6befb402b6be4e019081633b1501469b528b28375c763350d70c9f76bb8eb2e
+        checksum/config: 6fbfc8f17165ab380179fb1ebbe7634b5de98b73054dd7ebc1fed16e69c88c67
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -260,9 +260,9 @@ data:
           - k8sattributes
           - filter/logs
           - batch
+          - resourcedetection
           - resource
           - resource/logs
-          - resourcedetection
           receivers:
           - fluentforward
           - otlp

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 52725852ce15d899f8698b35dd931d38cdbcdee90366c3b01a3dba0d7a2eb3a5
+        checksum/config: d467bd9ef8b6ed4a3143c0983bdcdcbd1c57aa831551a959a1d112a589981e0c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -171,9 +171,9 @@ data:
           - k8sattributes
           - filter/logs
           - batch
+          - resourcedetection
           - resource
           - resource/logs
-          - resourcedetection
           receivers:
           - fluentforward
           - otlp

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 0787206e1625c03c08387c6091bc607ee85163ef5e6ff23225d008ae63575d63
+        checksum/config: 2cb533284133e677e7b44f1e02c6f3961e88bd0cc9fa1c7bb346144d125c8d2d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -267,9 +267,9 @@ data:
           - k8sattributes
           - filter/logs
           - batch
+          - resourcedetection
           - resource
           - resource/logs
-          - resourcedetection
           receivers:
           - filelog
           - fluentforward

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 2823864857d08201ec8ed14d36f4ff97d7be5cd2a6289262c3f41817990c0396
+        checksum/config: 8d60465b07d9c255c7f3c2e0bfdd3c3cfdd08dc3d06edeb7ea1cae1762db4871
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -182,9 +182,9 @@ data:
           - k8sattributes
           - filter/logs
           - batch
+          - resourcedetection
           - resource
           - resource/logs
-          - resourcedetection
           receivers:
           - fluentforward
           - otlp

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 40db516f86848e2f31f508e63834aa7a641f7286f396b476e3089970b05c0376
+        checksum/config: d94db1b6b1253ec1059e3a802e147921cb94c76de23cf955ccb3f7b80b53fd9e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -542,8 +542,10 @@ processors:
   # attributes from container environments.
   {{- include "splunk-otel-collector.resourceDetectionProcessor" . | nindent 2 }}
 
+  # General resource attributes that apply to all telemetry passing through the agent.
+  # It's important to put this processor after resourcedetection to make sure that
+  # k8s.name.cluster attribute is always set to "{{ .Values.clusterName }}".
   resource:
-    # General resource attributes that apply to all telemetry passing through the agent.
     attributes:
       - action: insert
         key: k8s.node.name
@@ -698,6 +700,7 @@ service:
         - filter/logs
         {{- end }}
         - batch
+        - resourcedetection
         - resource
         {{- if not $gatewayEnabled }}
         {{- if .Values.splunkPlatform.fieldNameConvention.renameFieldsSck }}
@@ -705,7 +708,6 @@ service:
         {{- end }}
         - resource/logs
         {{- end }}
-        - resourcedetection
         {{- if .Values.environment }}
         - resource/add_environment
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -104,6 +104,8 @@ processors:
         key: k8s.namespace.name
         value: "${K8S_NAMESPACE}"
 
+  # It's important to put this processor after resourcedetection to make sure that
+  # k8s.name.cluster attribute is always set to "{{ .Values.clusterName }}".
   resource/add_cluster_name:
     attributes:
       - action: upsert


### PR DESCRIPTION
https://github.com/signalfx/splunk-otel-collector-chart/pull/660 changed the order of `resourcedetection` and `resource` processors in the logs pipeline, while the other pipelines were unchanged. This order is crucial because the `resourcedetection` processor's `gcp` detector sets the `k8s.cluster.name` attribute, which we then override with the user-provided value in the `resource` processor. By keeping the `resource` processor after the `resourcedetection` processor, we ensure that `k8s.cluster.name` attribute is always set with the user-provided value.

This change ensures that the order of processors is consistent across all pipelines, guaranteeing that the `k8s.cluster.name` attribute is always set to the value provided in the `clusterName` field of the values.yaml file.