### PR TITLE
Set cluster_name for host logs too if renameFieldsSck is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Set cluster_name for host logs too if renameFieldsSck is enabled [#837](https://github.com/signalfx/splunk-otel-collector-chart/pull/837)
+
 ### Added
 
 - Update PodDisruptionBudgets API version to allow both `policy/v1beta1` and `policy/v1` [#835](https://github.com/signalfx/splunk-otel-collector-chart/pull/835)

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -160,9 +160,6 @@ resource/logs:
     - key: container_name
       from_attribute: k8s.container.name
       action: upsert
-    - key: cluster_name
-      from_attribute: k8s.cluster.name
-      action: upsert
     - key: container_id
       from_attribute: container.id
       action: upsert
@@ -185,8 +182,6 @@ resource/logs:
     {{- end }}
     {{- if not .Values.splunkPlatform.fieldNameConvention.keepOtelConvention }}
     - key: k8s.container.name
-      action: delete
-    - key: k8s.cluster.name
       action: delete
     - key: container.id
       action: delete

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -527,6 +527,15 @@ processors:
         key: "{{ .name }}"
         value: "{{ .value }}"
       {{- end }}
+      {{- if .Values.splunkPlatform.fieldNameConvention.renameFieldsSck }}
+      - key: cluster_name
+        from_attribute: k8s.cluster.name
+        action: upsert
+      {{- if not .Values.splunkPlatform.fieldNameConvention.keepOtelConvention }}
+      - key: k8s.cluster.name
+        action: delete
+      {{- end }}
+      {{- end }}
 
   # Resource attributes specific to the agent itself.
   resource/add_agent_k8s:


### PR DESCRIPTION
Up to now the cluster_name field was only set in `resource/logs`. This snippet was only included for the container logs, but not for host logs (files, journald).

This change moves the cluster_name field to the `resource` snippet, which is according inline comment used for all things that pass through otel.

Fixes #682