### PR TITLE
Disable opencensus.resourcetype attribute in cluster_receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+
+- Disable `opencensus.resourcetype` resource attribute in k8s_cluster receiver [#914](https://github.com/signalfx/splunk-otel-collector-chart/pull/914)
+  - This change does not affect Splunk Observability users since it has already been disabled in the default translation rules of the Signalfx exporter
+
 ### Fixed
 
 - Enable native OTel logs collection (logsEngine=otel) in GKE Autopilot [#809](https://github.com/signalfx/splunk-otel-collector-chart/pull/809)

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,6 +82,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       k8sobjects:
         auth_type: serviceAccount
         objects:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8cfe65cd18475c78274bc59991d793b5e2f4289fdc61708423d0ae808c4ef6b9
+        checksum/config: 682e43a457f4049bcb6cc0c4f7d35709be96d49b124d31c91341dfa168eccf22
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -85,6 +85,9 @@ data:
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 13ceb1abe54ebf5de52859b0c1c2a9b52e846c59ffd935b5b1160d89177635f4
+        checksum/config: 2b4aca22b1dc96d3899a8cc5656d3fc6af6785fe61b512686045d2a4b831d6dc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -72,6 +72,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bbb5dfb5b29e5e7272b83f57687b5bc21403005248247a824d6a49e9c06e9dc8
+        checksum/config: 6facef59e0c76dbf6fc7d256e9a788ce7120f22ad547b043e0813c6e504ad1a2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -76,6 +76,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9026a7e874d0dd53ee1b41307130fe30386acd7da26b50237b442d4554205e95
+        checksum/config: 16ce1ccded7512670f7be64b038fb6ba3834e251bf2b26c300ce10da821d06ae
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -72,6 +72,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s-api-server:
         config:
           scrape_configs:

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fb2969586d0b0cb50ae804905b5b16a44844cd02a29d956bbffbeda59a5e7c40
+        checksum/config: 740fd31ffd02c8969581abd3f3c86fdce3b604590b668ae229c311edff4cf499
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,6 +71,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 459272636a5fe8e866ea28fdf5672ea341de1f0b5677e85ed4aef0ee626d6f82
+        checksum/config: 562b0297a25ef35481c4beac227a11891fcd447fe9ca6d4f4b21d607b426e985
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,6 +71,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 459272636a5fe8e866ea28fdf5672ea341de1f0b5677e85ed4aef0ee626d6f82
+        checksum/config: 562b0297a25ef35481c4beac227a11891fcd447fe9ca6d4f4b21d607b426e985
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,6 +71,9 @@ data:
         distribution: openshift
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a37594be98a8a1d564fa13ce5b0f423b1db116a8876e0943815624b2182df595
+        checksum/config: 31b3d3f68670569c21b0d8bc732737c256e5d43259051d82b78646a14e8b8977
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-network-explorer/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-network-explorer/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 36d6eb70da031c23d4a8271dcb665c733750d9dc18814a433a0ce6812de3fce0
+        checksum/config: 112106f29e640f1c4026b01d61d6c98867d122a6beb31b99587faa557d2c8e1e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -85,6 +85,9 @@ data:
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 13ceb1abe54ebf5de52859b0c1c2a9b52e846c59ffd935b5b1160d89177635f4
+        checksum/config: 2b4aca22b1dc96d3899a8cc5656d3fc6af6785fe61b512686045d2a4b831d6dc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -85,6 +85,9 @@ data:
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 13ceb1abe54ebf5de52859b0c1c2a9b52e846c59ffd935b5b1160d89177635f4
+        checksum/config: 2b4aca22b1dc96d3899a8cc5656d3fc6af6785fe61b512686045d2a4b831d6dc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 571588737b2c8c9bd08d4c4d1f761baacf5d683b8f1707dc97f0401d99659350
+        checksum/config: fa6a1f5ff76c1f6bc80e2022b85d5d809dba7256135affa3ae0589b34cc31df6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,6 +70,9 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
+        resource_attributes:
+          opencensus.resourcetype:
+            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42c3370f306709a869bd3f0c1bcaa695086fa0ecd9d4d3601ab5f2ff161ff1e8
+        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -35,6 +35,9 @@ receivers:
     {{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
     distribution: openshift
     {{- end }}
+    resource_attributes:
+      opencensus.resourcetype:
+        enabled: false
   {{- if and (eq (include "splunk-otel-collector.objectsEnabled" .) "true") (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   k8sobjects:
     auth_type: serviceAccount


### PR DESCRIPTION
Disable a redundant `opencensus.resourcetype` resource attribute in k8s_cluster receiver. The attribute will be removed from the receiver upstream anyway, but this will happen in a deprecation process, so we need to put this config in the receiver to avoid throwing deprecation warnings.

This change doe not affect Splunk Observability users, because it has been already disabled in the signalfx exporter default translation rules.

This can be a breaking change for Splunk Platform users relying on this attribute. If required, it can added back by configuring an additional `resource` processor the following way:

```
clusterReceiver:
  config:
    processors:
      resource/add_opencensus_resourcetype:
        attributes:
        - action: insert
          key: opencensus.resourcetype
          value: k8s
    service:
      pipelines:
        metrics:
          processors: 
            - memory_limiter
            - batch
            - resource
            - resource/k8s_cluster
            - resource/add_opencensus_resourcetype
```
