### PR TITLE
Deprecate the networkExplorer option

### DIFF
--- a/.chloggen/deprecate-network-explorer.yaml
+++ b/.chloggen/deprecate-network-explorer.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, networkExplorer, operator, chart, other)
+component: networkExplorer
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate networkExplorer in favor of the upstream OpenTelemetry eBPF helm chart.
+# One or more tracking issues related to the change
+issues: [1026]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,48 @@
 # Upgrade guidelines
 
+## 0.87.0 to 0.88.0
+
+The `networkExplorer` option is deprecated now. Please use the upstream OpenTelemetry eBPF Helm chart to collect
+the network metrics by following the next steps:
+
+1. Make sure the Splunk OpenTelemetry Collector helm chart is installed with the gateway enabled:
+
+```yaml
+gateway:
+  enabled: true
+```
+
+2. Disable the network explorer:
+
+```yaml
+networkExplorer:
+  enabled: false
+```
+
+3. Grab name of the Splunk OpenTelemetry Collector gateway service:
+
+```bash
+kubectl get svc | grep splunk-otel-collector-gateway
+```
+
+4. Install the upstream OpenTelemetry eBPF helm chart pointing to the Splunk OpenTelemetry Collector gateway service:
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update open-telemetry
+helm install my-opentelemetry-ebpf -f ./otel-ebpf-values.yaml open-telemetry/opentelemetry-ebpf
+```
+
+`otel-ebpf-values.yaml` must at least have `endpoint.address` option set to the Splunk OpenTelemetry
+Collector gateway service name captured in the step 2. Additionally, if you had any custom confgurations in the
+`networkExplorer` section, you need to move them to the `otel-ebpf-values.yaml` file.
+
+```yaml
+endpoint:
+  address: <my-splunk-otel-collector-gateway>
+# addttional custom configuration moved from the networkExplorer section in Splunk OpenTelemetry Collector helm chart.
+```
+
 ## 0.85.0 to 0.86.0
 
 The default logs collection engine (`logsEngine`) changed from `fluentd` to the native OpenTelemetry logs collection (`otel`).

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -780,3 +780,35 @@ agent:
   * Cluster receiver is a 1-replica deployment of Open-temlemetry collector.
   * As any available node can be selected by the Kubernetes control plane to run the cluster receiver pod (unless we explicitly specify the `clusterReceiver.nodeSelector` to pin the pod to a specific node), `hostPath` or `local` volume mounts wouldn't work for such envrionments.
   * Data Persistence is currently not applicable to the k8s cluster metrics and k8s events.
+
+### Using OpenTelemetry eBPF helm chart with Splunk OpenTelemetry Collector for Kubernetes
+
+[OpenTelemetry eBPF Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-ebpf)
+can be used to collect network metrics from linux kernel. The metrics collected by eBPF can be
+sent to Splunk OpenTelemetry Collector for Kubernetes gateway. The gateway will then forward the metrics to Splunk
+Observability Cloud or Splunk Enterprise.
+
+To use the OpenTelemetry eBPF helm chart with Splunk OpenTelemetry Collector for Kubernetes, follow the steps below:
+
+1. Make sure the Splunk OpenTelemetry Collector helm chart is installed with the gateway enabled:
+
+```yaml
+gateway:
+  enabled: true
+```
+
+2. Grab name of the Splunk OpenTelemetry Collector gateway service:
+
+```bash
+kubectl get svc | grep splunk-otel-collector-gateway
+```
+
+3. Install the upstream OpenTelemetry eBPF helm chart pointing to the Splunk OpenTelemetry Collector gateway service:
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update open-telemetry
+helm install my-opentelemetry-ebpf --set=endpoint.address=<my-splunk-otel-collector-gateway> open-telemetry/opentelemetry-ebpf
+```
+
+where <my-splunk-otel-collector-gateway> is the gateway service name captured in the step 2.

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -85,3 +85,7 @@ Splunk Network Explorer is installed and configured.
   - Some libraries may be enabled by default. For current status, see: https://github.com/open-telemetry/opentelemetry-operator#controlling-instrumentation-capabilities
   - Splunk provides best-effort support for native OpenTelemetry libraries, and full support for Splunk library distributions. For used libraries, refer to the values.yaml under "operator.instrumentation.spec".
 {{- end }}
+{{- if .Values.networkExplorer.enabled }}
+[WARNING] `networkExplorer` option is deprecated and will be removed soon.
+          Follow https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0870-to-0880 to replace it with the upstream OpenTelemetry eBPF helm chart.
+{{- end }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1133,10 +1133,9 @@ service:
   annotations: {}
 
 ################################################################################
-# Configuration section for Network Explorer (disabled by default).
-# Network Explorer allows you to collect network metrics from linux kernel.
-# Note that Network Explorer is not supported for Linux kernel version 6 at the moment.
-# Setting networkExplorer.enabled=true for Linux kernel 6 will lead to errors.
+# [DEPRECATED] Configuration section for Network Explorer (disabled by default).
+# Follow https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0870-to-0880
+# to replace it with the upstream OpenTelemetry eBPF helm chart.
 ################################################################################
 
 networkExplorer:


### PR DESCRIPTION
Add instruction on how to replace networkExplorer with the upstream OpenTelemetry eBPF Helm Chart.
