### PR TITLE
Fix Helm chart incorrectly handling Kubernetes versions

### DIFF
--- a/.chloggen/fix-pdb-k8s-version-bug.yaml
+++ b/.chloggen/fix-pdb-k8s-version-bug.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Helm chart incorrectly handling Kubernetes versions containing a "+" character, causing deployment errors for PodDisruptionBudget in certain environments
+# One or more tracking issues related to the change
+issues: [1144]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -332,7 +332,7 @@ compatibility with the old config group name: "otelAgent".
 The apiVersion for podDisruptionBudget policies.
 */}}
 {{- define "splunk-otel-collector.PDB-apiVersion" -}}
-{{- if (semverCompare ">= 1.21.0" .Capabilities.KubeVersion.Version) -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
 {{- print "policy/v1" -}}
 {{- else -}}
 {{- print "policy/v1beta1" -}}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Fix Helm chart incorrectly handling Kubernetes version values containing a "+" character, causing deployment errors for PodDisruptionBudget in certain environments.

**Testing:**
- Tested manually by deploying to Kubernetes clusters with versions that did and did not contain "+" characters.

**Documentation:**
- Not needed.