### PR TITLE
max_connections -> max_idle_conns_per_host

### DIFF
--- a/.chloggen/max-connections.yaml
+++ b/.chloggen/max-connections.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, networkExplorer, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the use of the `max_connections` configuration key, use `max_idle_conns_per_host` instead.
+# One or more tracking issues related to the change
+issues: [1034]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -22,7 +22,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         profiling_data_enabled: false
         retry_on_failure:
           enabled: true
@@ -46,7 +47,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         retry_on_failure:
           enabled: true
           initial_interval: 5s
@@ -69,7 +71,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: ""
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         retry_on_failure:
           enabled: true
           initial_interval: 5s

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -22,7 +22,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         retry_on_failure:
           enabled: true
           initial_interval: 5s

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d7ca3afc1ccab94e40c8b3697c23164236ff5cb72c368d84b0ab770cee32b34a
+        checksum/config: 187492c19cfcca59e3b782649a43d25082b1b69711131d4cdb4dec4e419d6719
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9547b735c5b005ea14f1a1ef48db9748f8d7fc4ed422204ca0a9114ae797f1ba
+        checksum/config: d77ab300ef90ca5261dd7ad10c61d9ad47a3a2e64d9b6f7a03fc330ea0814078
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -22,7 +22,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         profiling_data_enabled: false
         retry_on_failure:
           enabled: true
@@ -46,7 +47,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         retry_on_failure:
           enabled: true
           initial_interval: 5s
@@ -69,7 +71,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: ""
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         retry_on_failure:
           enabled: true
           initial_interval: 5s

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -22,7 +22,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         retry_on_failure:
           enabled: true
           initial_interval: 5s

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1f7ff0b2b202fb4d70489d5df2556d3445c8115be7a38bcf7c957a7784559265
+        checksum/config: 5a01ee8fb02c9d739b4e7eac06adc365db1f2f58fea993fc14b6611cde983c9c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9547b735c5b005ea14f1a1ef48db9748f8d7fc4ed422204ca0a9114ae797f1ba
+        checksum/config: d77ab300ef90ca5261dd7ad10c61d9ad47a3a2e64d9b6f7a03fc330ea0814078
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -22,7 +22,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         retry_on_failure:
           enabled: true
           initial_interval: 5s

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -22,7 +22,8 @@ data:
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         retry_on_failure:
           enabled: true
           initial_interval: 5s

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8a155b3cb73c076afae45f390499d1634527318d7855ef4c729161d3ab684052
+        checksum/config: 0e9a0082768053a97ee50e39df66d50ff69bf522540ab6e0e92465d881b03e9c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9547b735c5b005ea14f1a1ef48db9748f8d7fc4ed422204ca0a9114ae797f1ba
+        checksum/config: d77ab300ef90ca5261dd7ad10c61d9ad47a3a2e64d9b6f7a03fc330ea0814078
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -22,7 +22,8 @@ data:
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main
-        max_connections: 200
+        max_idle_conns: 200
+        max_idle_conns_per_host: 200
         profiling_data_enabled: false
         retry_on_failure:
           enabled: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 30c274f7c8f43e808fb5b3919ce3004db9bffd4766c300f72ac20f85418434cb
+        checksum/config: 19aaca7f720f4443f063565ac9cac35f4f62b5d5ce209138f516cecdab75d77a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -244,7 +244,8 @@ splunk_hec/platform_logs:
   token: "${SPLUNK_PLATFORM_HEC_TOKEN}"
   index: {{ .Values.splunkPlatform.index | quote }}
   source: {{ .Values.splunkPlatform.source | quote }}
-  max_connections: {{ .Values.splunkPlatform.maxConnections }}
+  max_idle_conns: {{ .Values.splunkPlatform.maxConnections }}
+  max_idle_conns_per_host: {{ .Values.splunkPlatform.maxConnections }}
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
   idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}
@@ -285,7 +286,8 @@ splunk_hec/platform_metrics:
   token: "${SPLUNK_PLATFORM_HEC_TOKEN}"
   index: {{ .Values.splunkPlatform.metricsIndex | quote }}
   source: {{ .Values.splunkPlatform.source | quote }}
-  max_connections: {{ .Values.splunkPlatform.maxConnections }}
+  max_idle_conns: {{ .Values.splunkPlatform.maxConnections }}
+  max_idle_conns_per_host: {{ .Values.splunkPlatform.maxConnections }}
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
   idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}
@@ -325,7 +327,8 @@ splunk_hec/platform_traces:
   token: "${SPLUNK_PLATFORM_HEC_TOKEN}"
   index: {{ .Values.splunkPlatform.tracesIndex | quote }}
   source: {{ .Values.splunkPlatform.source | quote }}
-  max_connections: {{ .Values.splunkPlatform.maxConnections }}
+  max_idle_conns: {{ .Values.splunkPlatform.maxConnections }}
+  max_idle_conns_per_host: {{ .Values.splunkPlatform.maxConnections }}
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
   idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}


### PR DESCRIPTION
This PR removes the use of the deprecated `max_connections` configuration field on the Splunk HEC exporter.
