### PR TITLE
Reuse k8s attributes processor configuration between agent and gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix cri-o log format time layout [#817](https://github.com/signalfx/splunk-otel-collector-chart/pull/817)
+- Align the set of default resource attributes added by k8s attributes processor if the gateway is enabled [#818](https://github.com/signalfx/splunk-otel-collector-chart/pull/818)
 
 ## [0.79.0] - 2023-16-07
 

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -69,6 +69,9 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         pod_association:
         - sources:
           - from: resource_attribute

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 5cab42d674e75c5ac547095e8eaa31b82d76315a154189734ede0d226cf663f6
+        checksum/config: c4860a3e5d03fdc5031fcd1038a2eda9ab7744b92d6b077b76ff4b069cafed99
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -69,6 +69,9 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         pod_association:
         - sources:
           - from: resource_attribute

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 5cab42d674e75c5ac547095e8eaa31b82d76315a154189734ede0d226cf663f6
+        checksum/config: c4860a3e5d03fdc5031fcd1038a2eda9ab7744b92d6b077b76ff4b069cafed99
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -69,6 +69,9 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         pod_association:
         - sources:
           - from: resource_attribute

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9848fcd2a620b379318b96591c2b2d9c2ce5465fea6bf33614a1ba19fde6df47
+        checksum/config: 789e3881a9368310e1d143b9fce8a756f2d1cc9f49ccbdba90ed014bf8f50b0e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-network-explorer/rendered_manifests/configmap-gateway.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/configmap-gateway.yaml
@@ -69,6 +69,9 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
         pod_association:
         - sources:
           - from: resource_attribute

--- a/examples/enable-network-explorer/rendered_manifests/deployment-gateway.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 5cab42d674e75c5ac547095e8eaa31b82d76315a154189734ede0d226cf663f6
+        checksum/config: c4860a3e5d03fdc5031fcd1038a2eda9ab7744b92d6b077b76ff4b069cafed99
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -85,6 +85,60 @@ resourcedetection:
 {{- end }}
 
 {{/*
+Common config for K8s attributes processor adding k8s metadata to resource attributes.
+*/}}
+{{- define "splunk-otel-collector.k8sAttributesProcessor" -}}
+k8sattributes:
+  pod_association:
+    - sources:
+      - from: resource_attribute
+        name: k8s.pod.uid
+    - sources:
+      - from: resource_attribute
+        name: k8s.pod.ip
+    - sources:
+      - from: resource_attribute
+        name: ip
+    - sources:
+      - from: connection
+    - sources:
+      - from: resource_attribute
+        name: host.name
+  extract:
+    metadata:
+      - k8s.namespace.name
+      - k8s.node.name
+      - k8s.pod.name
+      - k8s.pod.uid
+      - container.id
+      - container.image.name
+      - container.image.tag
+    annotations:
+      - key: splunk.com/sourcetype
+        from: pod
+      - key: {{ include "splunk-otel-collector.filterAttr" . }}
+        tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
+        from: namespace
+      - key: {{ include "splunk-otel-collector.filterAttr" . }}
+        tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
+        from: pod
+      - key: splunk.com/index
+        tag_name: com.splunk.index
+        from: namespace
+      - key: splunk.com/index
+        tag_name: com.splunk.index
+        from: pod
+      {{- include "splunk-otel-collector.addExtraAnnotations" . | nindent 6 }}
+    {{- if or .Values.extraAttributes.podLabels .Values.extraAttributes.fromLabels }}
+    labels:
+      {{- range .Values.extraAttributes.podLabels }}
+      - key: {{ . }}
+      {{- end }}
+      {{- include "splunk-otel-collector.addExtraLabels" . | nindent 6 }}
+    {{- end }}
+{{- end }}
+
+{{/*
 Resource processor for logs manipulations
 */}}
 {{- define "splunk-otel-collector.resourceLogsProcessor" -}}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -456,8 +456,8 @@ receivers:
 
 # By default k8sattributes and batch processors enabled.
 processors:
-  # k8sattributes enriches traces and metrics with k8s metadata
-  k8sattributes:
+  {{- include "splunk-otel-collector.k8sAttributesProcessor" . | nindent 2 }}
+    # Agent specific configuration of k8sattributes:
     # If gateway deployment is enabled, the `passthrough` configuration is enabled by default.
     # It means that traces and metrics enrichment happens in the gateway, and the agent only passes information
     # about traces and metrics source, without calling k8s API.
@@ -466,53 +466,6 @@ processors:
     {{- end }}
     filter:
       node_from_env_var: K8S_NODE_NAME
-    pod_association:
-      - sources:
-        - from: resource_attribute
-          name: k8s.pod.uid
-      - sources:
-        - from: resource_attribute
-          name: k8s.pod.ip
-      - sources:
-        - from: resource_attribute
-          name: ip
-      - sources:
-        - from: connection
-      - sources:
-        - from: resource_attribute
-          name: host.name
-    extract:
-      metadata:
-        - k8s.namespace.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
-        - container.id
-        - container.image.name
-        - container.image.tag
-      annotations:
-        - key: splunk.com/sourcetype
-          from: pod
-        - key: {{ include "splunk-otel-collector.filterAttr" . }}
-          tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
-          from: namespace
-        - key: {{ include "splunk-otel-collector.filterAttr" . }}
-          tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
-          from: pod
-        - key: splunk.com/index
-          tag_name: com.splunk.index
-          from: namespace
-        - key: splunk.com/index
-          tag_name: com.splunk.index
-          from: pod
-        {{- include "splunk-otel-collector.addExtraAnnotations" . | nindent 8 }}
-      {{- if or .Values.extraAttributes.podLabels .Values.extraAttributes.fromLabels }}
-      labels:
-        {{- range .Values.extraAttributes.podLabels }}
-        - key: {{ . }}
-        {{- end }}
-        {{- include "splunk-otel-collector.addExtraLabels" . | nindent 8 }}
-      {{- end }}
 
   {{- if eq .Values.logsEngine "fluentd" }}
   # Move flat fluentd logs attributes to resource attributes

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -33,52 +33,7 @@ receivers:
 
 # By default k8sattributes, memory_limiter and batch processors enabled.
 processors:
-  k8sattributes:
-    pod_association:
-      - sources:
-        - from: resource_attribute
-          name: k8s.pod.uid
-      - sources:
-        - from: resource_attribute
-          name: k8s.pod.ip
-      - sources:
-        - from: resource_attribute
-          name: ip
-      - sources:
-        - from: connection
-      - sources:
-        - from: resource_attribute
-          name: host.name
-    extract:
-      metadata:
-        - k8s.namespace.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
-      annotations:
-        - key: splunk.com/sourcetype
-          from: pod
-        - key: {{ include "splunk-otel-collector.filterAttr" . }}
-          tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
-          from: namespace
-        - key: {{ include "splunk-otel-collector.filterAttr" . }}
-          tag_name: {{ include "splunk-otel-collector.filterAttr" . }}
-          from: pod
-        - key: splunk.com/index
-          tag_name: com.splunk.index
-          from: namespace
-        - key: splunk.com/index
-          tag_name: com.splunk.index
-          from: pod
-        {{- include "splunk-otel-collector.addExtraAnnotations" . | nindent 8 }}
-      {{- if or .Values.extraAttributes.podLabels .Values.extraAttributes.fromLabels }}
-      labels:
-        {{- range .Values.extraAttributes.podLabels }}
-        - key: {{ . }}
-        {{- end }}
-        {{- include "splunk-otel-collector.addExtraLabels" . | nindent 8 }}
-      {{- end }}
-
+  {{- include "splunk-otel-collector.k8sAttributesProcessor" . | nindent 2 }}
   {{- include "splunk-otel-collector.resourceLogsProcessor" . | nindent 2 }}
   {{- include "splunk-otel-collector.filterLogsProcessors" . | nindent 2 }}
 


### PR DESCRIPTION
This also fixes an inconsistency between resource attributes added by default depending on whether the gateway is enabled or not. The gateway was missing the following attributes:
  - container.id
  - container.image.name
  - container.image.tag