### PR TITLE
add original names of subcharts to values schema

### DIFF
--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1503,6 +1503,16 @@
       "type": "object",
       "additionalProperties": true
     },
+    "opentelemetry-operator": {
+      "description": "OpenTelemetry Operator configuration. A subchart that is used to install the operator, see https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/values.schema.json for more info.",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "cert-manager": {
+      "description": "cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.",
+      "type": "object",
+      "additionalProperties": true
+    },
     "featureGates": {
       "description": "Helm Chart Feature Gates.",
       "type": "object",


### PR DESCRIPTION
values schema file contains entries for sub-charts but it uses the alias as the key. This works when using splunk-otel-collector-chart directly but when the chart is itself used as a sub-chart, helm fails to lint the chart resulting in issues in CI and deployment pipelines.

This commit explicitly allows both alias and original names of sub-charts in the values schema to work around the limitation in helm.

This should be ideally fixed in helm but this patch is minor enough with a relative big amount of impact so I think we should carry it. 

fixes https://github.com/signalfx/splunk-otel-collector-chart/issues/874

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
