### PR TITLE
Add service.name attribute to OTel logs if istio autodetect is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Add `service.name` resource attribute to logs if `autodetect.istio` is enabled using transform processor. This change
+  removes the limitation of `service.name` attribute being available only with logsEngine=fluentd.
+  [#823](https://github.com/signalfx/splunk-otel-collector-chart/pull/823)
+
 ## [0.79.1] - 2023-06-22
 
 This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk OpenTelemetry Collector v0.79.1](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.79.1).

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -405,13 +405,7 @@ The following configuration can be used to achieve that:
 logsEngine: otel
 ```
 
-There are following known limitations of native OTel logs collection:
-
-- `service.name` attribute will not be automatically constructed in istio environment.
-  This means that correlation between logs and traces will not work in Splunk Observability.
-  Logs collection with fluentd is still recommended if chart deployed with `autodetect.istio=true`.
-- Not yet supported in GKE Autopilot.
-
+**NOTE:** Native OTel logs collection is not yet supported in GKE Autopilot.
 
 ### Add log files from Kubernetes host machines/volumes
 

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -106,7 +106,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 0e659dd84e4c56bccb171e6ad0b584ce8a7b81de1089772cfa49d94fbfffb424
+        checksum/config: e68f45dc5d5ad899a71a006ace9941aaa37d88abf3b8d2680fda8672c3681acd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 73bb1b751fafde7671fd780e39ae4cc6281822ddcc0d1d2da197b286afb71c39
+        checksum/config: 87c798151a01dd47d4706373a0b092d87104a41f5b6f2c415c763ccdc43d6e1b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 4a002be3c7ecd4042a2956e482a462b376464ccfe53f25c34ef8c72086196b07
+        checksum/config: 5e482b805db2c896dfb2132882c8483c3eeedd75b44adbf0ef3864e602a17b7a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -73,7 +73,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name
@@ -153,20 +152,29 @@ data:
           key: k8s.pod.annotations.splunk.com/sourcetype
         - action: delete
           key: splunk.com/exclude
-        - action: insert
-          from_attribute: k8s.pod.labels.app
-          key: service.name
-        - action: insert
-          from_attribute: istio_service_name
-          key: service.name
-        - action: delete
-          key: istio_service_name
       resourcedetection:
         detectors:
         - env
         - system
         override: true
         timeout: 10s
+      transform/istio_service_name:
+        error_mode: ignore
+        log_statements:
+        - context: resource
+          statements:
+          - set(attributes["service.name"], Concat([attributes["k8s.pod.labels.app"],
+            attributes["k8s.namespace.name"]], ".")) where attributes["service.name"]
+            == nil and attributes["k8s.pod.labels.app"] != nil and attributes["k8s.namespace.name"]
+            != nil
+          - set(cache["owner_name"], attributes["k8s.pod.name"]) where attributes["service.name"]
+            == nil and attributes["k8s.pod.name"] != nil
+          - replace_pattern(cache["owner_name"], "^(.+?)-(?:(?:[0-9bcdf]+-)?[bcdfghjklmnpqrstvwxz2456789]{5}|[0-9]+)$$",
+            "$$1") where attributes["service.name"] == nil and cache["owner_name"] !=
+            nil
+          - set(attributes["service.name"], Concat([cache["owner_name"], attributes["k8s.namespace.name"]],
+            ".")) where attributes["service.name"] == nil and cache["owner_name"] != nil
+            and attributes["k8s.namespace.name"] != nil
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:8006
@@ -291,6 +299,7 @@ data:
           - batch
           - resourcedetection
           - resource
+          - transform/istio_service_name
           - resource/logs
           receivers:
           - fluentforward

--- a/examples/autodetect-istio/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-fluentd.yaml
@@ -265,17 +265,6 @@ data:
         @type jq_transformer
         jq '.record | . + (.source | capture("^/var/log/containers/(?<k8s.pod.name>[^_]+)_(?<k8s.namespace.name>[^_]+)_(?<k8s.container.name>[-0-9a-z]+)-(?<container.id>[^.]+).log$")) | . + (.pods_source | capture("^/var/log/pods/[^_]+_[^_]+_(?<k8s.pod.uid>[^/]+)/[^._]+/[0-9]+.log$") // {}) | .sourcetype = ("kube:container:" + .["k8s.container.name"])'
       </filter>
-      # This filter prepares a temporary "istio_service_name" attribute, the same way as istio service name is generated:
-      # https://github.com/istio/istio/blob/77e00b47a61f0e995a29b33438c9dae7e8aace82/galley/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml#L110-L115
-      # The temporary "istio_service_name" attribute will be used to set "service.name" attribute in otel-collector
-      # if the pod doesn't have "app" label that should be used instead.
-      # Name of the k8s deployment (or another object owning the pod, if any) is taken from "k8s.pod.name" attribute
-      # using regex to filter out name suffix according to the k8s name generation rules:
-      # https://github.com/kubernetes/apimachinery/blob/ff522ab81c745a9ac5f7eeb7852fac134194a3b6/pkg/util/rand/rand.go#L92-L127
-      <filter tail.containers.**>
-        @type jq_transformer
-        jq '.record | . + (.istio_service_name = (.["k8s.pod.name"] // "istio-proxy" | (capture("^(?<owner_obj>.+?)-(?:(?:[0-9bcdf]+-)?[bcdfghjklmnpqrstvwxz2456789]{5}|[0-9]+)$") | .owner_obj) // .) + "." + (.["k8s.namespace.name"] // "default"))'
-      </filter>
 
       @include output.transform.conf
 

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3dcdac57b9acfe1d3a51cdb8872327133f0fe0fce9cae720decb59c9b5e1d572
+        checksum/config: 87750c2383c72b2201b89caa4951c926b837abf514b7f599b4debb43e37fa22a
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d677ec3f0e904bb1d72a470e752d7af2428ca2abd550efa7903c6455f33fb0d5
+        checksum/config: e99d38672d7af00809472d0007d39b7347034ee8ce712211c1618b97541b1dc6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -43,7 +43,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d36d21c3e2606683d3ab18e55ba866ba14085e642c64f2fc4f2143659afe52fe
+        checksum/config: b31f3459bf195bd6989c1ce5664661e08afc35ff5baf721cf9c78a26cf5258c0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d677ec3f0e904bb1d72a470e752d7af2428ca2abd550efa7903c6455f33fb0d5
+        checksum/config: e99d38672d7af00809472d0007d39b7347034ee8ce712211c1618b97541b1dc6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d677ec3f0e904bb1d72a470e752d7af2428ca2abd550efa7903c6455f33fb0d5
+        checksum/config: e99d38672d7af00809472d0007d39b7347034ee8ce712211c1618b97541b1dc6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d2a325f645878a01cd9d15840fc0cff915b54ba47ef602de5eb397c5a80dbf25
+        checksum/config: 5d5f7d9cc3f9bc3690445766b2dc8a6dbbce54ae23eb256dbe0c4fb53defd0df
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 72d3ef35708d73f557805c4b1db518e7d8aef5cf7b7ebbccc8e11dec49357ae2
+        checksum/config: 5a8514057f579502b8b9640a609b58b826628f893041ef02f821c0d1bea065cd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 8365dc8340154bb78c831b3956d74815c2ca44e993963323c5d7354ee297a1de
+        checksum/config: ea693c3c977e21d215446e3e7080ac790920ad791c52ac8f0211aad7dc8acbf4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6cb593faafc430464e95eaf75183572e881f3108044e604e8c9616f958eddf85
+        checksum/config: eb2ced9b70520485eb1a994662e8c7ac3adeb4262abcf78cd17bf8bc4fe0ce81
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 1baf515d058a316405140bf3ce0c256d2601779c136d2c01677b2f353a2c8f07
+        checksum/config: 969ec02296836b0917b17f0170841501916fa0020dd80c66587cc56d5b46beea
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -55,7 +55,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 77141e6b825568f2b99e4235b5614805f96bda4ffb5fa03032d7c3bf6b4edb4e
+        checksum/config: 60369ef4feaed6cbdda1f91c81849dde8c208171d08b63b59b3188efccd5f5dc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: b8e177ef50524fef9e40b7d4c02f78b43a5c52f97951865dff14f24748a193a0
+        checksum/config: 0485c3f47b38fecdd2131aef3b8f2ce58f4afbe377dec55a5d89c293bd96a996
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -50,7 +50,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 337ee1825559991ba530b0c9e3f8665b3b0ee80d05cbfba3bac6607dbaa85c13
+        checksum/config: 808af141c721889928fbf37843e21ae5a801ad23926906fe8079bea4a770f6f2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -55,7 +55,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: dceee6ef27f7c36204ff332651c0b9187d7ebb1ce03423b86353d782c8648174
+        checksum/config: d87484626e31781d3dea049ff2075477ad2a97a621d3ac121493e4f2dc4def7b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -55,7 +55,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: af7400ed3ac68ca7068436ff14ea959fbf5674221428be4ebea8da50e6ebfd06
+        checksum/config: 23e792e836f91801b7fb680f3680e1e241dfd137435aa40916061d6fc75ded0e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -52,7 +52,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 1fa8fbdb0cb148c37a72d98f167437ab15bd9f599037f0535537819de20fc36c
+        checksum/config: 5a1bf72129fc7eaf0cf9f5ef7ee96dad77cf58d84d6ab8a223169994153b82da
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -62,7 +62,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 0c250513f2c05a32aedd30fe7694b9bae0c5d24c15193a743935e8ab45bf8035
+        checksum/config: b393364934cbda7ad4bcde838bb274760ffbc3971c0aa9c777d3fc8c898b7f5c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -46,7 +46,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 8e8168a794ebaa044768314918f15fa02bfb0daf46dca23edcc7eca9e49a7e05
+        checksum/config: 7c11b28537f12f684a817d4ed09b02084837caec54a020db5662aeba01a5eaf6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: c1923a3cf02f32f5ae0852266af6315627e83475ef462bb13cb4ed9f560274c0
+        checksum/config: 64e922f5ba6e799a70b35dbbdc8d71b77d461123f694c8d480f1cbeba0bc15c2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -53,7 +53,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 76a5e8b2f51cd941c059caa40b6fff316159945e684d41436520c7d5ae9c63ee
+        checksum/config: ec918d7a65deba43bb887b074d3b8fdff4e901f6db9e99d1de354420995ae57d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -63,7 +63,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 9696c7e48c9a06e16464696187de7a269bce57ae6e24457765bac38da9f2cf06
+        checksum/config: 657e453d077ac5560d5e0d3590c60a37a1630003308fe4611e28c86e556c6ba6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -49,7 +49,6 @@ data:
         - com.splunk.sourcetype
         - container.id
         - fluent.tag
-        - istio_service_name
         - k8s.container.name
         - k8s.namespace.name
         - k8s.pod.name

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d677ec3f0e904bb1d72a470e752d7af2428ca2abd550efa7903c6455f33fb0d5
+        checksum/config: e99d38672d7af00809472d0007d39b7347034ee8ce712211c1618b97541b1dc6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -35,6 +35,9 @@ receivers:
 processors:
   {{- include "splunk-otel-collector.k8sAttributesProcessor" . | nindent 2 }}
   {{- include "splunk-otel-collector.resourceLogsProcessor" . | nindent 2 }}
+  {{- if .Values.autodetect.istio }}
+  {{- include "splunk-otel-collector.transformLogsProcessor" . | nindent 2 }}
+  {{- end }}
   {{- include "splunk-otel-collector.filterLogsProcessors" . | nindent 2 }}
 
   {{- include "splunk-otel-collector.otelMemoryLimiterConfig" . | nindent 2 }}
@@ -207,6 +210,9 @@ service:
         - k8sattributes
         - filter/logs
         - batch
+        {{- if .Values.autodetect.istio }}
+        - transform/istio_service_name
+        {{- end }}
         - resource/logs
       exporters:
         {{- if (eq (include "splunk-otel-collector.o11yLogsOrProfilingEnabled" .) "true") }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -204,20 +204,6 @@ data:
         jq '.record | . + (.source | capture("^/var/log/containers/(?<k8s.pod.name>[^_]+)_(?<k8s.namespace.name>[^_]+)_(?<k8s.container.name>[-0-9a-z]+)-(?<container.id>[^.]+).log$")) | . + (.pods_source | capture("^/var/log/pods/[^_]+_[^_]+_(?<k8s.pod.uid>[^/]+)/[^._]+/[0-9]+.log$") // {}) | .sourcetype = ("kube:container:" + .["k8s.container.name"])'
       </filter>
 
-      {{- if .Values.autodetect.istio }}
-      # This filter prepares a temporary "istio_service_name" attribute, the same way as istio service name is generated:
-      # https://github.com/istio/istio/blob/77e00b47a61f0e995a29b33438c9dae7e8aace82/galley/pkg/config/analysis/analyzers/testdata/common/sidecar-injector-configmap.yaml#L110-L115
-      # The temporary "istio_service_name" attribute will be used to set "service.name" attribute in otel-collector
-      # if the pod doesn't have "app" label that should be used instead.
-      # Name of the k8s deployment (or another object owning the pod, if any) is taken from "k8s.pod.name" attribute
-      # using regex to filter out name suffix according to the k8s name generation rules:
-      # https://github.com/kubernetes/apimachinery/blob/ff522ab81c745a9ac5f7eeb7852fac134194a3b6/pkg/util/rand/rand.go#L92-L127
-      <filter tail.containers.**>
-        @type jq_transformer
-        jq '.record | . + (.istio_service_name = (.["k8s.pod.name"] // "istio-proxy" | (capture("^(?<owner_obj>.+?)-(?:(?:[0-9bcdf]+-)?[bcdfghjklmnpqrstvwxz2456789]{5}|[0-9]+)$") | .owner_obj) // .) + "." + (.["k8s.namespace.name"] // "default"))'
-      </filter>
-      {{- end }}
-
       @include output.transform.conf
 
       # create source and sourcetype

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -198,6 +198,10 @@ distribution: ""
 
 autodetect:
   prometheus: false
+  # This option is recommended for istio environments. It does the following things:
+  # - Enables scraping istio control plane metrics from Promethes endpoints.
+  # - Add a `service.name` resource attribute to logs with the same value as istio generates for
+  #   traces to enable correlation between logs and traces usign this attribute.
   istio: false
 
 ################################################################################


### PR DESCRIPTION
Add `service.name` resource attribute to logs if `autodetect.istio` is enabled using transform processor instead of using fluentd jq plugin. This change removes the limitation of `service.name` attribute being available only with logsEngine=fluentd.

Once https://github.com/signalfx/splunk-otel-collector-chart/pull/826 merged, the rendered diff will show the istio related changes