### PR TITLE
Do not mount docker logs path in GKE Autopilot

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -390,9 +390,11 @@ spec:
         - name: varlog
           mountPath: /var/log
           readOnly: true
+        {{- if (not (eq .Values.distribution "gke/autopilot")) }}
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        {{- end }}
         {{- end }}
         - name: checkpoint
           mountPath: {{ .Values.logsCollection.checkpointPath }}
@@ -446,9 +448,11 @@ spec:
       - name: varlog
         hostPath:
           path: /var/log
+      {{- if (not (eq .Values.distribution "gke/autopilot")) }}
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      {{- end }}
       {{- end }}
       - name: checkpoint
         hostPath:


### PR DESCRIPTION
The path is not needed in GKE Autopilot because it doesn't come with docker engine. This is a preparation to allow native logs collection in Autopilot cluster which is currently not supported, so no need to a changelog entry.