### PR TITLE
Update the secret validation hook pod to use imagePullSecrets instead of possible non-existing serviceAccountName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk Op
 ### Fixed
 
 - Use "ContainerAdministrator" user for windows nodes by default [#809](https://github.com/signalfx/splunk-otel-collector-chart/pull/809)
+- Update the secret validation hook pod to use imagePullSecrets instead of possible non-existing serviceAccountName [#888](https://github.com/signalfx/splunk-otel-collector-chart/pull/888)
 
 ## [0.81.0] - 2023-07-21
 

--- a/examples/secret-validation/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRoleBinding.yaml
@@ -20,5 +20,5 @@ roleRef:
   name: default-splunk-otel-collector
 subjects:
 - kind: ServiceAccount
-  name: splunk-collector
+  name: default-splunk-otel-collector
   namespace: default

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      serviceAccountName: splunk-collector
+      serviceAccountName: default-splunk-otel-collector
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:

--- a/examples/secret-validation/rendered_manifests/secret-splunk-validation-hook.yaml
+++ b/examples/secret-validation/rendered_manifests/secret-splunk-validation-hook.yaml
@@ -16,7 +16,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  serviceAccountName: splunk-collector
   restartPolicy: Never
   containers:
   - name: validate-secret

--- a/examples/secret-validation/rendered_manifests/serviceAccount.yaml
+++ b/examples/secret-validation/rendered_manifests/serviceAccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: splunk-collector
+  name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
     helm.sh/chart: splunk-otel-collector-0.82.0

--- a/examples/secret-validation/secret-validation-values.yaml
+++ b/examples/secret-validation/secret-validation-values.yaml
@@ -10,7 +10,3 @@ logsEngine: otel
 secret:
   create: false
   name: splunk-otel-collector
-serviceAccount:
-  # Assuming serviceAccount doesn't exist yet and is not necessary to access the secret
-  create: true
-  name: splunk-collector

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk-validation-hook.yaml
@@ -11,7 +11,6 @@ metadata:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  serviceAccountName: {{ template "splunk-otel-collector.serviceAccountName" . }}
   restartPolicy: Never
   containers:
   - name: validate-secret
@@ -43,4 +42,10 @@ spec:
     - name: secret
       secret:
         secretName: {{ template "splunk-otel-collector.secret" . }}
+  {{- if .Values.image.imagePullSecrets }}
+  imagePullSecrets:
+  {{- range .Values.image.imagePullSecrets }}
+    - name: {{ . }}
+  {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Issue: https://github.com/signalfx/splunk-otel-collector-chart/issues/780

Description:
- The secret validation hook runs in the pre-install phase while the service account is made in the install phase. This can cause errors.

Testing:
- Validated the secret validation hook pod works when pulling and using images from a private image registry.