### PR TITLE
Fix issue where the collector agent exporter endpoint used in operator auto-instrumentation was missing the proper IP address 

### DIFF
--- a/.chloggen/operator-envvar-bugfix.yaml
+++ b/.chloggen/operator-envvar-bugfix.yaml
@@ -3,7 +3,7 @@ change_type: bug_fix
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: operator
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix issue where the collector agent exporter endpoint used in operator .Net and Python auto-instrumentation was missing the proper IP address
+note: Fix issue where the collector agent exporter endpoint used in operator .NET and Python auto-instrumentation was missing the proper IP address
 # One or more tracking issues related to the change
 issues: [1129]
 # (Optional) One or more lines of additional information to render under the primary note.

--- a/.chloggen/operator-envvar-bugfix.yaml
+++ b/.chloggen/operator-envvar-bugfix.yaml
@@ -5,7 +5,7 @@ component: operator
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Fix issue where the collector agent exporter endpoint used in operator .Net and Python auto-instrumentation was missing the proper IP address
 # One or more tracking issues related to the change
-issues: []
+issues: [1129]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/.chloggen/operator-envvar-bugfix.yaml
+++ b/.chloggen/operator-envvar-bugfix.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: operator
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where the collector agent exporter endpoint used in operator .Net and Python auto-instrumentation was missing the proper IP address
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
@@ -41,6 +41,11 @@ spec:
         value: "Splunk.OpenTelemetry.AutoInstrumentation.Plugin, Splunk.OpenTelemetry.AutoInstrumentation"
       - name: OTEL_RESOURCE_ATTRIBUTES
         value: splunk.zc.method=splunk-otel-dotnet:v1.3.0
+      - name: SPLUNK_OTEL_AGENT
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: status.hostIP
       # dotnet auto-instrumentation uses http/proto by default, so data must be sent to 4318 instead of 4317.
       # See: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -70,6 +75,11 @@ spec:
     env:
       - name: OTEL_RESOURCE_ATTRIBUTES
         value: splunk.zc.method=autoinstrumentation-python:0.43b0
+      - name: SPLUNK_OTEL_AGENT
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: status.hostIP
       # python auto-instrumentation uses http/proto by default, so data must be sent to 4318 instead of 4317.
       # See: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
       - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
@@ -32,7 +32,7 @@ Helper to ensure the correct usage of the Splunk OpenTelemetry Collector Operato
 {{/*
 Helper to define an endpoint for exporting telemetry data related to auto-instrumentation.
 - Determines the endpoint based on user-defined values or default agent/gateway settings.
-- Order of precedence: User-defined > Agent endpoint > Gateway endpoint
+- Order of precedence: User-defined > Agent service endpoint > Agent host port endpoint > Gateway endpoint
 */}}
 {{- define "splunk-otel-collector.operator.instrumentation-exporter-endpoint" -}}
   {{- /* Initialize endpoint variable */ -}}
@@ -46,7 +46,10 @@ Helper to define an endpoint for exporting telemetry data related to auto-instru
     (ne .Values.operator.instrumentation.spec.exporter.endpoint "")
   }}
   {{- $endpoint = .Values.operator.instrumentation.spec.exporter.endpoint -}}
-  {{- /* Use the agent endpoint if the agent is enabled */ -}}
+  {{- /* Use the agent service endpoint if the agent is enabled */ -}}
+  {{- else if .Values.agent.service.enabled -}}
+    {{- $endpoint = printf "http://%s-agent:4317" (include "splunk-otel-collector.fullname" .) -}}
+  {{- /* Use the agent host port endpoint if the agent is enabled */ -}}
   {{- else if .Values.agent.enabled -}}
     {{- $endpoint = "http://$(SPLUNK_OTEL_AGENT):4317" -}}
   {{- /* Use the gateway endpoint if the gateway is enabled */ -}}

--- a/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
@@ -163,6 +163,11 @@ Helper for generating environment variables for each instrumentation library.
 
   {{- /* Output final OTEL_EXPORTER_OTLP_ENDPOINT, if applicable based on input conditions */ -}}
   {{- if $customOtelExporterEndpoint }}
+    {{- /* {{- /* Ensure the SPLUNK_OTEL_AGENT env var is set with per language env vars to successfully use it in env var substitution */ -}}
+    {{- if contains "SPLUNK_OTEL_AGENT" $customOtelExporterEndpoint -}}
+      {{- printf "- name: SPLUNK_OTEL_AGENT\n  valueFrom:\n    fieldRef:\n      apiVersion: v1\n      fieldPath: status.hostIP" | indent 6 }}
+      {{- printf "\n" -}}
+    {{- end -}}
     {{- if contains "4318" $customOtelExporterEndpoint }}
       {{- printf "# %s auto-instrumentation uses http/proto by default, so data must be sent to 4318 instead of 4317." .instLibName | indent 6 -}}
       {{- printf "\n" -}}

--- a/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
@@ -166,7 +166,7 @@ Helper for generating environment variables for each instrumentation library.
 
   {{- /* Output final OTEL_EXPORTER_OTLP_ENDPOINT, if applicable based on input conditions */ -}}
   {{- if $customOtelExporterEndpoint }}
-    {{- /* {{- /* Ensure the SPLUNK_OTEL_AGENT env var is set with per language env vars to successfully use it in env var substitution */ -}}
+    {{- /* Ensure the SPLUNK_OTEL_AGENT env var is set with per language env vars to successfully use it in env var substitution */ -}}
     {{- if contains "SPLUNK_OTEL_AGENT" $customOtelExporterEndpoint -}}
       {{- printf "- name: SPLUNK_OTEL_AGENT\n  valueFrom:\n    fieldRef:\n      apiVersion: v1\n      fieldPath: status.hostIP" | indent 6 }}
       {{- printf "\n" -}}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- This PR addresses an issue where the Collector Agent Exporter endpoint, utilized in the Operator configuration for .NET and Python auto-instrumentation, lacked the correct IP address assignment. 
  - This flaw specifically impacted setups where trace data was exported to the Collector Agent without using the service (`agent.service.enabled: false`), which resulted in failed trace transmissions.
  - Trace data exported by other auto-instrumentation languages that are not .NET  and Python were unaffected. 
  - Trace data exported to the gateway and related service (`agent.enabled: false` and `gateway.enabled: true`) were unaffected.
  
Testing:
- Adding test coverage as part of https://github.com/signalfx/splunk-otel-collector-chart/pull/1117
