### PR TITLE
Add sudo to apt commands

### DIFF
--- a/.github/workflows/update_java_agent.yaml
+++ b/.github/workflows/update_java_agent.yaml
@@ -41,10 +41,10 @@ jobs:
         run: |
           echo Making the templates
           curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-          apt install -y apt-transport-https
+          sudo apt install -y apt-transport-https
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-          apt update
-          apt install -y build-essential zip helm gh
+          sudo apt update
+          sudo apt install -y build-essential zip helm gh
           make render
           git --no-pager diff
       - name: PR the new version


### PR DESCRIPTION
The job fails without `sudo` 
https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/5348164185/jobs/9697669471#step:4:27