### PR TITLE
Drop time attribute from log records

### DIFF
--- a/.chloggen/drop-time-attribute.yaml
+++ b/.chloggen/drop-time-attribute.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, networkExplorer, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Drop time attribute used during parsing the time from log record, so it is not reported as an extra field.
+# One or more tracking issues related to the change
+issues: [912]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -283,8 +283,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -283,11 +283,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7208ff3bb983755be9e8a0e4fe8b76632016edc817589fb2a269edbdb80cfb57
+        checksum/config: 419884697a587527338c9cef618ba0e26dec0f42001718b1c55bd29d145033fb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 419884697a587527338c9cef618ba0e26dec0f42001718b1c55bd29d145033fb
+        checksum/config: 286cee3013ccf7af9f50976fbed44b7dc9fd7a5a87337b34b812e4175621d055
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -232,8 +232,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -232,11 +232,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e990314a1fb336c12cef61726bf5baee2751640b85fa461fb1659b4e8ef35739
+        checksum/config: ec5e4269e44b4492001c10f2823399e94d836965acd710272c8d41e19adc4cc3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9f25bd2c05450ed99c47d5f7b168304f9f1e45c24f033decb08f555193f9f4eb
+        checksum/config: e990314a1fb336c12cef61726bf5baee2751640b85fa461fb1659b4e8ef35739
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -267,11 +267,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -267,8 +267,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1984fbe03aa21a6a119816f9dae66d30ff9ffb56e8cb817f24250a6d5a3e05b4
+        checksum/config: 51a3aabbf2bae5c56e21cd4901220f0cd1cb65c0fc2ab891010b7e0a1c9b36c9
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 76a121bc4a793f7059a2df7415457dfdb931f41b32c7abe4d45b3db2326a8878
+        checksum/config: 1984fbe03aa21a6a119816f9dae66d30ff9ffb56e8cb817f24250a6d5a3e05b4
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -290,11 +290,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -290,8 +290,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3c5bb22805859992a6b9d9cb33272a72c130a295a05650f202941e7d773061c6
+        checksum/config: b21a36492a285b23eb2bf2328225d42d29aefeec38ca094dd968f562ef4d5e7f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 818f82900199e6a65a5aea42c54dfea6d8fca61502d1830543ece49a014b9bd2
+        checksum/config: 3c5bb22805859992a6b9d9cb33272a72c130a295a05650f202941e7d773061c6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -237,8 +237,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -237,11 +237,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c7294d2819e34fd87e657ad8d118c65e86df3bb4ef0d129bebe8254d0560c8a9
+        checksum/config: 1bd036ad2e040f0e2e2fdab35b1ec845e48c4fa5d6a848b15a9e0d01e97b75fb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1bd036ad2e040f0e2e2fdab35b1ec845e48c4fa5d6a848b15a9e0d01e97b75fb
+        checksum/config: aac0f2aba3d0d6dbff09fedbcd948a7093040391463e182610b8502708ea1a7c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -290,11 +290,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -290,8 +290,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c69fb3089bc33e5c071f6d1d592ca6fa93960771b60505044f44de803a010bdd
+        checksum/config: 68c0ee7f9e666322a8e10d9de526f224d705396c294dc4211af281055995922c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 68c0ee7f9e666322a8e10d9de526f224d705396c294dc4211af281055995922c
+        checksum/config: 6f9be4197a9b2dcc109d0c4aaaae037e7f7c1d946f873afd097bda6069949b00
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -237,8 +237,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -237,11 +237,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2277edc0eea63bd7f92fb97ab58aba1e575c66f02ad5d47e8112aa84b939ebf0
+        checksum/config: 847848a331868f674e242ce4dd36f24dc01f748bdb8218bc5ed5e60a4f08d575
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 847848a331868f674e242ce4dd36f24dc01f748bdb8218bc5ed5e60a4f08d575
+        checksum/config: 9bd116f32e7b9310ad0e723f83c4e8bc9c7ad861e579c51aae379b2d89984b5c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -229,8 +229,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -229,11 +229,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7a595f4a1f3566ab58fa74ca0a5ec0568967badb4848a7c6e9379e2dbe66b1b6
+        checksum/config: a720d5275f1def5f7af289f56292bab6ceff6c719c37b4174530b6c97ff36b40
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2da9a5cc150492c54d2c3f55c2e2a17ae7f51cd2845ad3b561865c4f9cac8ffa
+        checksum/config: 7a595f4a1f3566ab58fa74ca0a5ec0568967badb4848a7c6e9379e2dbe66b1b6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -229,8 +229,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -229,11 +229,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 339246fc9fb976ea24127b9330de79a749b41402a6dee0d10d80f198290dca63
+        checksum/config: c4faa399f221cfbb0d35f0db0b270f127cb3e71d24dc12eb0dbe1d951bd327d0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c4faa399f221cfbb0d35f0db0b270f127cb3e71d24dc12eb0dbe1d951bd327d0
+        checksum/config: 02fff5db1a43b4123ca5801d5769215660e9a0bace155f26406cdc6155c5f17e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -229,8 +229,12 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -229,11 +229,9 @@ data:
           type: move
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7a595f4a1f3566ab58fa74ca0a5ec0568967badb4848a7c6e9379e2dbe66b1b6
+        checksum/config: a720d5275f1def5f7af289f56292bab6ceff6c719c37b4174530b6c97ff36b40
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2da9a5cc150492c54d2c3f55c2e2a17ae7f51cd2845ad3b561865c4f9cac8ffa
+        checksum/config: 7a595f4a1f3566ab58fa74ca0a5ec0568967badb4848a7c6e9379e2dbe66b1b6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -243,8 +243,12 @@ data:
           type: copy
         - from: attributes.log
           id: clean-up-log-record
+          output: clean-up-time-attribute
           to: body
           type: move
+        - field: attributes.time
+          id: clean-up-time-attribute
+          type: remove
         poll_interval: 200ms
         retry_on_failure:
           enabled: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -243,11 +243,9 @@ data:
           type: copy
         - from: attributes.log
           id: clean-up-log-record
-          output: clean-up-time-attribute
           to: body
           type: move
         - field: attributes.time
-          id: clean-up-time-attribute
           type: remove
         poll_interval: 200ms
         retry_on_failure:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 375f57ece2b6927d36be610e87394f2e81bddd319090d9272fa54a8cc68c020f
+        checksum/config: 8ae7099953c34ed9f359cdd311951776f97eb7026e4f03ab3af943228db957c1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cccdee128973a5886a8f5d59d3bb9582fa729b486d43e894fc8e87d970eab2ba
+        checksum/config: 375f57ece2b6927d36be610e87394f2e81bddd319090d9272fa54a8cc68c020f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -414,8 +414,12 @@ receivers:
       # Clean up log record
       - type: move
         id: clean-up-log-record
+        output: clean-up-time-attribute
         from: attributes.log
         to: body
+      - type: remove
+        id: clean-up-time-attribute
+        field: attributes.time
   {{- end }}
 
   {{- if .Values.logsCollection.extraFileLogs }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -414,11 +414,9 @@ receivers:
       # Clean up log record
       - type: move
         id: clean-up-log-record
-        output: clean-up-time-attribute
         from: attributes.log
         to: body
       - type: remove
-        id: clean-up-time-attribute
         field: attributes.time
   {{- end }}
 


### PR DESCRIPTION
**Description:**
Fixes #912 

This drops the time attribute from the log records parsed, so it is not sent as an extra field to Splunk.
