### PR TITLE
Update the Kubernetes Proxy monitor for OpenShift clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Adopt new control-plane node toleration [#814](https://github.com/signalfx/splunk-otel-collector-chart/pull/814)
 
+### Changed
+
+- Update the Kubernetes Proxy monitor for OpenShift clusters to start using secure ports 9101 or 29101 with authentication [#810](https://github.com/signalfx/splunk-otel-collector-chart/pull/810)
+
 ## [0.78.0] - 2023-06-07
 
 This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk OpenTelemetry Collector v0.78.1](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.78.1).

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -214,9 +214,12 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-proxy
-              port: 29101
+              skipVerify: true
               type: kubernetes-proxy
-            rule: type == "pod" && labels["app"] == "sdn"
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "port" && pod.labels["app"] == "sdn" && (port == 9101 || port
+              == 29101)
           smartagent/kubernetes-scheduler:
             config:
               extraDimensions:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5015b9567107e9b822bc7f80d80f9a90ecc1e37288493008310feaf2c5077723
+        checksum/config: 9308e59c21f2728caccbf91037441f223382a6ccb0ca2c8078abd4a70cd55c78
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -91,7 +91,7 @@ receivers:
 
       # Receivers for collecting k8s control plane metrics.
       # Distributions besides Kubernetes and Openshift are not supported.
-      # Verified with Kubernetes v1.22 and Openshift v4.9.
+      # Verified with Kubernetes v1.22 and Openshift v4.10.59.
       {{- if or (eq .Values.distribution "openshift") (eq .Values.distribution "") }}
       # Below, the TLS certificate verification is often skipped because the k8s default certificate is self signed and
       # will fail the verification.
@@ -173,7 +173,7 @@ receivers:
       {{- if .Values.agent.controlPlaneMetrics.proxy.enabled }}
       smartagent/kubernetes-proxy:
         {{- if eq .Values.distribution "openshift" }}
-        rule: type == "pod" && labels["app"] == "sdn"
+        rule: type == "port" && pod.labels["app"] == "sdn" && (port == 9101 || port == 29101)
         {{- else }}
         rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
         {{- end }}
@@ -182,7 +182,9 @@ receivers:
             metric_source: kubernetes-proxy
           type: kubernetes-proxy
           {{- if eq .Values.distribution "openshift" }}
-          port: 29101
+          skipVerify: true
+          useHTTPS: true
+          useServiceAccount: true
           {{- else }}
           port: 10249
           {{- end }}


### PR DESCRIPTION
Description:
Stop using insecure port 29101 and start using secure port 9101 with authentication.

Attaching notes for each version investigated and tested.
- OpenShift v4.10.59
  - Successfully work and scrapes Kube Proxy metrics from SDN pods.
- OpenShift v4.11-4.13
  - [OVN](https://docs.openshift.com/container-platform/4.12/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html?extIdCarryOver=true&intcmp=7013a000002CtetAAC&sc_cid=701f2000001OH7iAAG#about-ovn-kubernetes) was installed by default instead of [SDN](https://docs.openshift.com/container-platform/3.11/architecture/networking/sdn.html).
  - OVN metrics didn't look compatible with the SA Kube Proxy receiver from a first look. 
  - The Kube proxy metrics could not be collected from "out of the box" OpenShift clusters of these versions. Will add documentation and code changes later for collecting OVN Prometheus metrics.