### PR TITLE
[fluentd] expose some tail plungin configs

### DIFF
--- a/.chloggen/expose-fluentd-tail-configs.yaml
+++ b/.chloggen/expose-fluentd-tail-configs.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, networkExplorer, operator, chart, other)
+component: agent, fluentd
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow users to override `enable_stat_watcher` and `refresh_interval` for tail plugin from values.yaml
+# One or more tracking issues related to the change
+issues: [982]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd.yaml
@@ -73,6 +73,8 @@ data:
       pos_file /var/log/splunk-fluentd-containers.log.pos
       path_key source
       read_from_head true
+      enable_stat_watcher true
+      refresh_interval 60
       <parse>
         @include source.containers.parse.conf
         time_key time

--- a/examples/fluentd-refresh-interval/README.md
+++ b/examples/fluentd-refresh-interval/README.md
@@ -1,0 +1,6 @@
+# Example of chart configuration
+
+## Multiline Fluentd logging for Java stacktraces
+
+This example shows how to configure FluentD to capture logs that span multiple lines,
+specifically Java application stacktraces.

--- a/examples/fluentd-refresh-interval/README.md
+++ b/examples/fluentd-refresh-interval/README.md
@@ -1,6 +1,5 @@
 # Example of chart configuration
 
-## Multiline Fluentd logging for Java stacktraces
+## Fluentd refresh interval and stat watcher
 
-This example shows how to configure FluentD to capture logs that span multiple lines,
-specifically Java application stacktraces.
+This example shows how to configure refresh_interval and enable_stat_watcher for tail plugin in FluentD

--- a/examples/fluentd-refresh-interval/fluentd-refresh-interval-values.yaml
+++ b/examples/fluentd-refresh-interval/fluentd-refresh-interval-values.yaml
@@ -1,0 +1,12 @@
+clusterName: CHANGEME
+splunkObservability:
+  realm: CHANGEME
+  accessToken: CHANGEME
+  logsEnabled: true
+
+logsEngine: fluentd
+
+fluentd:
+  config:
+    refreshInterval: 30
+    enableStatWatcher: false

--- a/examples/fluentd-refresh-interval/rendered_manifests/clusterRole.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/clusterRole.yaml
@@ -1,0 +1,83 @@
+---
+# Source: splunk-otel-collector/templates/clusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.86.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.87.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.86.1
+    release: default
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/proxy
+  - pods
+  - pods/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/fluentd-refresh-interval/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/clusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: splunk-otel-collector/templates/clusterRoleBinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.86.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.87.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.86.1
+    release: default
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-splunk-otel-collector
+subjects:
+- kind: ServiceAccount
+  name: default-splunk-otel-collector
+  namespace: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -1,0 +1,306 @@
+---
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-agent
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.86.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.87.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.86.1
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      sapm:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      signalfx:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        api_url: https://api.CHANGEME.signalfx.com
+        correlation: null
+        ingest_url: https://ingest.CHANGEME.signalfx.com
+        sync_host_metadata: true
+      splunk_hec/o11y:
+        disable_compression: true
+        endpoint: https://ingest.CHANGEME.signalfx.com/v1/log
+        log_data_enabled: true
+        profiling_data_enabled: false
+        token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+    extensions:
+      health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
+      memory_ballast:
+        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+      zpages: null
+    processors:
+      batch: null
+      filter/logs:
+        logs:
+          exclude:
+            match_type: strict
+            resource_attributes:
+            - key: splunk.com/exclude
+              value: "true"
+      groupbyattrs/logs:
+        keys:
+        - com.splunk.source
+        - com.splunk.sourcetype
+        - container.id
+        - fluent.tag
+        - k8s.container.name
+        - k8s.namespace.name
+        - k8s.pod.name
+        - k8s.pod.uid
+      k8sattributes:
+        extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: namespace
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          - from: pod
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          labels:
+          - key: app
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: ip
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: host.name
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_agent_k8s:
+        attributes:
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 10s
+    receivers:
+      fluentforward:
+        endpoint: 0.0.0.0:8006
+      hostmetrics:
+        collection_interval: 10s
+        scrapers:
+          cpu: null
+          disk: null
+          filesystem: null
+          load: null
+          memory: null
+          network: null
+          paging: null
+          processes: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:14250
+          thrift_http:
+            endpoint: 0.0.0.0:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 10s
+        endpoint: ${K8S_NODE_IP}:10250
+        extra_metadata_labels:
+        - container.id
+        metric_groups:
+        - container
+        - pod
+        - node
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus/agent:
+        config:
+          scrape_configs:
+          - job_name: otel-agent
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+      receiver_creator:
+        receivers:
+          smartagent/coredns:
+            config:
+              extraDimensions:
+                metric_source: k8s-coredns
+              port: 9153
+              type: coredns
+            rule: type == "pod" && labels["k8s-app"] == "kube-dns"
+          smartagent/kube-controller-manager:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-controller-manager
+              port: 10257
+              skipVerify: true
+              type: kube-controller-manager
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-controller-manager"
+          smartagent/kubernetes-apiserver:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-apiserver
+              skipVerify: true
+              type: kubernetes-apiserver
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
+          smartagent/kubernetes-proxy:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-proxy
+              port: 10249
+              scrapeFailureLogLevel: debug
+              type: kubernetes-proxy
+            rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
+          smartagent/kubernetes-scheduler:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-scheduler
+              port: 10259
+              skipVerify: true
+              type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
+        watch_observers:
+        - k8s_observer
+      signalfx:
+        endpoint: 0.0.0.0:9943
+      smartagent/signalfx-forwarder:
+        listenAddress: 0.0.0.0:9080
+        type: signalfx-forwarder
+      zipkin:
+        endpoint: 0.0.0.0:9411
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      - memory_ballast
+      - zpages
+      pipelines:
+        logs:
+          exporters:
+          - splunk_hec/o11y
+          processors:
+          - memory_limiter
+          - groupbyattrs/logs
+          - k8sattributes
+          - filter/logs
+          - batch
+          - resourcedetection
+          - resource
+          - resource/logs
+          receivers:
+          - fluentforward
+          - otlp
+        metrics:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          - resource
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - otlp
+          - receiver_creator
+          - signalfx
+        metrics/agent:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_agent_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/agent
+        traces:
+          exporters:
+          - sapm
+          - signalfx
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - batch
+          - resourcedetection
+          - resource
+          receivers:
+          - otlp
+          - jaeger
+          - smartagent/signalfx-forwarder
+          - zipkin
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -1,0 +1,110 @@
+---
+# Source: splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.86.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.87.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.86.1
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      signalfx:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
+        ingest_url: https://ingest.CHANGEME.signalfx.com
+        timeout: 10s
+    extensions:
+      health_check: null
+      memory_ballast:
+        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
+    processors:
+      batch:
+        send_batch_max_size: 32768
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: metric_source
+          value: kubernetes
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_collector_k8s:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/k8s_cluster:
+        attributes:
+        - action: insert
+          key: receiver
+          value: k8scluster
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 10s
+    receivers:
+      k8s_cluster:
+        auth_type: serviceAccount
+        metadata_exporters:
+        - signalfx
+      prometheus/k8s_cluster_receiver:
+        config:
+          scrape_configs:
+          - job_name: otel-k8s-cluster-receiver
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+    service:
+      extensions:
+      - health_check
+      - memory_ballast
+      pipelines:
+        metrics:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource
+          - resource/k8s_cluster
+          receivers:
+          - k8s_cluster
+        metrics/collector:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_collector_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/k8s_cluster_receiver
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd-json.yaml
@@ -1,0 +1,24 @@
+---
+# Source: splunk-otel-collector/templates/configmap-fluentd-json.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-fluentd-json
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.86.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.87.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.86.1
+    release: default
+    heritage: Helm
+data:
+  source.containers.parse.conf: |-
+    @type json
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+
+  output.filter.conf: ""
+
+  output.transform.conf: ""

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd.yaml
@@ -74,7 +74,7 @@ data:
       path_key source
       read_from_head true
       enable_stat_watcher true
-      refresh_interval 60
+      refresh_interval 30
       <parse>
         @include source.containers.parse.conf
         time_key time

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1c29b0dcba3cf6ba0f4428e2173637e2833540b2b39c7c59f32d3610c2715e2d
+        checksum/config: da8680da4ddd070e37922c0a21e51155d2ed3d32ece0e0bd1024b201c41ae859
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -1,0 +1,102 @@
+---
+# Source: splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: default-splunk-otel-collector-k8s-cluster-receiver
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.86.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.87.0"
+    app: splunk-otel-collector
+    component: otel-k8s-cluster-receiver
+    chart: splunk-otel-collector-0.86.1
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-k8s-cluster-receiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      component: otel-k8s-cluster-receiver
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        component: otel-k8s-cluster-receiver
+        release: default
+      annotations:
+        checksum/config: e035e76af07ec79ac18ef884b78a59174ec62339c6042b6d46127ce34f700423
+    spec:
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+          kubernetes.io/os: linux
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        image: quay.io/signalfx/splunk-otel-collector:0.87.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: default-splunk-otel-collector
+                key: splunk_observability_access_token
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: collector-configmap
+        - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+          name: run-collectd
+          readOnly: false
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: collector-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+          items:
+            - key: relay
+              path: relay.yaml
+      - name: run-collectd
+        emptyDir:
+          sizeLimit: 25Mi

--- a/examples/fluentd-refresh-interval/rendered_manifests/secret-splunk.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/secret-splunk.yaml
@@ -1,0 +1,19 @@
+---
+# Source: splunk-otel-collector/templates/secret-splunk.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.86.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.87.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.86.1
+    release: default
+    heritage: Helm
+type: Opaque
+data:
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/examples/fluentd-refresh-interval/rendered_manifests/serviceAccount.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/serviceAccount.yaml
@@ -1,0 +1,16 @@
+---
+# Source: splunk-otel-collector/templates/serviceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.86.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.87.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.86.1
+    release: default
+    heritage: Helm

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: af91f41c621f1943d016ee75b3a888e12b3427dd580d652363fdb2382fb863e5
+        checksum/config: 19a60871ce274d51d2508d6bed42cc89142b4929180f44d32b5d458ab8ac2a3d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -72,6 +72,8 @@ data:
       pos_file {{ .Values.fluentd.config.posFilePrefix }}-containers.log.pos
       path_key source
       read_from_head true
+      enable_stat_watcher {{ .Values.fluentd.config.enableStatWatcher | default true }}
+      refresh_interval {{ .Values.fluentd.config.refreshInterval | default 60 }}
       <parse>
         @include source.containers.parse.conf
         time_key time

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -937,6 +937,12 @@
             "posFilePrefix": {
               "type": "string"
             },
+            "refreshInterval": {
+              "type": "integer"
+            },
+            "enableStatWatcher": {
+              "type": "boolean"
+            },
             "customFilters": {
               "type": "object",
               "patternProperties": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -706,7 +706,7 @@ fluentd:
     # uncomment the line below to override default behaviour
     # refreshInterval: 60
 
-    # Enables the stat_watcher. Defaults to true. 
+    # Enables the stat_watcher. Defaults to true.
     # See: https://docs.fluentd.org/v1.0/articles/in_tail#enable_stat_watcher"
     # uncomment the line below to disable it
     # enableStatWatcher: false

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -703,11 +703,13 @@ fluentd:
     posFilePrefix: /var/log/splunk-fluentd
 
     # Specify the interval of refreshing the list of watch file. Defaults to 60 (seconds)
-    refreshInterval: 60
+    # uncomment the line below to override default behaviour
+    # refreshInterval: 60
 
-    # Boolean to whether enables the additional inotify-based watcher.
-    # Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing.
-    enableStatWatcher: true
+    # Enables the stat_watcher. Defaults to true. 
+    # See: https://docs.fluentd.org/v1.0/articles/in_tail#enable_stat_watcher"
+    # uncomment the line below to disable it
+    # enableStatWatcher: false
 
     # `customFilters` defines the custom filters to be used.
     # This section can be used to define custom filters using plugins like https://github.com/splunk/fluent-plugin-jq

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -702,6 +702,13 @@ fluentd:
     # https://docs.fluentd.org/input/tail#pos_file-highly-recommended
     posFilePrefix: /var/log/splunk-fluentd
 
+    # Specify the interval of refreshing the list of watch file. Defaults to 60 (seconds)
+    refreshInterval: 60
+
+    # Boolean to whether enables the additional inotify-based watcher.
+    # Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing.
+    enableStatWatcher: true
+
     # `customFilters` defines the custom filters to be used.
     # This section can be used to define custom filters using plugins like https://github.com/splunk/fluent-plugin-jq
     # Its also possible to use other filters like https://www.fluentd.org/plugins#filter


### PR DESCRIPTION
**Description:** This PR exposes some fluentd tail configs that were exposed in SCK. This is a further attempt to fill the gap in the SCK->SOCK transition.

**Link to Splunk idea:** https://ideas.splunk.com/ideas/PORTALSID-I-192

**Fixes:** https://github.com/signalfx/splunk-otel-collector-chart/issues/982