### PR TITLE
Update eks distro example with receiver to scrape k8s api-server metrics

### DIFF
--- a/examples/distribution-eks/distribution-eks-values.yaml
+++ b/examples/distribution-eks/distribution-eks-values.yaml
@@ -5,3 +5,34 @@ splunkObservability:
 
 distribution: eks
 cloudProvider: aws
+
+clusterReceiver:
+  config:
+    receivers:
+     # -- Example receiver to collect k8s api server metrics from EKS
+     # You can find the list of metrics available by running
+     # "kubectl get --raw /metrics" command against an EKS cluster
+      prometheus/k8s-api-server:
+        config:
+          scrape_configs:
+            - job_name: 'api-server-metrics'
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              scheme: https
+              scrape_interval: 120s
+              static_configs:
+                - targets:
+                  - ${KUBERNETES_SERVICE_HOST}:443
+              metric_relabel_configs:
+                - action: keep
+                  source_labels:
+                  - __name__
+                  regex: "(apiserver_request_total|etcd_db_total_size_in_bytes|apiserver_storage_objects)"
+    service:
+      pipelines:
+        metrics:
+          receivers:
+            - k8s_cluster
+            - prometheus/k8s-api-server

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -72,6 +72,24 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+      prometheus/k8s-api-server:
+        config:
+          scrape_configs:
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            job_name: api-server-metrics
+            metric_relabel_configs:
+            - action: keep
+              regex: (apiserver_request_total|etcd_db_total_size_in_bytes|apiserver_storage_objects)
+              source_labels:
+              - __name__
+            scheme: https
+            scrape_interval: 120s
+            static_configs:
+            - targets:
+              - ${KUBERNETES_SERVICE_HOST}:443
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -95,6 +113,7 @@ data:
           - resource/k8s_cluster
           receivers:
           - k8s_cluster
+          - prometheus/k8s-api-server
         metrics/collector:
           exporters:
           - signalfx

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8001b51ebfce881b1c8abc882ab774911d7802e086bed3e761a514e990846566
+        checksum/config: 8aab824104cae064e8fdee23e3351d3b9c586e88800468183ec8fcc5a9a8e096
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
This PR adds a new receiver to the eks distribution example to show users how they can make use of the prometheus receiver to scrape and report metrics from k8s api-server in a managed cluster like EKS.