### PR TITLE
document 2019/2022 tags

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -1,6 +1,9 @@
 name: Splunk Platform Functional Test
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '!**.md'
 
 jobs:
   functional-test:

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -3,6 +3,8 @@ name: functional-tests
 
 on:
   pull_request:
+    paths:
+      - '!**.md'
   push:
     branches: [ main ]
 

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -98,7 +98,11 @@ Splunk OpenTelemetry Collector for Kubernetes supports collection of metrics,
 traces and logs (using OTel native logs collection only) from Windows nodes.
 
 All windows images are available in a separate `quay.io` repository:
-`quay.io/signalfx/splunk-otel-collector-windows`.
+`quay.io/signalfx/splunk-otel-collector-windows` with two release tracking tags
+available: `latest` (Server 2019) and `latest-2022` (Server 2022). Version tags
+follow the convention of `<appVersion>` (2019) and `<appVersion>-2022` (2022).
+The digests for each release are detailed at
+https://github.com/signalfx/splunk-otel-collector/releases.
 
 Use the following values.yaml configuration to install the helm chart on Windows
 worker nodes:
@@ -108,6 +112,7 @@ isWindows: true
 image:
   otelcol:
     repository: quay.io/signalfx/splunk-otel-collector-windows
+    tag: <appVersion>-2022
 logsEngine: otel
 readinessProbe:
   initialDelaySeconds: 60


### PR DESCRIPTION
Currently we don't document the available platform tags for windows installations, which can lead to installation errors like those reported in https://github.com/signalfx/splunk-otel-collector-chart/issues/908.