### PR TITLE
Update makefile

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --config=ct.yaml
+        run: make lint
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.8.0

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,14 @@ dep-build: ## Build the Helm chart with latest dependencies from the current Hel
 render: repo-update dep-build ## Render the Helm chart with the examples as input
 	examples/render-examples.sh || exit 1
 
+##@ Test
+# Tasks related to testing the Helm chart
+
+.PHONY: lint
+lint: ## Lint the Helm chart with ct
+	@echo "Linting Helm chart..."
+	ct lint --config=ct.yaml || exit 1
+
 ##@ Changelog
 # Tasks related to changelog management
 

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,11 @@ lint: ## Lint the Helm chart with ct
 	@echo "Linting Helm chart..."
 	ct lint --config=ct.yaml || exit 1
 
+.PHONY: pre-commit
+pre-commit: render ## Test the Helm chart with pre-commit
+	@echo "Checking the Helm chart with pre-commit..."
+	pre-commit run --all-files || exit 1
+
 ##@ Changelog
 # Tasks related to changelog management
 

--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,11 @@ chlog-update: chlog-validate ## Creates an update to CHANGELOG.md for a release 
 	$(CHLOGGEN) update --version "[$(VERSION)] - $$(date +'%Y-%m-%d')" || exit 1; \
 	ci_scripts/chloggen-update.sh || exit 1
 
+##@ Cert Manager
+# Tasks related to deploying and managing Cert Manager
+
 .PHONY: cert-manager
-cert-manager: cmctl
+cert-manager: cmctl ## Installs cert-manager in the current Kubernetes cluster and verifies API access with cmctl
 	# Consider using cmctl to install the cert-manager once install command is not experimental
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${CERTMANAGER_VERSION}/cert-manager.yaml
 	$(CMCTL) check api --wait=5m
@@ -120,7 +123,7 @@ cert-manager: cmctl
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 CMCTL = $(shell pwd)/bin/cmctl
 .PHONY: cmctl
-cmctl:
+cmctl: ## Downloads and installs cmctl, the CLI for cert-manager, to your local system
 	@{ \
 	set -e ;\
 	if (`pwd`/bin/cmctl version | grep ${CERTMANAGER_VERSION}) > /dev/null 2>&1 ; then \

--- a/ci_scripts/install-tools.sh
+++ b/ci_scripts/install-tools.sh
@@ -76,7 +76,7 @@ install_go() {
 }
 
 # install brew-based tools
-for tool in kubectl helm pre-commit go; do
+for tool in kubectl helm chart-testing pre-commit go; do
   install "$tool" brew
 done
 


### PR DESCRIPTION
**Description:**
- Introduce 'make lint' for lint testing the chart
- Implement 'make pre-commit' for executing pre-commit tests
- Enhance documentation with 'make help' for new cert-manager actions

**Testing:**  Commands validated both locally and within GitHub workflows.

Running 'make help' now includes the new following additions
```
Test
  lint             Lint the Helm chart with ct
  pre-commit       Test the Helm chart with pre-commit
Cert Manager
  cert-manager     Installs cert-manager in the current Kubernetes cluster and verifies API access with cmctl
  cmctl            Downloads and installs cmctl, the CLI for cert-manager, to your local system
```
