### PR TITLE
Improve the collector github workflow

### DIFF
--- a/.github/workflows/update_collector.yaml
+++ b/.github/workflows/update_collector.yaml
@@ -37,6 +37,6 @@ jobs:
           commit-message: Update collector version
           title: Update collector version to ${{ steps.update.outputs.LATEST_VER }}
           body: Use the new version of the collector
-          branch: "update-${{ steps.update.outputs.LATEST_VER }}"
+          branch: "update-collector"
           base: main
           delete-branch: true

--- a/.github/workflows/update_collector.yaml
+++ b/.github/workflows/update_collector.yaml
@@ -38,5 +38,8 @@ jobs:
           title: Update collector version to ${{ steps.update.outputs.LATEST_VER }}
           body: Use the new version of the collector
           branch: "update-collector"
+          # The "Skip Changelog" label is applied because the ci_scripts/chloggen-update.sh script
+          # will automatically add information about the collector when a release is created.
+          labels: ["Skip Changelog"]
           base: main
           delete-branch: true


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Apply the 'Skip Changelog' label for PRs created by the collector workflow since the automated release notes will handle this task
- Optimize collector workflow to use a single 'update-collector' feature branch, preventing multiple PRs existing at the same time for updating the collector to various versions

