### PR TITLE
Disable signalfx exporter default translations in clusterReceiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Disable `opencensus.resourcetype` resource attribute in k8s_cluster receiver [#914](https://github.com/signalfx/splunk-otel-collector-chart/pull/914)
   - This change does not affect Splunk Observability users since it has already been disabled in the default translation rules of the Signalfx exporter
+- Disable signalfx exporter default translations in clusterReceiver deployment [#915](https://github.com/signalfx/splunk-otel-collector-chart/pull/915)
+  - This change improves performance of clusterReceiver, but can be breaking if the deprecated signalfx exporter `translation_rules` option is being used
 
 ### Fixed
 

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
       splunk_hec/o11y:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 682e43a457f4049bcb6cc0c4f7d35709be96d49b124d31c91341dfa168eccf22
+        checksum/config: 07fe6154bbabbf50a9df757449c019cff49d69faa959f2894978f84f51ea80f0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 6facef59e0c76dbf6fc7d256e9a788ce7120f22ad547b043e0813c6e504ad1a2
+        checksum/config: d35079f6b081482ab4ef4908328991cfbec205eac46fe1462d5522df8f797053
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 16ce1ccded7512670f7be64b038fb6ba3834e251bf2b26c300ce10da821d06ae
+        checksum/config: bda1634030699d43038763bb0d9050b3228a0623fb95ea8078c73cfdafc2ad03
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 740fd31ffd02c8969581abd3f3c86fdce3b604590b668ae229c311edff4cf499
+        checksum/config: d592d500334c37e8d3b9d3206a5e6be8098ba2aeba8ea73f3f3fa3dcf82b0ec1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 562b0297a25ef35481c4beac227a11891fcd447fe9ca6d4f4b21d607b426e985
+        checksum/config: 47548eeda01c8d8574246b5ab96806be0fe55c4c7855ad8df938c672448b4011
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 562b0297a25ef35481c4beac227a11891fcd447fe9ca6d4f4b21d607b426e985
+        checksum/config: 47548eeda01c8d8574246b5ab96806be0fe55c4c7855ad8df938c672448b4011
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 31b3d3f68670569c21b0d8bc732737c256e5d43259051d82b78646a14e8b8977
+        checksum/config: f22aeb98f989f3b4a91a775c2a9999151a3b6707b66c6e8eba039f979b19f97d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-network-explorer/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/enable-network-explorer/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.us0.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.us0.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 112106f29e640f1c4026b01d61d6c98867d122a6beb31b99587faa557d2c8e1e
+        checksum/config: c90ef590c6581167af546a077482d7052282848f655240ec55a262157880e114
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: http://<custom-gateway-url>:6060
+        disable_default_translation_rules: true
         ingest_url: http://<custom-gateway-url>:9943
         timeout: 10s
     extensions:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fa6a1f5ff76c1f6bc80e2022b85d5d809dba7256135affa3ae0589b34cc31df6
+        checksum/config: 26ad3aacbd13dda3a4eda0071cdeeb30ddd10647af3ebbff28d58275acc9416f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,6 +20,7 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 59f89c0177629ef8be97db5ec7c7ecde63de7c8510cda406a1d8063bf937fff5
+        checksum/config: 84e7ae04428625dee5e44f0a5f2c6a3be0e26fa0eae21aaef9350b0d8fcc08a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -174,6 +174,7 @@ exporters:
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     timeout: 10s
+    disable_default_translation_rules: true
   {{- end }}
 
   {{- if and (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true") }}


### PR DESCRIPTION
This change disables signalfx exporter default translations in the clusterReceiver deployment to avoid wasting CPU cycles. Removing of `opencensus.resourcetype` attribute was the only translation applicable to k8s_cluster receiver metrics. After the attribute was disabled on the receiver side in https://github.com/signalfx/splunk-otel-collector-chart/pull/914, the default translations are not needed anymore.

This can be a breaking change for Splunk Observability users who use the deprecated `translation_rules` option in signalfx exporter in clusterReceiver. The option has been deprecated for more than half a year, so we should encourage users not to use it anymore.
