### PR TITLE
K8s version update

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -11,13 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         # The kubernetes_version matrix entries are currently following native Kubernetes version support and +1, see: https://endoflife.date/kubernetes
+        # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
         # TODO: Automate updating this and expand/contract matrix coverage for other Kubernetes distributions
         kubernetes_version:
-          # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
           - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
           - v1.28.4 # Support: 28 Aug 2024 - 28 Oct 2024
           - v1.27.8  # Support: 28 Apr 2024 - 28 Jun 2024
           - v1.26.11 # Support: 28 Dec 2023 - 28 Feb 2024
+          - v1.25.16 # Support: 27 Aug 2023 - 27 Oct 2023
         container_runtime:
           - "docker"
           - "containerd"

--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -13,11 +13,11 @@ jobs:
         # The kubernetes_version matrix entries are currently following native Kubernetes version support and +1, see: https://endoflife.date/kubernetes
         # TODO: Automate updating this and expand/contract matrix coverage for other Kubernetes distributions
         kubernetes_version:
-          - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
-          - v1.27.4  # Support: 28 Apr 2024 - 28 Jun 2024
-          - v1.26.7 # Support: 28 Dec 2023 - 28 Feb 2024
-          - v1.25.12 # Support: 27 Aug 2023 - 27 Oct 2023
-          - v1.24.16  # Support: 28 May 2023 - 28 Jul 2023
+          # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
+          - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
+          - v1.28.4 # Support: 28 Aug 2024 - 28 Oct 2024
+          - v1.27.8  # Support: 28 Apr 2024 - 28 Jun 2024
+          - v1.26.11 # Support: 28 Dec 2023 - 28 Feb 2024
         container_runtime:
           - "docker"
           - "containerd"

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -17,12 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The kubernetes_version matrix entries are currently following native Kubernetes version support and +1, see: https://endoflife.date/kubernetes
+        # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
         k8s-version:
-          # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
           - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
           - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
           - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
           - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024
+          - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
+          # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
+          - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
           - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
           - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
           - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024
-          - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
-          - v1.24.15  # Support: 28 May 2023 - 28 Jul 2023
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/migration_tests.yaml
+++ b/.github/workflows/migration_tests.yaml
@@ -18,8 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
-          - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
-    runs-on: ubuntu-latest
+          # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
+          - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
+          - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
+          - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
+          - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/migration_tests.yaml
+++ b/.github/workflows/migration_tests.yaml
@@ -17,12 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The kubernetes_version matrix entries are currently following native Kubernetes version support and +1, see: https://endoflife.date/kubernetes
+        # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
         k8s-version:
-          # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
           - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
           - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
           - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
-          - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024    runs-on: ubuntu-latest
+          - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024
+          - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Description:
Kubernetes 1.29 just released and 1.25 recently aged out. These changes update the test matrix for k8s versions.