### PR TITLE
[chore] move Node.js image to quay

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 charset = utf-8
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -55,11 +55,6 @@ jobs:
       - name: Deploy cert-manager
         run: |
           make cert-manager
-      - name: Build Node.js docker image
-        run: |
-          cd functional_tests/testdata/nodejs
-          docker build -t nodejs_test:latest .
-          kind load docker-image nodejs_test:latest --name kind
       - name: run functional tests
         run: |
           cd functional_tests

--- a/functional_tests/testdata/expected_cluster_receiver.yaml
+++ b/functional_tests/testdata/expected_cluster_receiver.yaml
@@ -1121,7 +1121,7 @@ resourceMetrics:
                         stringValue: 38809b5e5212eddddeec2d4d387e2f27ff754e0c3f67cc9a9ffb89db72601480
                     - key: container.image.name
                       value:
-                        stringValue: docker.io/library/nodejs_test
+                        stringValue: quay.io/splunko11ytest/nodejs_test
                     - key: container.image.tag
                       value:
                         stringValue: latest
@@ -1952,7 +1952,7 @@ resourceMetrics:
                         stringValue: 38809b5e5212eddddeec2d4d387e2f27ff754e0c3f67cc9a9ffb89db72601480
                     - key: container.image.name
                       value:
-                        stringValue: docker.io/library/nodejs_test
+                        stringValue: quay.io/splunko11ytest/nodejs_test
                     - key: container.image.tag
                       value:
                         stringValue: latest

--- a/functional_tests/testdata/expected_traces.yaml
+++ b/functional_tests/testdata/expected_traces.yaml
@@ -75,7 +75,7 @@ resourceSpans:
             stringValue: nodejs-test
         - key: container.image.name
           value:
-            stringValue: nodejs_test
+            stringValue: quay.io/splunko11ytest/nodejs_test
         - key: container.image.tag
           value:
             stringValue: latest

--- a/functional_tests/testdata/nodejs/Makefile
+++ b/functional_tests/testdata/nodejs/Makefile
@@ -1,0 +1,4 @@
+
+.PHONY: push
+push: build
+	docker buildx build --file Dockerfile --platform linux/amd64,linux/arm64 --tag quay.io/splunko11ytest/nodejs_test:latest --push .

--- a/functional_tests/testdata/nodejs/README.md
+++ b/functional_tests/testdata/nodejs/README.md
@@ -1,0 +1,15 @@
+# Node.js test image
+
+This image is used for testing the auto-instrumentation of Node.js application through the OpenTelemetry Operator.
+
+This image is pushed to https://quay.io/repository/splunko11ytest/nodejs_test.
+
+The container performs two separate functions:
+* It runs a Node.js HTTP server on port 3000 of the container host.
+* It runs HTTP requests against the server every second.
+
+Running this container inside a Kubernetes cluster under observation of the operator therefore creates traces.
+
+## Develop
+
+Login to quay.io and push with `make push`

--- a/functional_tests/testdata/nodejs/deployment.yaml
+++ b/functional_tests/testdata/nodejs/deployment.yaml
@@ -16,6 +16,6 @@ spec:
         instrumentation.opentelemetry.io/inject-nodejs: "true"
     spec:
       containers:
-        - image: nodejs_test:latest
+        - image: quay.io/splunko11ytest/nodejs_test:latest
           name: nodejs-test
-          imagePullPolicy: Never
+          imagePullPolicy: IfNotPresent


### PR DESCRIPTION
As we need to test in remote clusters, we are going to move the node.js image out to a remote registry so it may be pulled at test time.
