### PR TITLE
[chore] restrict EKS tests runs

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -105,6 +105,7 @@ jobs:
           cd functional_tests
           go test -v
   eks-upgrade-test:
+    needs: kubernetes-test
     concurrency:
       group: eks-access
     env:

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -106,6 +106,7 @@ jobs:
           go test -v
   eks-upgrade-test:
     needs: kubernetes-test
+    if: github.repository == 'signalfx/splunk-otel-collector-chart'
     concurrency:
       group: eks-access
     env:

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -60,6 +60,8 @@ jobs:
           cd functional_tests
           go test -v
   eks-test:
+    needs: kubernetes-test
+    if: github.repository == 'signalfx/splunk-otel-collector-chart'
     concurrency:
       group: eks-access
     env:


### PR DESCRIPTION
Only run EKS tests if functional tests have run and are successful, and if the job runs on the signalfx/splunk-otel-collector-chart.

This limits the possibility of seeing EKS tests canceled midway through execution, which may leave the EKS environment in an unknown state, and avoid having build failures for PRs from forks.