### PR TITLE
Update project  usages of 'make repo-update' and 'make dep-build' to use 'make dep-update'

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Deploy splunk-otel-collector chart
         run: |
-          make repo-update dep-build
+          make dep-update
           export CI_SPLUNK_HOST=$(kubectl get pod splunk --template={{.status.podIP}})
           ci_scripts/deploy_collector.sh
 

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -51,7 +51,7 @@ jobs:
           kubectl get csr -o=jsonpath='{range.items[?(@.spec.signerName=="kubernetes.io/kubelet-serving")]}{.metadata.name}{" "}{end}' | xargs kubectl certificate approve
       - name: Update dependencies
         run: |
-          make repo-update dep-build
+          make dep-update
       - name: Deploy cert-manager
         run: |
           make cert-manager

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -25,7 +25,7 @@ jobs:
           version: v3.7.1
 
       - name: Set up chart dependencies
-        run: make repo-update dep-build
+        run: make dep-update
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/update_chart_dependencies.yaml
+++ b/.github/workflows/update_chart_dependencies.yaml
@@ -42,8 +42,8 @@ jobs:
             DEBUG_ARG="--debug"
           fi
 
-          # Ensure repositories are up-to-date
-          make repo-update
+          # Ensure chart dependencies are up-to-date
+          make dep-update
 
           # Fetch the latest version using helm search repo
           LATEST_VER=$(helm search repo ${{ matrix.repo }} --versions | awk 'NR==2{print $2}')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
     - id: render
       name: Create the rendered Kubernetes manifest resources for the project examples
-      entry: make repo-update dep-build render
+      entry: make render
       language: system
       pass_filenames: false
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ install-tools: ## Install tools (macOS/Linux)
 ##@ Build
 # Tasks related to building the Helm chart
 
-.PHONY: repo-update
-repo-update: ## Update Helm repositories to latest
+.PHONY: dep-update
+dep-update: ## Update Helm chart dependencies to latest, build the Helm chart with latest dependencies
 	@{ \
 	if ! (helm repo list | grep -q open-telemetry) ; then \
 		helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts || exit 1; \
@@ -50,20 +50,15 @@ repo-update: ## Update Helm repositories to latest
 		helm repo add jetstack https://charts.jetstack.io || exit 1; \
 	fi ;\
 	helm repo update open-telemetry jetstack || exit 1; \
-	}
-
-.PHONY: dep-build
-dep-build: ## Build the Helm chart with latest dependencies from the current Helm repositories
-	@{ \
 	DEP_OK=true ;\
 	DIR=helm-charts/splunk-otel-collector ;\
 	if ! helm dependencies list $$DIR | grep open-telemetry | grep -q ok ; then DEP_OK=false ; fi ;\
 	if ! helm dependencies list $$DIR | grep jetstack | grep -q ok ; then DEP_OK=false ; fi ;\
-	if [ "$$DEP_OK" = "false" ] ; then helm dependencies build $$DIR || exit 1; fi ;\
+	if [ "$$DEP_OK" = "false" ] ; then helm dependencies update $$DIR || exit 1; fi ;\
 	}
 
 .PHONY: render
-render: repo-update dep-build ## Render the Helm chart with the examples as input
+render: dep-update ## Render the Helm chart with the examples as input
 	examples/render-examples.sh || exit 1
 
 ##@ Test


### PR DESCRIPTION
Description:
- This PR merges 'make repo-update' and 'make dep-build' into one command - 'make dep-update'. With our current practice of pinning dependencies to fixed versions, the Chart.lock file generated by 'make dep-build' becomes redundant. The new 'make dep-update' command updates dependencies directly using the [Chart.yaml](https://github.com/signalfx/splunk-otel-collector-chart/blob/a2e332b12f5d6dcc807f633a0ee0bfd99cbc4dac/helm-charts/splunk-otel-collector/Chart.yaml#L20) as the source of truth, bypassing the need for a Chart.lock file for a more efficient workflow. 
- Before this change, developers would have to update or delete a local Chart.lock file if dependencies changed (which is an extra step we don't need).