### PR TITLE
Add deployment.environment to metrics always instead of just when splunkPlatform metrics are enabled

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -805,7 +805,7 @@ service:
         {{- end }}
         - resourcedetection
         - resource
-        {{- if (and .Values.splunkPlatform.metricsEnabled .Values.environment) }}
+        {{- if .Values.environment }}
         - resource/add_environment
         {{- end }}
         {{- if .Values.isWindows }}


### PR DESCRIPTION
When pulling in some prometheus generated metrics via annotations, I noticed the deployment.environment key was not getting set in SignalFx.

This PR changes it so that key always gets set when environment is set in the values file.