### PR TITLE
ShellCheck fixes to pass shell linter checks

### DIFF
--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -50,7 +50,7 @@ data:
     fi
     chmod a+x kubectl
     # label node
-    ./kubectl label nodes $K8S_NODE_NAME splunk-otel-eks-fargate-kubeletstats-receiver-node=true
+    ./kubectl label nodes "$K8S_NODE_NAME" splunk-otel-eks-fargate-kubeletstats-receiver-node=true
     
     echo "Disabling k8s_cluster receiver for this instance"
     # strip k8s_cluster and its pipeline
@@ -59,4 +59,5 @@ data:
     
     # set kubelet stats to not monitor ourselves (all other kubelets)
     echo "Ensuring k8s_observer-based kubeletstats receivers won't monitor own node to avoid Fargate network limitation."
+    # shellcheck disable=SC2016
     ./yq e -i '.receivers.receiver_creator.receivers.kubeletstats.rule = .receivers.receiver_creator.receivers.kubeletstats.rule + " && not ( name contains \"${K8S_NODE_NAME}\" )"' /splunk-messages/config.yaml

--- a/helm-charts/splunk-otel-collector/scripts/init-eks-fargate-cluster-receiver.sh
+++ b/helm-charts/splunk-otel-collector/scripts/init-eks-fargate-cluster-receiver.sh
@@ -32,7 +32,7 @@ if [ "${ACTUAL}" != "e84ff8c607b2a10f635c312403f9ede40a045404957e55adcf3d663f9e3
 fi
 chmod a+x kubectl
 # label node
-./kubectl label nodes $K8S_NODE_NAME splunk-otel-eks-fargate-kubeletstats-receiver-node=true
+./kubectl label nodes "$K8S_NODE_NAME" splunk-otel-eks-fargate-kubeletstats-receiver-node=true
 
 echo "Disabling k8s_cluster receiver for this instance"
 # strip k8s_cluster and its pipeline
@@ -41,4 +41,5 @@ echo "Disabling k8s_cluster receiver for this instance"
 
 # set kubelet stats to not monitor ourselves (all other kubelets)
 echo "Ensuring k8s_observer-based kubeletstats receivers won't monitor own node to avoid Fargate network limitation."
+# shellcheck disable=SC2016
 ./yq e -i '.receivers.receiver_creator.receivers.kubeletstats.rule = .receivers.receiver_creator.receivers.kubeletstats.rule + " && not ( name contains \"${K8S_NODE_NAME}\" )"' /splunk-messages/config.yaml


### PR DESCRIPTION
**Description:** 

Fixes shellcheck suggestions in `init-eks-fargate-cluster-receiver.sh` to pass shell linter checks.

**Link to Splunk idea:** n/a
**Testing:**  Run the shellscript 

**Documentation:** n/a