### PR TITLE
[chore] Add a comment for `environment.deployment` attribute

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -806,7 +806,7 @@ service:
         - resourcedetection
         - resource
         {{/*
-        `deployment.environment` atributes is not being set on metrics sent to Splunk Observability because it's already synced as `sf_environment` property.
+        The attribute `deployment.environment` is not being set on metrics sent to Splunk Observability because it's already synced as the `sf_environment` property.
         More details: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#traces-configuration-correlation-only
         */}}
         {{- if (and .Values.splunkPlatform.metricsEnabled .Values.environment) }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -805,6 +805,10 @@ service:
         {{- end }}
         - resourcedetection
         - resource
+        {{/*
+        `deployment.environment` atributes is not being set on metrics sent to Splunk Observability because it's already synced as `sf_environment` property.
+        More details: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#traces-configuration-correlation-only
+        */}}
         {{- if (and .Values.splunkPlatform.metricsEnabled .Values.environment) }}
         - resource/add_environment
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -219,6 +219,10 @@ service:
         {{- if .Values.extraAttributes.custom }}
         - resource/add_custom_attrs
         {{- end }}
+        {{/*
+        `deployment.environment` atributes is not being set on metrics sent to Splunk Observability because it's already synced as `sf_environment` property.
+        More details: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#traces-configuration-correlation-only
+        */}}
         {{- if (and .Values.splunkPlatform.metricsEnabled .Values.environment) }}
         - resource/add_environment
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -220,7 +220,7 @@ service:
         - resource/add_custom_attrs
         {{- end }}
         {{/*
-        `deployment.environment` atributes is not being set on metrics sent to Splunk Observability because it's already synced as `sf_environment` property.
+        The attribute `deployment.environment` is not being set on metrics sent to Splunk Observability because it's already synced as the `sf_environment` property.
         More details: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter#traces-configuration-correlation-only
         */}}
         {{- if (and .Values.splunkPlatform.metricsEnabled .Values.environment) }}


### PR DESCRIPTION
Add a comment clarifying the absence of the `environment.deployment` attribute on the metrics sent to Splunk Observability.

Following up on https://github.com/signalfx/splunk-otel-collector-chart/pull/791