### PR TITLE
[chore] Allow enabling profiling only for Observability

### DIFF
--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -218,6 +218,13 @@
               "const": true
             }
           }
+        },
+        {
+          "properties": {
+            "profilingEnabled": {
+              "const": true
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
This change allows the chart to be deployed just to pass profiling data to Splunk Observability