### PR TITLE
Update PodDisruptionBudgets API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Added
-- Update PodDisruptionBudgets API version to allow both `policy/v1beta1` and `policy/v1` [#835](https://github.com/signalfx/splunk-otel-collector-chart/pull/835),
+
+- Update PodDisruptionBudgets API version to allow both `policy/v1beta1` and `policy/v1` [#835](https://github.com/signalfx/splunk-otel-collector-chart/pull/835)
 
 ## [0.80.0] - 2023-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+- Update PodDisruptionBudgets API version to allow both `policy/v1beta1` and `policy/v1` [#835](https://github.com/signalfx/splunk-otel-collector-chart/pull/835),
+
 ## [0.80.0] - 2023-06-27
 
 This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk OpenTelemetry Collector v0.80.0](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.80.0).

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -332,6 +332,17 @@ compatibility with the old config group name: "otelAgent".
 {{- end -}}
 
 {{/*
+The apiVersion for podDisruptionBudget policies.
+*/}}
+{{- define "splunk-otel-collector.PDB-apiVersion" -}}
+{{- if (semverCompare ">= 1.21.0" .Capabilities.KubeVersion.Version) -}}
+{{- print "policy/v1" -}}
+{{- else -}}
+{{- print "policy/v1beta1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 The name of the gateway service.
 */}}
 {{- define "splunk-otel-collector.gatewayServiceName" -}}

--- a/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-cluster-receiver.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" ) .Values.podDisruptionBudget }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "splunk-otel-collector.PDB-apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}-otel-k8s-cluster-receiver

--- a/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
@@ -1,7 +1,7 @@
 {{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
 {{ $gatewayEnabled := eq (include "splunk-otel-collector.gatewayEnabled" .) "true" }}
 {{- if and $gatewayEnabled .Values.podDisruptionBudget }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "splunk-otel-collector.PDB-apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "splunk-otel-collector.fullname" . }}


### PR DESCRIPTION
Fixes #833 PodDisruptionBudget policies fail to create at k8s v1.25+

Description: `Capabilities.KubeVersion.Version` checks the kube version. If above 1.21, `apiVersion: policy/v1` is set for PodDisruptionBudget, else `apiVersion: policy/v1beta1`.