### PR TITLE
Enable native OTel logs collection in GKE Autopilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Enable native OTel logs collection (logsEngine=otel) in GKE Autopilot [#809](https://github.com/signalfx/splunk-otel-collector-chart/pull/809)
+
 ### Added
 
 - Add option to disable Openshift SecurityContextConstraint resource [#843](https://github.com/signalfx/splunk-otel-collector-chart/pull/843)

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -138,8 +138,6 @@ make sure to set `distribution` setting to `gke/autopilot`:
 distribution: gke/autopilot
 ```
 
-**NOTE:** Native OTel logs collection is not yet supported in GKE Autopilot.
-
 Sometimes Splunk OTel Collector agent daemonset can have [problems scheduling in
 Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/daemonset#autopilot-ds-best-practices)
 If you run into these issues, you can assign the daemonset a higher [priority
@@ -409,8 +407,6 @@ The following configuration can be used to achieve that:
 ```yaml
 logsEngine: otel
 ```
-
-**NOTE:** Native OTel logs collection is not yet supported in GKE Autopilot.
 
 ### Add log files from Kubernetes host machines/volumes
 

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -232,7 +232,7 @@ spec:
         {{- else }}
         - /otelcol
         - --config=/conf/relay.yaml
-        {{- if eq .Values.distribution "gke/autopilot" }}
+        {{- if and (eq .Values.distribution "gke/autopilot") (eq .Values.logsEngine "fluentd") }}
         {{- /* Temporary no-op argument required to run collector on GKE Autopilot */}}
         - --metrics-addr=0.0.0.0:8889
         {{- end }}


### PR DESCRIPTION
Native OTel logs collection is now available in GKE Autopilot. The `--metrics-addr` hack still required if fluent is enabled.
