### PR TITLE
[chore] Remove configuration for disabling opencensus.resourcetype

### DIFF
--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -83,9 +83,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       k8sobjects:
         auth_type: serviceAccount
         objects:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a56c43b3b42ef5c0d89aad36237a2681625cb0300b7581be47e095c358233c12
+        checksum/config: 9afb2c52b83ab03660d4b1bbe7f6a35c309afe82193d0cdbe6925ca745426b9f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -85,9 +85,6 @@ data:
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 75778278c764a49a4a1614a6f87b01f94c8cb23a6416d65efb7dea4f0c982e1c
+        checksum/config: b54a19466fc7f07dfcca5c669b99e44351d4a83282d508c22d3af93b5df2871f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -73,9 +73,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 42fce531ec8abb5336d916b3b9ad39058c3fa3334e609f4f361a96fb6f4b396e
+        checksum/config: a7f36578e3ac3d61efe5d148603823d949b74c3230983aec62b4a5dd4b1adb39
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -77,9 +77,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: ad4d5aeb2694216467a9cefce932f005593014141d6ae33c545cbbe9f7e4db9c
+        checksum/config: a90be0594b524a66fad2b2da97edd91059a64b399645b5d03dcafe745f87f2a4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -73,9 +73,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s-api-server:
         config:
           scrape_configs:

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3bf6ab269cad65443cc3cf5c19546ea9e6068952ab8b88cb377a8efa53c44b8b
+        checksum/config: b1a63557a975af06fa8bdbe99780821d526171bef3fe3e5287e63ec4500fa2a3
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -72,9 +72,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0a8f2c5a6ab8cd92d1ba9ad245e29473b05a91b07f7c5de0b4eadf98c609aa78
+        checksum/config: 8b9aeedffc6d370cd8d0dc1ae396d5bb634137ce72ec97166f1a15ee80486c31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -72,9 +72,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0a8f2c5a6ab8cd92d1ba9ad245e29473b05a91b07f7c5de0b4eadf98c609aa78
+        checksum/config: 8b9aeedffc6d370cd8d0dc1ae396d5bb634137ce72ec97166f1a15ee80486c31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -72,9 +72,6 @@ data:
         distribution: openshift
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8f573af72f2e814fcec530d4e85eaade6f5ab2f4bb8b7d65f448b03741d2c97d
+        checksum/config: ee6a63f134bd28ec9fb0ab5bc688e35b9e58393f17cd2f587108ecf6658bc0f9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-network-explorer/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-network-explorer/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-network-explorer/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8cd58b8573dcc80296930e5c5cf3dcb382d9dcac96512a40234f7f808e5ffd16
+        checksum/config: c430e84bcea78a2381907061567d2ea7f59e1275c33342bba7ca3cfc8d1b3913
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -85,9 +85,6 @@ data:
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 75778278c764a49a4a1614a6f87b01f94c8cb23a6416d65efb7dea4f0c982e1c
+        checksum/config: b54a19466fc7f07dfcca5c669b99e44351d4a83282d508c22d3af93b5df2871f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -85,9 +85,6 @@ data:
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 75778278c764a49a4a1614a6f87b01f94c8cb23a6416d65efb7dea4f0c982e1c
+        checksum/config: b54a19466fc7f07dfcca5c669b99e44351d4a83282d508c22d3af93b5df2871f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dd363e24f4f7f0a0e9bbe9462829eb9359a71fc2534c44ff376ce70660236bb4
+        checksum/config: 695fdc1e281b8a44b304c34b01ef9d4f10dafb7b39fe90b831af93894f90a7cc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,9 +71,6 @@ data:
         auth_type: serviceAccount
         metadata_exporters:
         - signalfx
-        resource_attributes:
-          opencensus.resourcetype:
-            enabled: false
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1db167b918f2d7a1a75219fd4193d313762339fbea48e2ce5a0b4bff6dd1fbd7
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -35,9 +35,6 @@ receivers:
     {{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
     distribution: openshift
     {{- end }}
-    resource_attributes:
-      opencensus.resourcetype:
-        enabled: false
   {{- if and (eq (include "splunk-otel-collector.objectsEnabled" .) "true") (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   k8sobjects:
     auth_type: serviceAccount


### PR DESCRIPTION
The resource attribute was disabled upstream in 0.87.0 and will be removed in the next version.

This change has no effect on the end users, so no need to mention in the changelog
