### PR TITLE
Add rbac for eks aws-auth configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Update PodDisruptionBudgets API version to allow both `policy/v1beta1` and `policy/v1` [#835](https://github.com/signalfx/splunk-otel-collector-chart/pull/835)
+- Update clusterrole to allow collector to check for the `aws-auth` configmap in EKS clusters [#840](https://github.com/signalfx/splunk-otel-collector-chart/pull/840)
 
 ## [0.80.0] - 2023-06-27
 

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
@@ -87,3 +87,11 @@ rules:
     - nodes
   verbs:
     - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  resourceNames:
+  - aws-auth

--- a/examples/distribution-eks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRole.yaml
@@ -81,3 +81,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  resourceNames:
+  - aws-auth

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -94,6 +94,16 @@ rules:
   verbs:
     - patch
 {{- end }}
+{{- if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  resourceNames:
+  - aws-auth
+{{- end }}
 {{- with .Values.rbac.customRules }}
 {{ toYaml . }}
 {{- end }}


### PR DESCRIPTION
The EKS resource detector in the collector looks for the `aws-auth` configmap to exist when [verifying if it is running on eks](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/internal/aws/eks/detector.go#L82). This PR adds the necessary permissions needed for the collector pod to be able to check the existence of the configmap.