### PR TITLE
Fix cri-o log format time layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Fix cri-o log format time layout [#817](https://github.com/signalfx/splunk-otel-collector-chart/pull/817)
+
 ## [0.79.0] - 2023-16-07
 
 This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk OpenTelemetry Collector v0.79.0](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.79.0).

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -155,7 +155,7 @@ data:
         - id: parser-crio
           regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
           timestamp:
-            layout: "2006-01-02T15:04:05.999999999-07:00"
+            layout: 2006-01-02T15:04:05.999999999Z07:00
             layout_type: gotime
             parse_from: attributes.time
           type: regex_parser

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7b50a263d2916690b8e710aae9ab2b5415ce7f42e020b7f0724e180c33f320f0
+        checksum/config: 16ee76d72fcbdb9a005ca1e2da9c15e0c50a84075f7804dd0f2e1e326a556b18
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -155,7 +155,7 @@ data:
         - id: parser-crio
           regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
           timestamp:
-            layout: "2006-01-02T15:04:05.999999999-07:00"
+            layout: 2006-01-02T15:04:05.999999999Z07:00
             layout_type: gotime
             parse_from: attributes.time
           type: regex_parser

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 693edcd9dc744f0f0fd7b385e02f02cf165a1829d80e84345ab56208cef85f31
+        checksum/config: ee9d8b641e0a025163ba311ffc26fdfa4606eb017257a38cc01002bf10d65d58
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -297,7 +297,7 @@ receivers:
         timestamp:
           parse_from: attributes.time
           layout_type: gotime
-          layout: '2006-01-02T15:04:05.999999999-07:00'
+          layout: '2006-01-02T15:04:05.999999999Z07:00'
       - type: recombine
         id: crio-recombine
         output: handle_empty_log


### PR DESCRIPTION
Related Issues (duplicates):
- https://github.com/signalfx/splunk-otel-collector-chart/issues/644
- https://github.com/open-telemetry/opentelemetry-helm-charts/issues/718

Description:

- Adopting a bug fix from the community. Basically the root cause of the bug being fixed is containerd log formats are not as finalized as CRI-O and Docker log formats. containerd log formats have recently changed in some K8s environments to look very much like CRI-O log formats. 
- The community has updated the CRI-O parser to accept containerd logs that are formatted very similarly to CRI-O logs, which fixes this bug. We may only need one parser for CRI-O and containerd logs in the future. 
- Keeping our current containerd parser would be a good idea for now for having legacy containerd format support.