### PR TITLE
Add Github Worfklow coverage to update values.yaml and Chart.yaml dependency versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - main
-    # Release only on changes in Chart.yaml
+    # Release only if the 'version' field in Chart.yaml was updated
     paths:
       - helm-charts/**/Chart.yaml
 
 jobs:
-  release:
+  maybe_update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,18 +17,33 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
+      - name: Validate Chart.yaml Update
+        id: check_update_chart
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          VERSION_DIFF=$(git diff HEAD^ -- "*Chart.yaml" | grep -E "^\+version:" || echo "")
+          echo "VERSION_DIFF=$VERSION_DIFF"  # example value: +version: 0.80.1
+          if [[ ! -z "$VERSION_DIFF" ]]; then
+            echo "New release needed, creating..."
+            echo "VALID_UPDATE=1" >> $GITHUB_OUTPUT
+          else
+            echo "No new release needed"
+            echo "VALID_UPDATE=0" >> $GITHUB_OUTPUT
+          fi
+          exit 0
+
+      - name: Configure Git
+        run: git config user.name "$GITHUB_ACTOR" && git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        if: ${{ steps.check_update_chart.outputs.VALID_UPDATE == 1 }}
 
       - name: Install Helm
         uses: azure/setup-helm@v3.5
         with:
           version: v3.11.3
+        if: ${{ steps.check_update_chart.outputs.VALID_UPDATE == 1 }}
 
       - name: Set up chart dependencies
-        run: make repo-update dep-build
+        run: make render
+        if: ${{ steps.check_update_chart.outputs.VALID_UPDATE == 1 }}
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
@@ -36,3 +51,4 @@ jobs:
           charts_dir: helm-charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        if: ${{ steps.check_update_chart.outputs.VALID_UPDATE == 1 }}

--- a/.github/workflows/update_chart_dependencies.yaml
+++ b/.github/workflows/update_chart_dependencies.yaml
@@ -1,0 +1,63 @@
+name: Check for new chart dependency updates
+
+on:
+  schedule:
+    # Run every Monday at noon.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+env:
+  CHART_YAML: helm-charts/splunk-otel-collector/Chart.yaml
+
+jobs:
+  maybe_update:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Currently this worfklow will update the listed dependencies in the Chart.yaml
+        repo: ['cert-manager', 'opentelemetry-operator'] # Add other repos here
+    steps:
+      - uses: actions/checkout@v3.5.3
+      - name: Update Chart
+        id: update_chart
+        run: |
+          # Run make repo-update to ensure repositories are up-to-date
+          make repo-update
+
+          # Fetch the latest version using helm search repo
+          LATEST_VER=$(helm search repo ${{ matrix.repo }} --versions | awk 'NR==2{print $2}')
+          echo "LATEST_VER=$LATEST_VER" >> $GITHUB_OUTPUT
+
+          # Retrieve the current version from chart.yaml
+          DEP_PATH=$(yq eval ".dependencies[] | select(.name == \"${{ matrix.repo }}\") | .version" $CHART_YAML)
+
+          echo "Current version of ${{ matrix.repo }} is $DEP_PATH, latest is $LATEST_VER"
+
+          if [ "$LATEST_VER" == "$DEP_PATH" ]; then
+            echo We are already up to date. Nothing else to do.
+          else
+            echo 'Looks like we need to update...'
+            echo Updating to new version in chart.yaml
+            echo "NEED_UPDATE=1" >> $GITHUB_OUTPUT
+
+            # Update the version in chart.yaml using yq and jq
+            DEP_LINE=$(yq eval ".dependencies | keys | map(tonumber) | map(select(. != null)) | map(select(. < 10000)) | map(. + 1)" $CHART_YAML | jq ".[] | select(.[\"name\"] == \"${{ matrix.repo }}\")")
+            sed -i "${DEP_LINE}s/$DEP_PATH/$LATEST_VER/" $CHART_YAML
+
+            echo Updating rendered examples
+            make render
+
+            echo "Current git diff:"
+            git --no-pager diff
+          fi
+      - name: PR the new version
+        if: ${{ steps.update_chart.outputs.NEED_UPDATE == 1 }}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Update ${{ matrix.repo }} chart version
+          title: Update ${{ matrix.repo }} chart version to ${{ steps.update_chart.outputs.LATEST_VER }}
+          body: Use the new version of the ${{ matrix.repo }} chart
+          branch: "update-${{ matrix.repo }}-${{ steps.update_chart.outputs.LATEST_VER }}"
+          base: main
+          delete-branch: true
+          modify-outputs: false

--- a/.github/workflows/update_instrumentation_dependencies.yaml
+++ b/.github/workflows/update_instrumentation_dependencies.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Currently this workflow will update the listed operator instrumentatipon dependencies in values.yaml
+        # Currently this workflow will update the listed operator instrumentation dependencies in values.yaml
         language: ['java'] # Add other languages here
     steps:
       - uses: actions/checkout@v3.5.3

--- a/.github/workflows/update_instrumentation_dependencies.yaml
+++ b/.github/workflows/update_instrumentation_dependencies.yaml
@@ -2,7 +2,8 @@ name: Check for new instrumentation versions
 
 on:
   schedule:
-    - cron: "45 */4 * * *"
+    # Run every 12th hour at minute 45 past.
+    - cron: "45 */12 * * *"
   workflow_dispatch:
 
 env:
@@ -14,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # Currently this workflow will update the listed operator instrumentatipon dependencies in values.yaml
         language: ['java'] # Add other languages here
     steps:
       - uses: actions/checkout@v3.5.3
@@ -25,37 +27,39 @@ jobs:
           LATEST_VER=$(curl -qs -H "Accept: application/vnd.github+json" $(echo $LATEST_API | sed "s/{lang}/${{ matrix.language }}/g") | jq -r .tag_name)
           echo "LATEST_VER=$LATEST_VER" >> $GITHUB_OUTPUT
           echo "Current version of ${{ matrix.language }} is $LOCAL_VER, latest is $LATEST_VER"
+
           if [ "$LATEST_VER" == "$LOCAL_VER" ]; then
             echo We are already up to date. Nothing else to do.
           else
             echo 'Verifying that the image is pullable...'
-            echo '(If this fails, the agent version is out of sync with ghcr version)'
+            echo '(If this fails, the image version is out of sync with ghcr version)'
             docker pull $REPO:$LATEST_VER
             echo 'Looks like we are good to update...'
-            echo Updating to new version
+            echo Updating to new version in values.yaml
             echo "NEED_UPDATE=1" >> $GITHUB_OUTPUT
-            VLINE=$(grep -n $REPO $VALUES_YAML | cut -f1 -d:)
-            echo sed -i "${VLINE}s|:${LOCAL_VER}|:${LATEST_VER}|" $VALUES_YAML
-            sed -i "${VLINE}s|:${LOCAL_VER}|:${LATEST_VER}|" $VALUES_YAML
+            VLINE=$(grep -n "${REPO}" $VALUES_YAML | cut -f1 -d:)
+            echo "Line number for ${REPO} in ${VALUES_YAML} is: ${VLINE}"
+            OLD_VER=$(sed -n "${VLINE}p" $VALUES_YAML | grep -oP 'v\K[0-9.]+')
+            echo "Old version number is: ${OLD_VER}"
+            NEW_VER=${LATEST_VER#v} # removes 'v' from the start of the string
+            echo "New version number is: ${NEW_VER}"
+            echo "sed: ${VLINE}s/${OLD_VER}/${NEW_VER}/"
+            sed -i "${VLINE}s/${OLD_VER}/${NEW_VER}/" $VALUES_YAML
+
+            echo Render chart template
+            make render
+
+            echo "Current git diff:"
             git --no-pager diff
           fi
-      - name: render some templates
-        if: ${{ steps.swizzle_version.outputs.NEED_UPDATE == 1 }}
-        run: |
-          echo Making the templates
-          curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-          sudo apt install -y apt-transport-https
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-          sudo apt update
-          sudo apt install -y build-essential zip helm gh
-          make render
-          git --no-pager diff
       - name: PR the new version
         if: ${{ steps.swizzle_version.outputs.NEED_UPDATE == 1 }}
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Update ${{ matrix.language }} instrumentation version
-          title: Update ${{ matrix.language }} agent version to ${{ steps.swizzle_version.outputs.LATEST_VER }}
-          body: Use the new version of the ${{ matrix.language }} instrumentation library
+          title: Update ${{ matrix.language }} instrumentation version to ${{ steps.swizzle_version.outputs.LATEST_VER }}
+          body: Use the new version of the ${{ matrix.language }} instrumentation
           branch: "update-${{ matrix.language }}-${{ steps.swizzle_version.outputs.LATEST_VER }}"
           base: main
+          delete-branch: true
+          modify-outputs: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update PodDisruptionBudgets API version to allow both `policy/v1beta1` and `policy/v1` [#835](https://github.com/signalfx/splunk-otel-collector-chart/pull/835)
 - Update clusterrole to allow collector to check for the `aws-auth` configmap in EKS clusters [#840](https://github.com/signalfx/splunk-otel-collector-chart/pull/840)
 - Add support to create default Instrumentation for operator based auto-instrumentation [#836](https://github.com/signalfx/splunk-otel-collector-chart/pull/836)
+- Add Github workflow coverage to update values.yaml and Chart.yaml dependency versions [#852](https://github.com/signalfx/splunk-otel-collector-chart/pull/852)
 
 ## [0.80.0] - 2023-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update PodDisruptionBudgets API version to allow both `policy/v1beta1` and `policy/v1` [#835](https://github.com/signalfx/splunk-otel-collector-chart/pull/835)
 - Update clusterrole to allow collector to check for the `aws-auth` configmap in EKS clusters [#840](https://github.com/signalfx/splunk-otel-collector-chart/pull/840)
 - Add support to create default Instrumentation for operator based auto-instrumentation [#836](https://github.com/signalfx/splunk-otel-collector-chart/pull/836)
-- Add Github workflow coverage to update values.yaml and Chart.yaml dependency versions [#852](https://github.com/signalfx/splunk-otel-collector-chart/pull/852)
 
 ## [0.80.0] - 2023-06-27
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,11 +15,6 @@ of `version` field.
 
 To make a new release of the helm chart:
 1. Bump the chart `version` in [Chart.yaml](helm-charts/splunk-otel-collector/Chart.yaml)
-1. Bump dependencies versions as needed
-   - Look for new releases
-     - https://cert-manager.io/docs/installation/supported-releases/
-     - https://github.com/open-telemetry/opentelemetry-operator/releases
-   - Increment versions under `dependencies` in [Chart.yaml](helm-charts/splunk-otel-collector/Chart.yaml#)
 1. Run `make render` to update Helm dependencies and render all the examples with the latest changes.
 1. Create PR and request review from the team.
 1. When the PR gets merged, the release will automatically be made and the helm repo updated.


### PR DESCRIPTION
Description
- Needed to fix an issue with update_instrumentation_dependencies.yaml not getting the latest version numbers properly.
- Added .github/workflows/update_chart_dependencies.yaml so we could automate updating subchart dependencies.
- Dependabot makes very similar updates compared to these, but Dependabot does not support updating dependencies like these yet.

Testing
- Was able to successfully test and validate both workflows in my forked repo.