### PR TITLE
[chore] In the otel-demo, remove all env vars with PUBLIC_OTEL_* prefixes fromm Deployment objects

### DIFF
--- a/examples/enable-operator-and-auto-instrumentation/otel-demo/otel-demo.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/otel-demo/otel-demo.yaml
@@ -831,8 +831,6 @@ spec:
               value: 'opentelemetry-demo-shippingservice:8080'
             - name: WEB_OTEL_SERVICE_NAME
               value: frontend-web
-            - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-              value: http://localhost:8080/otlp-http/v1/traces
           resources:
             limits:
               memory: 200Mi


### PR DESCRIPTION
**Description:**
-  Remove all env vars with PUBLIC_OTEL_* prefixes from Deployment objects.
- This is a special case that was likely for legacy support, only the NodeJS opentelemetry-demo-frontend deployment in the otel-demo was using it.
- These env vars can cause compatibility issues with Splunk instrumentation and they don't seem to follow the OpenTelemetry spec.

**Testing:**
- Validated the Splunk NodeJS image now works with the  NodeJS opentelemetry-demo-frontend deployment in the otel-demo.
