### PR TITLE
Update the log level for metric scrape failures of the smartagent/kubernetes-proxy receiver from error to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Upgrade the Splunk OpenTelemetry Collector for Kubernetes subchart dependencies [#828](https://github.com/signalfx/splunk-otel-collector-chart/pull/828)
   - cert-manager upgraded from 1.11.1 to [1.12.2](https://github.com/cert-manager/cert-manager/releases/tag/v1.12.2)
   - opentelemetry-operator upgraded from 0.28.0 to [0.32.0)](https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-operator-0.32.0)
-- Update the log level of metric scrape failures of control plane smart agent receivers from error to debug [#832](https://github.com/signalfx/splunk-otel-collector-chart/pull/832)
+- Update the log level for metric scrape failures of the smartagent/kubernetes-proxy receiver from error to debug when distribution='' [#832](https://github.com/signalfx/splunk-otel-collector-chart/pull/832)
 
 ## [0.79.1] - 2023-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Upgrade the Splunk OpenTelemetry Collector for Kubernetes subchart dependencies [#828](https://github.com/signalfx/splunk-otel-collector-chart/pull/828)
   - cert-manager upgraded from 1.11.1 to [1.12.2](https://github.com/cert-manager/cert-manager/releases/tag/v1.12.2)
   - opentelemetry-operator upgraded from 0.28.0 to [0.32.0)](https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-operator-0.32.0)
+- Update the log level of metric scrape failures of control plane smart agent receivers from error to debug [#832](https://github.com/signalfx/splunk-otel-collector-chart/pull/832)
 
 ## [0.79.1] - 2023-06-22
 

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -379,7 +379,7 @@ agent:
 ### Known issues
 
 Kube Proxy
-* `10249: connect: connection refuse`
+* `10249: connect: connection refused`
   * Issue
     * When using a Kubernetes cluster with non-default configurations for kube proxy, there is a reported network connectivity issue that prevents the collection of proxy metrics.
   * Solution

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -379,14 +379,19 @@ agent:
 ### Known issues
 
 Kube Proxy
-* https://github.com/kubernetes/kops/issues/6472
-  * Problem
-    * When using a kops created Kubernetes cluster, a network connectivity issue has been reported that prevents proxy
-      metrics from being collected.
+* `10249: connect: connection refuse`
+  * Issue
+    * When using a Kubernetes cluster with non-default configurations for kube proxy, there is a reported network connectivity issue that prevents the collection of proxy metrics.
   * Solution
-    * This issue can be addressed updating the kubeProxy metric bind address in the kops cluster spec:
-      * Set "kubeProxy.metricsBindAddress: 0.0.0.0" in the kops cluster spec.
-      * Deploy the change with "kops update cluster {cluster_name}" and "kops rolling-update cluster {cluster_name}".
+    * Update the kube proxy metric bind address (--metrics-bind-address) in the cluster spec.
+Set the kubeProxy metrics bind address to 0.0.0.0 or another value based on your Kubernetes cluster distribution.
+For this particular issue, the solution may vary depending on the Kubernetes cluster distribution. It is recommended to research what your Kubernetes distribution recommends for addressing this issue.
+  * Related Issue Links
+    * [kubernetes - Expose kube-proxy metrics on 0.0.0.0 by default ](https://github.com/kubernetes/kubernetes/pull/74300)
+    * [kubernetes - kube-proxy TLS support](https://github.com/kubernetes/kubernetes/issues/106870)
+    * [splunk-otel-collector-chart - Error connecting to kubernetes-proxy](https://github.com/signalfx/splunk-otel-collector-chart/issues/758)
+    * [kops - expose metrics-bind-address configuration for kube-proxy](https://github.com/kubernetes/kops/issues/6472)
+    * [prometheus - prometheus-kube-stack - kube-proxy metrics status with connection refused](https://github.com/prometheus-community/helm-charts/issues/977)
 
 ## Logs collection
 

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -242,7 +242,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -250,7 +249,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -260,7 +258,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -279,7 +276,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -242,6 +242,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -249,6 +250,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -258,6 +260,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -268,6 +271,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -275,6 +279,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7e99a137b672c98ce2a93514890f9ec1f08c404ea7773d8692304ed948e7180e
+        checksum/config: 0d5e81dde2b89bae6cf60beb7443678fbfa3f7916aa235bbd32ef7156494f775
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -152,7 +152,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e68f45dc5d5ad899a71a006ace9941aaa37d88abf3b8d2680fda8672c3681acd
+        checksum/config: 9910c9dd5a2833ecdf545ae6738ea328ef15a0a9d5c564319414824c921d1b67
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 9910c9dd5a2833ecdf545ae6738ea328ef15a0a9d5c564319414824c921d1b67
+        checksum/config: 7e99a137b672c98ce2a93514890f9ec1f08c404ea7773d8692304ed948e7180e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -189,7 +189,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -197,7 +196,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -207,7 +205,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -226,7 +223,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -189,6 +189,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -196,6 +197,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -205,6 +207,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -215,6 +218,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -222,6 +226,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: b056ef03069c84a48d6d61471b2e6602c703e836f8c162bc53751b9d5dc2c0de
+        checksum/config: 5ff17e00f88e15acf0f5c507c9b32894fddf88b01f09745155e1d0fad185c324
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: aaab76b0ba4409fc761e642ded78e0998d4e3622d52357f6dd86ac5ad92f12e1
+        checksum/config: b056ef03069c84a48d6d61471b2e6602c703e836f8c162bc53751b9d5dc2c0de
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 87c798151a01dd47d4706373a0b092d87104a41f5b6f2c415c763ccdc43d6e1b
+        checksum/config: aaab76b0ba4409fc761e642ded78e0998d4e3622d52357f6dd86ac5ad92f12e1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -186,7 +186,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -194,7 +193,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -204,7 +202,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -223,7 +220,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -186,6 +186,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -193,6 +194,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -202,6 +204,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -212,6 +215,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -219,6 +223,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 42668ca7fe744e89fc0d7c421c90357a91f10c036b8261bd439101d0b44e6335
+        checksum/config: 6958d5ea88bae9c4480336224d10f5fe72bb38da69a4e0d82d8ed25f3182b12a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 6958d5ea88bae9c4480336224d10f5fe72bb38da69a4e0d82d8ed25f3182b12a
+        checksum/config: f3406d9e0e942c956df031f76fb02081c51d7b34ffb7c9aa39f81be6772e7a05
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 5e482b805db2c896dfb2132882c8483c3eeedd75b44adbf0ef3864e602a17b7a
+        checksum/config: 42668ca7fe744e89fc0d7c421c90357a91f10c036b8261bd439101d0b44e6335
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -234,6 +234,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -241,6 +242,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -250,6 +252,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -260,6 +263,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -267,6 +271,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -234,7 +234,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -242,7 +241,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -252,7 +250,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -271,7 +268,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3493d3098462df5040526c597dd0f0a1260a943e038ee543e93113df78b39788
+        checksum/config: e6978a275ab06dfeeea048cf5b06a614753aec473f5da018062f42fbfe7a7d77
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 87750c2383c72b2201b89caa4951c926b837abf514b7f599b4debb43e37fa22a
+        checksum/config: 3493d3098462df5040526c597dd0f0a1260a943e038ee543e93113df78b39788
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e6978a275ab06dfeeea048cf5b06a614753aec473f5da018062f42fbfe7a7d77
+        checksum/config: d664606cbf1f109b692576cd806fdce467655d1e42e55ced0e9095f567b58771
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:
@@ -153,7 +153,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -183,7 +183,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -191,7 +190,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -201,7 +199,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -220,7 +217,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -183,6 +183,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -190,6 +191,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -199,6 +201,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -209,6 +212,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -216,6 +220,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e99d38672d7af00809472d0007d39b7347034ee8ce712211c1618b97541b1dc6
+        checksum/config: f4c8840646246bfa2f9a248aa23949069d484766086a9b0e95ed238140595894
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 38061b4e2158d3248cfa9762e3c9644127a3559c36adb4b7cb8d36e2ab565acb
+        checksum/config: 51255f7bce9baabbbf67f49087059580b307a3c5571854db33cb7b00f3f862f7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f4c8840646246bfa2f9a248aa23949069d484766086a9b0e95ed238140595894
+        checksum/config: 38061b4e2158d3248cfa9762e3c9644127a3559c36adb4b7cb8d36e2ab565acb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -169,7 +169,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -177,7 +176,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -187,7 +185,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -206,7 +203,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -169,6 +169,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -176,6 +177,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -185,6 +187,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -195,6 +198,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -202,6 +206,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: b31f3459bf195bd6989c1ce5664661e08afc35ff5baf721cf9c78a26cf5258c0
+        checksum/config: 3664f885e167fee6d3443db28b3e739f37f3f462eb3c9e8f4768546e9ae513cf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3664f885e167fee6d3443db28b3e739f37f3f462eb3c9e8f4768546e9ae513cf
+        checksum/config: 2359af39f614c545c12688333ce103fd577c92804012230e4f6d2633cab0e12d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 2359af39f614c545c12688333ce103fd577c92804012230e4f6d2633cab0e12d
+        checksum/config: f9ef5b2dcc6c5ea66916acf315f96346be3f871e378d377c5c922289fbbddf92
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -183,7 +183,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -191,7 +190,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -201,7 +199,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -220,7 +217,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -183,6 +183,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -190,6 +191,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -199,6 +201,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -209,6 +212,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -216,6 +220,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e99d38672d7af00809472d0007d39b7347034ee8ce712211c1618b97541b1dc6
+        checksum/config: f4c8840646246bfa2f9a248aa23949069d484766086a9b0e95ed238140595894
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 38061b4e2158d3248cfa9762e3c9644127a3559c36adb4b7cb8d36e2ab565acb
+        checksum/config: 51255f7bce9baabbbf67f49087059580b307a3c5571854db33cb7b00f3f862f7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f4c8840646246bfa2f9a248aa23949069d484766086a9b0e95ed238140595894
+        checksum/config: 38061b4e2158d3248cfa9762e3c9644127a3559c36adb4b7cb8d36e2ab565acb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -183,7 +183,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -191,7 +190,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -201,7 +199,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -220,7 +217,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -183,6 +183,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -190,6 +191,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -199,6 +201,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -209,6 +212,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -216,6 +220,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e99d38672d7af00809472d0007d39b7347034ee8ce712211c1618b97541b1dc6
+        checksum/config: f4c8840646246bfa2f9a248aa23949069d484766086a9b0e95ed238140595894
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 38061b4e2158d3248cfa9762e3c9644127a3559c36adb4b7cb8d36e2ab565acb
+        checksum/config: 51255f7bce9baabbbf67f49087059580b307a3c5571854db33cb7b00f3f862f7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f4c8840646246bfa2f9a248aa23949069d484766086a9b0e95ed238140595894
+        checksum/config: 38061b4e2158d3248cfa9762e3c9644127a3559c36adb4b7cb8d36e2ab565acb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -183,6 +183,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9154
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: coredns
               useHTTPS: true
@@ -193,6 +194,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -203,6 +205,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -213,6 +216,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-proxy
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-proxy
               useHTTPS: true
@@ -224,6 +228,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -183,7 +183,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9154
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: coredns
               useHTTPS: true
@@ -194,7 +193,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -205,7 +203,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -216,7 +213,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-proxy
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-proxy
               useHTTPS: true
@@ -228,7 +224,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 31073db88b1ace2432096b453bee88a1c0216a5e751710ba304c29acd72d9a1e
+        checksum/config: 969ec02296836b0917b17f0170841501916fa0020dd80c66587cc56d5b46beea
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 969ec02296836b0917b17f0170841501916fa0020dd80c66587cc56d5b46beea
+        checksum/config: 31073db88b1ace2432096b453bee88a1c0216a5e751710ba304c29acd72d9a1e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -196,6 +196,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -203,6 +204,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -212,6 +214,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -222,6 +225,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -229,6 +233,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -196,7 +196,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -204,7 +203,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -214,7 +212,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -233,7 +230,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7b27b4bf43bb0ffd42c9a06fcfa52e65ee08d4f8473c58b247dc2bf736755c9c
+        checksum/config: e82bab9a1a5a64c9c2c95f1fb0fbaa2128174f9d66574b47809bae926d9c527b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -152,7 +152,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 60369ef4feaed6cbdda1f91c81849dde8c208171d08b63b59b3188efccd5f5dc
+        checksum/config: 8de8becd29ef7a6637e153435eb1d220a326577708271d47639597751b42ef71
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 8de8becd29ef7a6637e153435eb1d220a326577708271d47639597751b42ef71
+        checksum/config: 7b27b4bf43bb0ffd42c9a06fcfa52e65ee08d4f8473c58b247dc2bf736755c9c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -184,7 +184,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -192,7 +191,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -202,7 +200,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -221,7 +218,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -184,6 +184,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -191,6 +192,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -200,6 +202,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -210,6 +213,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -217,6 +221,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7e30d00f0a5cfb1d5e5533cc5dc983ce7255551b9e179776be66caf4c12495d0
+        checksum/config: a560c670f80a5fe39697bb880f70e6af50ffc9759ee8a09d9e6cbdb5480eb2a6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 3700f79598d048d0a255d2c0db14e333ee64ede4a8d22b9c10af4b5af4b8e07e
+        checksum/config: 7e30d00f0a5cfb1d5e5533cc5dc983ce7255551b9e179776be66caf4c12495d0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 808af141c721889928fbf37843e21ae5a801ad23926906fe8079bea4a770f6f2
+        checksum/config: 3700f79598d048d0a255d2c0db14e333ee64ede4a8d22b9c10af4b5af4b8e07e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -191,7 +191,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -199,7 +198,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -209,7 +207,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -228,7 +225,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -191,6 +191,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -198,6 +199,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -207,6 +209,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -217,6 +220,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -224,6 +228,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 9685fb07dfcb025d3b89781af6baf7d796fd0f029e681b04d3e9b80da849b828
+        checksum/config: 09e6ce30ca145d5264a0db26e544005b03540332285773916e31f0578f856320
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 09e6ce30ca145d5264a0db26e544005b03540332285773916e31f0578f856320
+        checksum/config: 04a6c8511fee6a54c7f1368df1cfbb90e7d8eb78989fcd7e2d27ee0f8fd26a44
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -152,7 +152,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: d87484626e31781d3dea049ff2075477ad2a97a621d3ac121493e4f2dc4def7b
+        checksum/config: 9685fb07dfcb025d3b89781af6baf7d796fd0f029e681b04d3e9b80da849b828
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -196,6 +196,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -203,6 +204,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -212,6 +214,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -222,6 +225,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -229,6 +233,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -196,7 +196,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -204,7 +203,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -214,7 +212,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -233,7 +230,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: c8fcc0e4827d544483a431a2e0d0b2747979b63e8cfb0c191a4141e9c6771b7c
+        checksum/config: 7f16c0500d7de9aab59e3b5035e5bd51e3d51dc6fb4f3ff8827dca9e645b959e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 23e792e836f91801b7fb680f3680e1e241dfd137435aa40916061d6fc75ded0e
+        checksum/config: c8fcc0e4827d544483a431a2e0d0b2747979b63e8cfb0c191a4141e9c6771b7c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
     engine: fluentd
@@ -30,7 +30,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7f16c0500d7de9aab59e3b5035e5bd51e3d51dc6fb4f3ff8827dca9e645b959e
+        checksum/config: a0675a23e7de0c43c110b15fdb7b702093ec5a592e1fa2a6f0a613fc8203f478
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet
@@ -124,7 +124,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -190,7 +190,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -198,7 +197,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -208,7 +206,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -227,7 +224,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -190,6 +190,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -197,6 +198,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -206,6 +208,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -216,6 +219,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -223,6 +227,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e73bd61a65f18073b549a4b6657eab8fe6c259ca9dbdb27da44eb351d6c2a4ac
+        checksum/config: f4ef029a8cff379e9016c6cab0f0bc7dcc7289e69be77090fbb34b8766a87326
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f4ef029a8cff379e9016c6cab0f0bc7dcc7289e69be77090fbb34b8766a87326
+        checksum/config: 915fdd3ba4159ed02f375bbac3a518479a2ddb9dabc4e489084430458b657eec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -63,7 +63,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: b393364934cbda7ad4bcde838bb274760ffbc3971c0aa9c777d3fc8c898b7f5c
+        checksum/config: e73bd61a65f18073b549a4b6657eab8fe6c259ca9dbdb27da44eb351d6c2a4ac
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -174,7 +174,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -182,7 +181,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -192,7 +190,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -211,7 +208,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -174,6 +174,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -181,6 +182,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -190,6 +192,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -200,6 +203,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -207,6 +211,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 69e881b7d0a98614fcd1b46abae8ac3f15b81bbd604a554a668127221209e421
+        checksum/config: 0fd11d3e92c694125fd1d53c65e87bf6d8bf8e027df856991190c6bf56ef44e5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 0fd11d3e92c694125fd1d53c65e87bf6d8bf8e027df856991190c6bf56ef44e5
+        checksum/config: b99e72496b5965538304a4b73241b0a28373ac6bd6da666cc37eeead18e96a5c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -63,7 +63,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 7c11b28537f12f684a817d4ed09b02084837caec54a020db5662aeba01a5eaf6
+        checksum/config: 69e881b7d0a98614fcd1b46abae8ac3f15b81bbd604a554a668127221209e421
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -187,6 +187,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -194,6 +195,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -203,6 +205,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -213,6 +216,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -220,6 +224,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -187,7 +187,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -195,7 +194,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -205,7 +203,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -224,7 +221,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: ec918d7a65deba43bb887b074d3b8fdff4e901f6db9e99d1de354420995ae57d
+        checksum/config: f41824e8fa4b88af56090243a8f4e38c092210053a838b4727f3f73a21e29d50
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e4ac9be8561a6a1fa3bec17cffbe2c0495261749c3a87ef7a4f8548e621ef247
+        checksum/config: e46f5efeb437d8e6f5283379f8d02fc50c08ab489d9040af5f62943305ca8416
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f41824e8fa4b88af56090243a8f4e38c092210053a838b4727f3f73a21e29d50
+        checksum/config: e4ac9be8561a6a1fa3bec17cffbe2c0495261749c3a87ef7a4f8548e621ef247
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -183,7 +183,6 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
-              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -191,7 +190,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -201,7 +199,6 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -220,7 +217,6 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
-              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -183,6 +183,7 @@ data:
               extraDimensions:
                 metric_source: k8s-coredns
               port: 9153
+              scrapeFailureLogLevel: debug
               type: coredns
             rule: type == "pod" && labels["k8s-app"] == "kube-dns"
           smartagent/kube-controller-manager:
@@ -190,6 +191,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-controller-manager
               port: 10257
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kube-controller-manager
               useHTTPS: true
@@ -199,6 +201,7 @@ data:
             config:
               extraDimensions:
                 metric_source: kubernetes-apiserver
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-apiserver
               useHTTPS: true
@@ -209,6 +212,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-proxy
               port: 10249
+              scrapeFailureLogLevel: debug
               type: kubernetes-proxy
             rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
           smartagent/kubernetes-scheduler:
@@ -216,6 +220,7 @@ data:
               extraDimensions:
                 metric_source: kubernetes-scheduler
               port: 10259
+              scrapeFailureLogLevel: debug
               skipVerify: true
               type: kubernetes-scheduler
               useHTTPS: true

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: e99d38672d7af00809472d0007d39b7347034ee8ce712211c1618b97541b1dc6
+        checksum/config: f4c8840646246bfa2f9a248aa23949069d484766086a9b0e95ed238140595894
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector-agent
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.79.1
+    helm.sh/chart: splunk-otel-collector-0.80.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.79.1"
+    app.kubernetes.io/version: "0.80.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.79.1
+    chart: splunk-otel-collector-0.80.0
     release: default
     heritage: Helm
 spec:
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: 38061b4e2158d3248cfa9762e3c9644127a3559c36adb4b7cb8d36e2ab565acb
+        checksum/config: 51255f7bce9baabbbf67f49087059580b307a3c5571854db33cb7b00f3f862f7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.79.1
+        image: quay.io/signalfx/splunk-otel-collector:0.80.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         app: splunk-otel-collector
         release: default
       annotations:
-        checksum/config: f4c8840646246bfa2f9a248aa23949069d484766086a9b0e95ed238140595894
+        checksum/config: 38061b4e2158d3248cfa9762e3c9644127a3559c36adb4b7cb8d36e2ab565acb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -106,6 +106,7 @@ receivers:
           extraDimensions:
             metric_source: k8s-coredns
           type: coredns
+          scrapeFailureLogLevel: debug
           {{- if eq .Values.distribution "openshift" }}
           port: 9154
           skipVerify: true
@@ -127,6 +128,7 @@ receivers:
           clientKeyPath: /otel/etc/etcd/tls.key
           useHTTPS: true
           type: etcd
+          scrapeFailureLogLevel: debug
           {{- if .Values.agent.controlPlaneMetrics.etcd.skipVerify }}
           skipVerify: true
           {{- else }}
@@ -154,6 +156,7 @@ receivers:
           type: kube-controller-manager
           useHTTPS: true
           useServiceAccount: true
+          scrapeFailureLogLevel: debug
       {{- end }}
       {{- if .Values.agent.controlPlaneMetrics.apiserver.enabled }}
       smartagent/kubernetes-apiserver:
@@ -169,6 +172,7 @@ receivers:
           type: kubernetes-apiserver
           useHTTPS: true
           useServiceAccount: true
+          scrapeFailureLogLevel: debug
       {{- end }}
       {{- if .Values.agent.controlPlaneMetrics.proxy.enabled }}
       smartagent/kubernetes-proxy:
@@ -181,6 +185,7 @@ receivers:
           extraDimensions:
             metric_source: kubernetes-proxy
           type: kubernetes-proxy
+          scrapeFailureLogLevel: debug
           {{- if eq .Values.distribution "openshift" }}
           skipVerify: true
           useHTTPS: true
@@ -204,6 +209,7 @@ receivers:
           type: kubernetes-scheduler
           useHTTPS: true
           useServiceAccount: true
+          scrapeFailureLogLevel: debug
       {{- end }}
       {{- end }}
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -106,7 +106,6 @@ receivers:
           extraDimensions:
             metric_source: k8s-coredns
           type: coredns
-          scrapeFailureLogLevel: debug
           {{- if eq .Values.distribution "openshift" }}
           port: 9154
           skipVerify: true
@@ -128,7 +127,6 @@ receivers:
           clientKeyPath: /otel/etc/etcd/tls.key
           useHTTPS: true
           type: etcd
-          scrapeFailureLogLevel: debug
           {{- if .Values.agent.controlPlaneMetrics.etcd.skipVerify }}
           skipVerify: true
           {{- else }}
@@ -156,7 +154,6 @@ receivers:
           type: kube-controller-manager
           useHTTPS: true
           useServiceAccount: true
-          scrapeFailureLogLevel: debug
       {{- end }}
       {{- if .Values.agent.controlPlaneMetrics.apiserver.enabled }}
       smartagent/kubernetes-apiserver:
@@ -172,7 +169,6 @@ receivers:
           type: kubernetes-apiserver
           useHTTPS: true
           useServiceAccount: true
-          scrapeFailureLogLevel: debug
       {{- end }}
       {{- if .Values.agent.controlPlaneMetrics.proxy.enabled }}
       smartagent/kubernetes-proxy:
@@ -185,7 +181,11 @@ receivers:
           extraDimensions:
             metric_source: kubernetes-proxy
           type: kubernetes-proxy
+          # Connecting to kube proxy in unknown Kubernetes distributions can be troublesome and generate log noise
+          # For now, set the scrape failure log level to debug when no specific distribution is selected
+          {{- if eq .Values.distribution "" }}
           scrapeFailureLogLevel: debug
+          {{- end }}
           {{- if eq .Values.distribution "openshift" }}
           skipVerify: true
           useHTTPS: true
@@ -209,7 +209,6 @@ receivers:
           type: kubernetes-scheduler
           useHTTPS: true
           useServiceAccount: true
-          scrapeFailureLogLevel: debug
       {{- end }}
       {{- end }}
 


### PR DESCRIPTION
Description:
The default behavior of smart agent receivers based on Prometheus was to log an error when a metric scraping failure occurs. This can result in excessive log noise, especially when dealing with unstable metric source targets. Prometheus native metric collector mechanisms log these failures at the debug level. In the case of our control plane smart agent receivers in this chart, deploying them to a new, untested, or unsupported Kubernetes distribution can generate a significant amount of log error noise. These changes aim to reduce unexpected log noise when deploying to Kubernetes environments that are not directly supported by this chart.

Notes:
- The kube proxy control plane smart agent receiver is a specific case that often generates substantial log error noise in different Kubernetes environments. Multiple related issues have been filed across various repositories regarding kube proxy metric collection, including this repository.
  - [Error connecting to kubernetes-proxy](https://github.com/signalfx/splunk-otel-collector-chart/issues/758)
- An upstream related pull request has been merged, which enables this functionality.
  - [Add scrapeFailureLogLevel config to smartagent prometheus receivers](https://github.com/signalfx/splunk-otel-collector/pulls?q=is%3Apr+is%3Aclosed+scrape)