### PR TITLE
Make the clusterName value optional in EKS and GKE

### DIFF
--- a/.chloggen/optionalclustername.yaml
+++ b/.chloggen/optionalclustername.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, networkExplorer, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make clusterName optional in EKS and GKE
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/optionalclustername.yaml
+++ b/.chloggen/optionalclustername.yaml
@@ -5,7 +5,7 @@ component: chart
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Make clusterName optional in EKS and GKE
 # One or more tracking issues related to the change
-issues: []
+issues: [1056]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The following parameter is required or optional depending on the Kubernetes serv
 
 - `clusterName`: arbitrary value that identifies your Kubernetes cluster. The value will be associated with every trace, metric and log as "k8s.cluster.name" attribute.
   * Optional: EKS and GKE. If `clusterName` is specified it will overwrite detected value.
-  * Required: All other services
+  * Required: For all other distributions.
 
 Run the following commands, replacing the parameters above with their appropriate values.
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,11 @@ For Splunk Observability Cloud the following parameters are required:
 - `splunkObservability.accessToken`: Your Splunk Observability org access
   token.
 
-The following parameter is required for any of the destinations:
+The following parameter is required or optional for any of the destinations, depending on the Kubernetes service:
 
 - `clusterName`: arbitrary value that identifies your Kubernetes cluster. The value will be associated with every trace, metric and log as "k8s.cluster.name" attribute.
+  * Optional: EKS and GKE. Detected value will be overwritten by this parameter if specified.
+  * Required: All other services
 
 Run the following commands, replacing the parameters above with their appropriate values.
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ For Splunk Observability Cloud the following parameters are required:
 - `splunkObservability.accessToken`: Your Splunk Observability org access
   token.
 
-The following parameter is required or optional for any of the destinations, depending on the Kubernetes service:
+The following parameter is required or optional depending on the Kubernetes service:
 
 - `clusterName`: arbitrary value that identifies your Kubernetes cluster. The value will be associated with every trace, metric and log as "k8s.cluster.name" attribute.
-  * Optional: EKS and GKE. Detected value will be overwritten by this parameter if specified.
+  * Optional: EKS and GKE. If `clusterName` is specified it will overwrite detected value.
   * Required: All other services
 
 Run the following commands, replacing the parameters above with their appropriate values.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ For Splunk Observability Cloud the following parameters are required:
 The following parameter is required or optional depending on the Kubernetes service:
 
 - `clusterName`: arbitrary value that identifies your Kubernetes cluster. The value will be associated with every trace, metric and log as "k8s.cluster.name" attribute.
-  * Optional: EKS and GKE. If `clusterName` is specified it will overwrite detected value.
+  * Optional: If `distribution` is set to EKS, EKS/fargate, GKE, and GKE/autopilot. If `clusterName` is specified it will overwrite detected value.
   * Required: For all other distributions.
 
 Run the following commands, replacing the parameters above with their appropriate values.

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -183,6 +183,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2ed8cac6190f5e6b4d88c2a41231a6e7e939e4bf0acdf70d7d55583aa56c3a71
+        checksum/config: 51de9ac52f1678407bfc952a0bd4038e40bb40d8c8257ca9b5259156032a4303
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -132,6 +132,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f17b83e48bb335a2bdc8eaae8e7599f35a9aaa91ac4255582c4351fdbba7803e
+        checksum/config: 893773b44fe97e265c14a5947207b6be7bae41338a5a00c5e4bf53cc0c70b733
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 730b35d6f7e4789fe8fe659d9ec9e4bcaac4f44fa68beedb10bf00907ce50fe9
+        checksum/config: 15919b0ab38ef42f028221fc8b69774c3b543edac3d9381e7bfdf29c9c0508a0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 82888cbf9fa590464676e01a10139250fc45e8b343b842514151320ef1a8aaf3
+        checksum/config: 62017f63e77890b706f6a3efb61527b4c78926010c0343355a202ef22d758403
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -150,6 +150,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
       transform/istio_service_name:
         error_mode: ignore
         log_statements:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4e44e9f614aa9e5000f2a641146e51d44c47b29885be5b83e5b903e17241606f
+        checksum/config: 1322578a4cc5c20d2c106b5f5e5038105bf580150dc41fd16725c751f8abbc96
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 33630506932c6f4b210dc9ee99ac4979339ab0a737edba26a5d080202ae581c8
+        checksum/config: 33eb0914c7cfd138ef1edd2bf1636855255def6e73f8889ce308d3f42100a03f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -110,6 +110,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       jaeger:
         protocols:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 78717919b7015ed68641b72c25951cf611e4fff51bc8215c187f1bdb6b6dd77f
+        checksum/config: 82088ffe37f558c434248823c1b9481cf0012d01195fc0bc28cd9a723782e916
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 1afcddac6dfce4237231dc01a4d7aecee885f5de2b6193f4de6e6ce999805523
+        checksum/config: ea4259c2968c3535c76528037624b24ece5c503be6b4ba7dcac993e6c407d29f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -72,6 +72,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
       transform/add_sourcetype:
         log_statements:
         - context: log

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 70f8b64d9c959e0bac5c2697fa2c04995ed79e0bebd64e3388b80da73a4a3787
+        checksum/config: b50612c77989dbe333321be4648a8d407a56e25e6fc61d4980507b9c70e6dbe9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       jaeger:
         protocols:

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 1afcddac6dfce4237231dc01a4d7aecee885f5de2b6193f4de6e6ce999805523
+        checksum/config: ea4259c2968c3535c76528037624b24ece5c503be6b4ba7dcac993e6c407d29f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 33630506932c6f4b210dc9ee99ac4979339ab0a737edba26a5d080202ae581c8
+        checksum/config: 33eb0914c7cfd138ef1edd2bf1636855255def6e73f8889ce308d3f42100a03f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 33630506932c6f4b210dc9ee99ac4979339ab0a737edba26a5d080202ae581c8
+        checksum/config: 33eb0914c7cfd138ef1edd2bf1636855255def6e73f8889ce308d3f42100a03f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -193,6 +193,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -83,6 +83,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3c6c309caba1de54c3c4f994cb260af6c6ce2ea8c9f84365521fd6b091edabec
+        checksum/config: 3a0a943ececc7a1f09d187aae59a24182cd20d48807952b5f816fcd8f8ecda0f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 20dc3ac012eb3ba7096b68c49c5bd2a2933b4a654fdbff11f2f47407ff13d7c5
+        checksum/config: 66eeac5228131be3cac37dc1fa62863287a02d7cf385afaad199fd52a3e92e94
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -126,6 +126,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -68,6 +68,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: db3c48468987799093fe60fb9153458d59affa9b6e645996201f644e74cfd050
+        checksum/config: e017bc451a9ae70c834f9fdd4b7e2a9342ba49dbed5d235b20270caaf078ad9b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: cb01dce8555943b687a6b3021d5a93288144430234540731b7a101cd7dceb251
+        checksum/config: d4d449945a7a01c5c6c815c527440e39065be20dd9d4eea697b4590f1e1bc6a3
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,8 +70,22 @@ data:
         - eks
         - ec2
         - system
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
         override: true
-        timeout: 10s
+        timeout: 15s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        - eks
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: true
+        timeout: 15s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -113,6 +127,7 @@ data:
           processors:
           - memory_limiter
           - batch
+          - resourcedetection/k8s_cluster_name
           - resource
           - resource/k8s_cluster
           receivers:
@@ -134,6 +149,7 @@ data:
           processors:
           - memory_limiter
           - batch
+          - resourcedetection/k8s_cluster_name
           - resource
           receivers:
           - receiver_creator

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -124,8 +124,22 @@ data:
         - eks
         - ec2
         - system
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
         override: true
-        timeout: 10s
+        timeout: 15s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        - eks
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: true
+        timeout: 15s
     receivers:
       jaeger:
         protocols:
@@ -173,6 +187,7 @@ data:
           processors:
           - memory_limiter
           - batch
+          - resourcedetection/k8s_cluster_name
           - resource/add_cluster_name
           receivers:
           - otlp
@@ -195,6 +210,7 @@ data:
           - memory_limiter
           - k8sattributes
           - batch
+          - resourcedetection/k8s_cluster_name
           - resource/add_cluster_name
           receivers:
           - otlp

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2cf8dd46bced8c8c2311f15b97872283ec7e5a9ea311f18a49c8b5693145eb8c
+        checksum/config: 46aa5eb9d8f3ed0f6e5e6fda4f00637f36c4c5b5bd75bbaaa0a8b017e7945eb4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: a4f7e2fa84ab7c4f718512f0764a2fbc68977c735ff9059aca682517cc30797e
+        checksum/config: 95d66979a34e205bcf82e5b62564afab5e4eb533d3a513678334b8c3aaaeedff
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -124,8 +124,22 @@ data:
         - eks
         - ec2
         - system
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
         override: true
-        timeout: 10s
+        timeout: 15s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        - eks
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: true
+        timeout: 15s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,8 +66,22 @@ data:
         - eks
         - ec2
         - system
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
         override: true
-        timeout: 10s
+        timeout: 15s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        - eks
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: true
+        timeout: 15s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -110,6 +124,7 @@ data:
           processors:
           - memory_limiter
           - batch
+          - resourcedetection/k8s_cluster_name
           - resource
           - resource/k8s_cluster
           receivers:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 845469486bc5e3d96d3721455b1230a1e2054222cb7be1e4babb81d82ad0cccd
+        checksum/config: 2203bc439b03b50e0e3cf7af0343addb7a4108455f5269b13271eca2457b6ff8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 99111207b0c9886d317697d58257b1f7afd16e9ae31e83736548be2dcef6400a
+        checksum/config: 2e0ec1c6cf522822508a8d716a0f538b4ad507dab6f1075dcf18c09bc671d880
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -123,6 +123,20 @@ data:
         - env
         - gcp
         - system
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: true
+        timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        - gcp
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
         override: true
         timeout: 10s
     receivers:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -65,6 +65,20 @@ data:
         - env
         - gcp
         - system
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: true
+        timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        - gcp
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
         override: true
         timeout: 10s
     receivers:
@@ -91,6 +105,7 @@ data:
           processors:
           - memory_limiter
           - batch
+          - resourcedetection/k8s_cluster_name
           - resource
           - resource/k8s_cluster
           receivers:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ea4138e38299a2719d58c62d853718adf03ab290636949e58c5b893331b165d0
+        checksum/config: 38dacfeb6c9ef0e4dc3098b8f98c7ee1d37ffae0656ec26cd2bb051652da4e5c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 797e26f0bc24340c75be3bb6e388ca873d357565b68dd6869783a6b416597855
+        checksum/config: b47242e56f3768095b06e6ee9851e6bc55bfd5b5a8f9562b15d0f00482ae116c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -123,6 +123,20 @@ data:
         - env
         - gcp
         - system
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: true
+        timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        - gcp
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
         override: true
         timeout: 10s
     receivers:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -65,6 +65,20 @@ data:
         - env
         - gcp
         - system
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        override: true
+        timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        - gcp
+        gcp:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
         override: true
         timeout: 10s
     receivers:
@@ -91,6 +105,7 @@ data:
           processors:
           - memory_limiter
           - batch
+          - resourcedetection/k8s_cluster_name
           - resource
           - resource/k8s_cluster
           receivers:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 87d6bff44032fb26f99625912c329603d36e2bff2bc6e333944ec1af4c5481e0
+        checksum/config: 5cf03971b40286b83ec694a28ba3c3d88d362c1d5801baec6d5997e0a0e797e2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 797e26f0bc24340c75be3bb6e388ca873d357565b68dd6869783a6b416597855
+        checksum/config: b47242e56f3768095b06e6ee9851e6bc55bfd5b5a8f9562b15d0f00482ae116c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 828c88c383695e5ced921e782729d86a24919f4332198fe1f513f0307e406f36
+        checksum/config: aee8989eb50586c2a379b0aa783984ca743b4bec264799de6ce624a223c29d36
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: abd567ce288b13190117f5d1ac2b3b44bc25118580b9c64e220d4c3c8c199ebd
+        checksum/config: 6f6a33350e7fe2daf931b057d197f15d18323d82a1ef74dd0c3746736758457c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -137,6 +137,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 01336a4b413d3492a70d61911531eaf7ccbf6a312342f83efed1b5106f1e6417
+        checksum/config: 54df66fb88cb9a2c1b7b5fafbecb9f6d665911cb72277a603db72a1324996d5e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a8ae0c813cb50eb920f069080c663caa77d305a7935b6c3e74b91387df4aec35
+        checksum/config: 9ed7300a9a0fdee3641188ff514c9540f19e8410caae931e0cc3d224d6f5567e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -193,6 +193,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -83,6 +83,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 966728752773f4caebe645f5b3a945cb28a060c5477b04f9451988783a1f38c0
+        checksum/config: 8c5492254d9fda08720f86f9f8afc1f95f0dfd5cce137017c14273211897e360
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 20dc3ac012eb3ba7096b68c49c5bd2a2933b4a654fdbff11f2f47407ff13d7c5
+        checksum/config: 66eeac5228131be3cac37dc1fa62863287a02d7cf385afaad199fd52a3e92e94
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       jaeger:
         protocols:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cfd72aa6fd4e9a8416f65e82f38feb9c772226bfad90bf2cbca215642e9bdf5a
+        checksum/config: 9e1e033f101014a0543796819db54acae28619509c10ceb5b31c928c4752d442
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -125,6 +125,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cd38c160ebad60d421223a3b16bc80ef6ebb06aed2b2b7208275b57bd942ebfd
+        checksum/config: 60c64dfd384cd86f4568f0a4af9bb2d838dfabfae9ce78b21694bbb45da821d3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -140,6 +140,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:8006

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 60846f090fb5c2b0d0786eed1c1292a260c621f2be5aabcee1f7d6963f32f12a
+        checksum/config: 28383cc481f8991de4b09ab7ac2fc34214ec7d55f019a53cec276b9db13b3897
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -140,6 +140,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:8006

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6f42a5bc847cc177b35ea3d5ee322710b0921af94d8a6fa67c692f793b80d345
+        checksum/config: f1b222eeb252f33eb66074906a53caf76b268cb348b01a1834de65e38e10007f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -137,6 +137,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 13ab6737daae3d416616a2ed45eecc8d5f7b009809978522654c45e20d2f0daf
+        checksum/config: 01b5098a630cb598c391ca5372bd829e67290a427f68949fd8151fe924110874
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -137,6 +137,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:8006

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c593ca9c4afd10040073e5381334b176eb0e27a1bac91d59dc51dec51b8358ea
+        checksum/config: 6a2b91eb2ff41f52fd2f9e79f53b43e8a0ecb44a976b20349e5ffca8cccd2c0a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -129,6 +129,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: facb9f085a0ead6d0b2f30328a53aba999608709107f1df3859720348e827220
+        checksum/config: f319903e82ebfe45626e6cbb2615af2d19aa61b0d3027e2561c270a68c1c2a68
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -129,6 +129,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2c06cb9e932f798431f6b8d86c709e2dffde482b2eefb801f8fae95d7cfa14d1
+        checksum/config: 6c81e78f283360c4cc091d89aea706c876f2f8fdb2c9b58e59f436806427e416
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -138,6 +138,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -83,6 +83,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d0fa4f3b13d0d41e82d3147e13e7e5a6e4f3b4ca872483aef7f6711fb46ecab3
+        checksum/config: 914c99568bf5a63c7fb6ec6a2f99a5032986f4ffe7e27586c7d4b9af6a4d9188
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 20dc3ac012eb3ba7096b68c49c5bd2a2933b4a654fdbff11f2f47407ff13d7c5
+        checksum/config: 66eeac5228131be3cac37dc1fa62863287a02d7cf385afaad199fd52a3e92e94
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -121,6 +121,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a1cf7875f596cc7e5676ac93b0fc5b60e8d16052658b0d5d6cbc2f2d092e1ba2
+        checksum/config: 2496aa6c488dbcb633d8dba6a280e0d8dfb1f9babc72d06920393422d7cad23d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       jaeger:
         protocols:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b93d65307cc72469d93ca6a2e311dfd4c2bb192cd9dd3455fd9d739a4f3b5005
+        checksum/config: c2ba99b395c879535e28585bac23daa58b3cb0c76e8e1c74fa7a35288ad1d11b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -128,6 +128,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4c6795008eafb57100abed28675d77858843b1ac62e7099761cd8aa2c202a078
+        checksum/config: 38db586a5c709b0d795fcf355348aa0099c101dcf2f94008c51f97cbd81fa9f1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a54e173c91387a67ad2fe83b818a1495a5a69d52dddeec75a13a20577de31de9
+        checksum/config: 03f0c6a7032e3ee935891387d3b53a30c101460385c54d3d28507640f3bc08e4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -129,6 +129,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5e3a7d27274cd2574ffef9c2637b07ca2fe2fa5fcf84598c75725a81bc969d7c
+        checksum/config: 124251fa32898b3e332b1b2c1eb11d8fbe6b372005fb4edc727179a8659ddaf4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -141,6 +141,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       filelog:
         encoding: utf-8

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b707f257168fb9ec6b063a7c8fc0e660c32288303739dd4dccbdd11ba8665022
+        checksum/config: ce64eb4f2f194de02d757843811ba25b8fe191e5fe05eb51498f1d9222dc9245
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       hostmetrics:
         collection_interval: 10s

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -66,6 +66,11 @@ data:
         - system
         override: true
         timeout: 10s
+      resourcedetection/k8s_cluster_name:
+        detectors:
+        - env
+        override: true
+        timeout: 10s
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 33630506932c6f4b210dc9ee99ac4979339ab0a737edba26a5d080202ae581c8
+        checksum/config: 33eb0914c7cfd138ef1edd2bf1636855255def6e73f8889ce308d3f42100a03f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14367a1254370c5fdbac0ebb1def583bdea4f355fae06dcc22e2dfb8ed5f5320
+        checksum/config: 04cc3b443f9422bd2f3e9a8dbfaf3a3de759142cb3830eca6bec635cde9576e2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -106,10 +106,8 @@ Common config for adding k8s.cluster.name using the resourcedetection processor
 {{- define "splunk-otel-collector.resourceDetectionProcessorKubernetesClusterName" -}}
 resourcedetection/k8s_cluster_name:
   detectors:
-    # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
-    # before it gets set later by the cloud provider detector.
     - env
-    {{- if or (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (eq (include "splunk-otel-collector.cloudProvider" .) "gcp") }}
+    {{- if hasPrefix "gke" (include "splunk-otel-collector.distribution" .) }}
     - gcp
     {{- else if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
     - eks

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -80,8 +80,58 @@ resourcedetection:
     # The `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering
     - system
+  {{- if hasPrefix "gke" (include "splunk-otel-collector.distribution" .) }}
+  gcp:
+    resource_attributes:
+      k8s.cluster.name:
+        enabled: true
+  {{- else if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
+  eks:
+    resource_attributes:
+      k8s.cluster.name:
+        enabled: true
+  {{- end }}
   override: true
+  {{/* Testing determined that the EKS cluster name detection required a slightly longer default timeout. */}}
+  {{- if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
+  timeout: 15s
+  {{- else -}}
   timeout: 10s
+  {{- end }}
+{{- end }}
+
+{{/*
+Common config for adding k8s.cluster.name using the resourcedetection processor
+*/}}
+{{- define "splunk-otel-collector.resourceDetectionProcessorKubernetesClusterName" -}}
+resourcedetection/k8s_cluster_name:
+  detectors:
+    # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
+    # before it gets set later by the cloud provider detector.
+    - env
+    {{- if or (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (eq (include "splunk-otel-collector.cloudProvider" .) "gcp") }}
+    - gcp
+    {{- else if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
+    - eks
+    {{- end }}
+  {{- if hasPrefix "gke" (include "splunk-otel-collector.distribution" .) }}
+  gcp:
+    resource_attributes:
+      k8s.cluster.name:
+        enabled: true
+  {{- else if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
+  eks:
+    resource_attributes:
+      k8s.cluster.name:
+        enabled: true
+  {{- end }}
+  override: true
+  {{/* Testing determined that the EKS cluster name detection required a slightly longer default timeout. */}}
+  {{- if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
+  timeout: 15s
+  {{- else -}}
+  timeout: 10s
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -523,8 +523,7 @@ processors:
   # attributes from container environments.
   {{- include "splunk-otel-collector.resourceDetectionProcessor" . | nindent 2 }}
 
-  # Resource detection processor that only detects and adds the k8s.cluster.name
-  # attribute.
+  # Resource detection processor that only detects the k8s.cluster.name attribute.
   {{- include "splunk-otel-collector.resourceDetectionProcessorKubernetesClusterName" . | nindent 2 }}
 
   # General resource attributes that apply to all telemetry passing through the agent.

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -523,17 +523,24 @@ processors:
   # attributes from container environments.
   {{- include "splunk-otel-collector.resourceDetectionProcessor" . | nindent 2 }}
 
+  # Resource detection processor that only detects and adds the k8s.cluster.name
+  # attribute.
+  {{- include "splunk-otel-collector.resourceDetectionProcessorKubernetesClusterName" . | nindent 2 }}
+
   # General resource attributes that apply to all telemetry passing through the agent.
   # It's important to put this processor after resourcedetection to make sure that
-  # k8s.name.cluster attribute is always set to "{{ .Values.clusterName }}".
+  # k8s.name.cluster attribute is always set to "{{ .Values.clusterName }}" when
+  # it's declared.
   resource:
     attributes:
       - action: insert
         key: k8s.node.name
         value: "${K8S_NODE_NAME}"
+      {{- if .Values.clusterName }}
       - action: upsert
         key: k8s.cluster.name
         value: {{ .Values.clusterName }}
+      {{- end }}
       {{- range .Values.extraAttributes.custom }}
       - action: insert
         key: "{{ .name }}"
@@ -737,6 +744,9 @@ service:
       processors:
         - memory_limiter
         - batch
+        {{- if or (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (hasPrefix "eks" (include "splunk-otel-collector.distribution" .)) }}
+        - resourcedetection/k8s_cluster_name
+        {{- end }}
         - resource
         {{- if .Values.environment }}
         - resource/add_environment

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -86,6 +86,7 @@ processors:
     send_batch_max_size: 32768
 
   {{- include "splunk-otel-collector.resourceDetectionProcessor" . | nindent 2 }}
+  {{- include "splunk-otel-collector.resourceDetectionProcessorKubernetesClusterName" . | nindent 2 }}
 
   {{- if eq (include "splunk-otel-collector.o11yInfraMonEventsEnabled" .) "true" }}
   resource/add_event_k8s:
@@ -137,9 +138,11 @@ processors:
       - action: insert
         key: metric_source
         value: kubernetes
+      {{- if .Values.clusterName }}
       - action: upsert
         key: k8s.cluster.name
         value: {{ .Values.clusterName }}
+      {{- end }}
       {{- range .Values.extraAttributes.custom }}
       - action: upsert
         key: {{ .name }}
@@ -209,7 +212,14 @@ service:
     # k8s metrics pipeline
     metrics:
       receivers: [k8s_cluster]
-      processors: [memory_limiter, batch, resource, resource/k8s_cluster]
+      processors:
+        - memory_limiter
+        - batch
+        {{- if or (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (hasPrefix "eks" (include "splunk-otel-collector.distribution" .)) }}
+        - resourcedetection/k8s_cluster_name
+        {{- end }}
+        - resource
+        - resource/k8s_cluster
       exporters:
         {{- if (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") }}
         - signalfx
@@ -221,7 +231,13 @@ service:
     {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
     metrics/eks:
       receivers: [receiver_creator]
-      processors: [memory_limiter, batch, resource]
+      processors:
+        - memory_limiter
+        - batch
+        {{- if or (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (hasPrefix "eks" (include "splunk-otel-collector.distribution" .)) }}
+        - resourcedetection/k8s_cluster_name
+        {{- end }}
+        - resource
       exporters:
         {{- if (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") }}
         - signalfx
@@ -300,8 +316,11 @@ service:
       processors:
         - memory_limiter
         - batch
+        - resourcedetection
         - resource
+        {{- if .Values.clusterName }}
         - resource/add_event_k8s
+        {{- end }}
       exporters:
         - signalfx
     {{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -264,6 +264,7 @@
     "distribution": {
       "description": "Kubernetes distribution where the collector is running",
       "type": "string",
+      "$comment": "Please ensure clusterName is set to the proper required/optional value when modifying this list",
       "enum": [
         "eks",
         "eks/fargate",
@@ -1550,19 +1551,37 @@
       "if": {
         "properties": {
           "distribution": { "pattern": "^[^g].[^k]*[^e].*" }
-        }
+        },
+        "required": ["distribution"]
       },
       "then": {
         "if": {
           "properties": {
             "distribution": { "pattern": "^[^e].[^k]*[^s].*" }
-          }
+          },
+          "required": ["distribution"]
         },
         "then": {
+          "$comment": "The clusterName is required if the distribution doesn't start with eks or gke.",
           "properties": {
             "clusterName": {
               "minLength": 1
             }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "distribution": { "pattern": "^[ ]?$" }
+        }
+      },
+      "then": {
+        "$comment": "We get here if the distribution is blank or just spaces. The clusterName is required for this case",
+        "properties": {
+          "clusterName": {
+            "minLength": 1
           }
         }
       }

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "required": [
-    "clusterName",
     "cloudProvider",
     "distribution"
   ],
@@ -22,8 +21,7 @@
     },
     "clusterName": {
       "description": "Cluster name that will be used as metadata attributes for all telemetry data",
-      "type": "string",
-      "minLength": 1
+      "type": "string"
     },
     "splunkPlatform": {
       "description": "Splunk Cloud / Splunk Enterprise configuration",
@@ -1547,6 +1545,27 @@
           }
         }
       ]
+    },
+    {
+      "if": {
+        "properties": {
+          "distribution": { "pattern": "^[^g].[^k]*[^e].*" }
+        }
+      },
+      "then": {
+        "if": {
+          "properties": {
+            "distribution": { "pattern": "^[^e].[^k]*[^s].*" }
+          }
+        },
+        "then": {
+          "properties": {
+            "clusterName": {
+              "minLength": 1
+            }
+          }
+        }
+      }
     },
     {
       "if": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -9,9 +9,10 @@ nameOverride: ""
 fullnameOverride: ""
 
 ################################################################################
-# clusterName is a REQUIRED. It can be set to an arbitrary value that identifies
+# clusterName is an optional parameter. It can be set to an arbitrary value that identifies
 # your K8s cluster. The value will be associated with every trace, metric and
-# log as "k8s.cluster.name" attribute.
+# log as "k8s.cluster.name" attribute. It's optional on EKS and GKE, but required
+# on all other Kubernetes services.
 ################################################################################
 
 clusterName: ""


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Now that the resource detection processor supports detecting the `k8s.cluster.name` in GKE and EKS environments, the `clusterName` value can be optional in these environments.

A simplified resource detection processor has been added to more pipelines in this change as well, in every place the `clusterName` was manually being added.

**Testing:** <Describe what testing was performed and which tests were added.>
Tested in GKE and kOps.  GKE sets cluster name properly without it specified, and overrides the detected `k8s.cluster.name` when `clusterName` is set. kOps fails without `clusterName` with the following message:
```
crobert$ ~/dev/splunk-otel-collector-chart $ helm upgrade ...
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
splunk-otel-collector:
- (root): Must validate "then" as "if" was valid
- clusterName: String length must be greater than or equal to 1
- (root): Must validate all the schemas (allOf)
```
The `- (root)` lines are a bit confusing, but that's simply saying that the check failed, AFAICT.

**Documentation:** <Describe the documentation added.>
Updated README and relevant comments in code.
