### PR TITLE
remove networkExplorer option

### DIFF
--- a/.chloggen/removenetworkexplorer.yaml
+++ b/.chloggen/removenetworkexplorer.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: networkExplorer
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The `networkExplorer` option was deprecated in 0.88.0. It is now entirely removed.
+# One or more tracking issues related to the change
+issues: [1156]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,9 @@
 # Upgrade guidelines
 
+# 0.93.0 to 0.94.0
+
+The `networkExplorer` option is removed.
+
 ## 0.87.0 to 0.88.0
 
 The `networkExplorer` option is deprecated now. Please use the upstream OpenTelemetry eBPF Helm chart to collect

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -82,6 +82,3 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
   - Some libraries may be enabled by default. For current status, see: https://github.com/open-telemetry/opentelemetry-operator#controlling-instrumentation-capabilities
   - Splunk provides best-effort support for native OpenTelemetry libraries, and full support for Splunk library distributions. For used libraries, refer to the values.yaml under "operator.instrumentation.spec".
 {{- end }}
-{{- if not (eq (toString .Values.networkExplorer) "<nil>")}}
-[WARNING] `networkExplorer` option is no longer supported. Please remove it from your custom values.yaml.
-{{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1409,10 +1409,6 @@
       "type": "boolean",
       "deprecated": true
     },
-    "networkExplorer": {
-      "deprecated": true,
-      "additionalProperties": true
-    },
     "operator": {
       "description": "OpenTelemetry Operator configuration. A subchart that is used to install the operator, see https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/values.schema.json for more info.",
       "type": "object",


### PR DESCRIPTION
**Description:**
Remove `networkExplorer` option from the chart. This option was first deprecated in 0.88.0.
