### PR TITLE
Remove by default empty allowedFlexVolumes

### DIFF
--- a/.chloggen/featureremovedefaultallowedFlexVolumes.yaml
+++ b/.chloggen/featureremovedefaultallowedFlexVolumes.yaml
@@ -1,0 +1,5 @@
+change_type: 'deprecation'
+component: 'chart'
+note: "Remove by default empty allowedFlexVolumes"
+issues: []
+subtext: "Removed the allowedFlexVolumes empty field since it does not provide any default additional benefits for the users."

--- a/.chloggen/featureremovedefaultallowedFlexVolumes.yaml
+++ b/.chloggen/featureremovedefaultallowedFlexVolumes.yaml
@@ -1,5 +1,5 @@
-change_type: 'deprecation'
+change_type: 'bug_fix'
 component: 'chart'
 note: "Remove by default empty allowedFlexVolumes"
-issues: []
+issues: [[981](https://github.com/signalfx/splunk-otel-collector-chart/pull/981)]
 subtext: "Removed the allowedFlexVolumes empty field since it does not provide any default additional benefits for the users."

--- a/.chloggen/featureremovedefaultallowedFlexVolumes.yaml
+++ b/.chloggen/featureremovedefaultallowedFlexVolumes.yaml
@@ -1,5 +1,5 @@
 change_type: 'bug_fix'
 component: 'chart'
 note: "Remove by default empty allowedFlexVolumes"
-issues: [https://github.com/signalfx/splunk-otel-collector-chart/pull/981]
+issues: [981]
 subtext: "Removed the allowedFlexVolumes empty field since it does not provide any default additional benefits for the users."

--- a/.chloggen/featureremovedefaultallowedFlexVolumes.yaml
+++ b/.chloggen/featureremovedefaultallowedFlexVolumes.yaml
@@ -1,5 +1,5 @@
 change_type: 'bug_fix'
 component: 'chart'
 note: "Remove by default empty allowedFlexVolumes"
-issues: [[981](https://github.com/signalfx/splunk-otel-collector-chart/pull/981)]
+issues: [https://github.com/signalfx/splunk-otel-collector-chart/pull/981]
 subtext: "Removed the allowedFlexVolumes empty field since it does not provide any default additional benefits for the users."

--- a/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
+++ b/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
@@ -23,7 +23,6 @@ allowHostPID: true
 allowHostPorts: true
 allowPrivilegedContainer: false
 allowedCapabilities: []
-allowedFlexVolumes: []
 defaultAddCapabilities: []
 fsGroup:
   type: MustRunAs

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -23,7 +23,6 @@ seLinuxContext:
     role: "system_r"
     type: "spc_t"
     level: "s0"
-allowedFlexVolumes: []
 allowedCapabilities: []
 defaultAddCapabilities: []
 fsGroup:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

It fixes an issue where an ArgoCD Application syncs the helm chart with the default SCC enabled. The ArgoCD application is always out of sync due to `allowedFlexVolumes `being empty on the cluster but being defined in Git.

This is actually expected due to the specifications [0] with `omitempty`.

The proposal is to remove the `allowedFlexVolumes `field since it does not provide any default additional benefits for the users.

**Testing:** <Describe what testing was performed and which tests were added.>
Tested on an OpenShift cluster 4.13. The ArgoCD Application is no longer out of sync and there is no impact.

**Documentation:** 

[0] https://github.com/openshift/api/blob/release-4.13/security/v1/types.go#L79

