### PR TITLE
[chore] do not update PRs if already open with no diff on helm chart

### DIFF
--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -69,10 +69,9 @@ jobs:
           branch: "update-${{ matrix.name }}" # Same branch name for all PRs
           base: main
           delete-branch: true
-          modify-outputs: false
 
       - name: Apply Version Update and Generate Changelog
-        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 }}
+        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 && steps.open_pr.outputs.pull-request-number != '' }}
         run: |
           # Apply the version update, update the rendered examples with the version update, and create a changelog entry
           # We run `make update-docker-image` again here because the open_pr peter-evans/create-pull-request step before clears out the update changes locally
@@ -81,7 +80,7 @@ jobs:
           make chlog-new FILENAME="update-${{ matrix.name }}" CHANGE_TYPE=enhancement COMPONENT=${{ matrix.component }} NOTE="Bump ${{ matrix.name }} to ${{ steps.check_for_update.outputs.LATEST_TAG }} in ${{ matrix.yaml_file_path }}" ISSUES=[${{ steps.open_pr.outputs.pull-request-number }}]
 
       - name: Finalize PR with updates
-        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 }}
+        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 && steps.open_pr.outputs.pull-request-number != '' }}
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Update ${{ matrix.name }} instrumentation version
@@ -90,4 +89,3 @@ jobs:
           branch: "update-${{ matrix.name }}" # Same branch name for all PRs
           base: main
           delete-branch: true
-          modify-outputs: false

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -54,7 +54,7 @@ jobs:
         id: check_if_pr_open
         run: |
           DIFF=0
-          git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts || DIFF=1
+          (git show-ref --verify --quiet refs/heads/update-${{ matrix.name }} && git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts) || DIFF=1
           echo "PR_NEEDED=$DIFF" >> "$GITHUB_OUTPUT"
 
       - name: Open PR for Version Update

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Check if PR is already open
         id: check_if_pr_open
         run: |
-          git diff --exit-code master..update-${{ matrix.name }} -- helm-charts
+          git diff --exit-code main..update-${{ matrix.name }} -- helm-charts
           echo "PR_NEEDED=$?" >> "$GITHUB_OUTPUT"
 
       - name: Open PR for Version Update

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -55,6 +55,8 @@ jobs:
         run: |
           DIFF=1
           git fetch origin
+          git show-ref --verify refs/heads/update-${{ matrix.name }} && true
+          git diff --no-ext-diff main..update-${{ matrix.name }} -- helm-charts
           (git show-ref --verify --quiet refs/heads/update-${{ matrix.name }}) && (git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts) && DIFF=0
           echo "PR_NEEDED=$DIFF" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -53,8 +53,8 @@ jobs:
       - name: Check if PR is already open
         id: check_if_pr_open
         run: |
-          DIFF=0
-          (git show-ref --verify --quiet refs/heads/update-${{ matrix.name }} && git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts) || DIFF=1
+          DIFF=1
+          (git show-ref --verify --quiet refs/heads/update-${{ matrix.name }}) && (git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts) && DIFF=0
           echo "PR_NEEDED=$DIFF" >> "$GITHUB_OUTPUT"
 
       - name: Open PR for Version Update

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -54,6 +54,7 @@ jobs:
         id: check_if_pr_open
         run: |
           DIFF=1
+          git fetch origin
           (git show-ref --verify --quiet refs/heads/update-${{ matrix.name }}) && (git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts) && DIFF=0
           echo "PR_NEEDED=$DIFF" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -16,8 +16,6 @@ on:
 
 jobs:
   check_and_update:
-    # Check if the event is not triggered by a fork
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # Continue all jobs even if one fails

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -55,9 +55,7 @@ jobs:
         run: |
           DIFF=1
           git fetch origin
-          git show-ref --verify refs/heads/update-${{ matrix.name }} && true
-          git diff --no-ext-diff main..update-${{ matrix.name }} -- helm-charts
-          (git show-ref --verify --quiet refs/heads/update-${{ matrix.name }}) && (git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts) && DIFF=0
+          ((git show-ref --verify --quiet refs/heads/update-${{ matrix.name }}) || (git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts)) && DIFF=0
           echo "PR_NEEDED=$DIFF" >> "$GITHUB_OUTPUT"
 
       - name: Open PR for Version Update

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -55,8 +55,9 @@ jobs:
       - name: Check if PR is already open
         id: check_if_pr_open
         run: |
-          git diff --exit-code main..update-${{ matrix.name }} -- helm-charts
-          echo "PR_NEEDED=$?" >> "$GITHUB_OUTPUT"
+          DIFF=0
+          git diff --no-ext-diff --quiet main..update-${{ matrix.name }} -- helm-charts || DIFF=1
+          echo "PR_NEEDED=$DIFF" >> "$GITHUB_OUTPUT"
 
       - name: Open PR for Version Update
         id: open_pr

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   check_and_update:
+    # Check if the event is not triggered by a fork
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false  # Continue all jobs even if one fails
@@ -50,9 +52,15 @@ jobs:
 
           make update-docker-image FILE_PATH=${{ matrix.yaml_file_path }} QUERY_STRING='${{ matrix.yaml_value_path }}' DEBUG_MODE=$DEBUG_MODE
 
+      - name: Check if PR is already open
+        id: check_if_pr_open
+        run: |
+          git diff --exit-code master..update-${{ matrix.name }} -- helm-charts
+          echo "PR_NEEDED=$?" >> "$GITHUB_OUTPUT"
+
       - name: Open PR for Version Update
         id: open_pr
-        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 }}
+        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 }}
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Update ${{ matrix.name }} instrumentation version
@@ -64,7 +72,7 @@ jobs:
           modify-outputs: false
 
       - name: Apply Version Update and Generate Changelog
-        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 }}
+        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 }}
         run: |
           # Apply the version update, update the rendered examples with the version update, and create a changelog entry
           # We run `make update-docker-image` again here because the open_pr peter-evans/create-pull-request step before clears out the update changes locally
@@ -73,7 +81,7 @@ jobs:
           make chlog-new FILENAME="update-${{ matrix.name }}" CHANGE_TYPE=enhancement COMPONENT=${{ matrix.component }} NOTE="Bump ${{ matrix.name }} to ${{ steps.check_for_update.outputs.LATEST_TAG }} in ${{ matrix.yaml_file_path }}" ISSUES=[${{ steps.open_pr.outputs.pull-request-number }}]
 
       - name: Finalize PR with updates
-        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 }}
+        if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 }}
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Update ${{ matrix.name }} instrumentation version


### PR DESCRIPTION
We have a PR [open](https://github.com/signalfx/splunk-otel-collector-chart/pull/1094) for the last few weeks that would be recreated every day based off the cron job updating the PR. Because the workflow creates the PR and then updates it, it forgets the previous state and forces update the PR.

* We get a notification a day of the PR refresh
* We lose work on the PR, such as fixing tests.

To fix this, we want to avoid recreating the PR if no changes are detected after performing the update against the helm-chart folder.