### PR TITLE
Remove a problematic networkExplorer deprecation note

### DIFF
--- a/.chloggen/remove-broken-notes-section.yaml
+++ b/.chloggen/remove-broken-notes-section.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove networkExplorer deprecation note that can cause the chart installation to fail
+# One or more tracking issues related to the change
+issues: [1162]

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -82,9 +82,6 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
   - Some libraries may be enabled by default. For current status, see: https://github.com/open-telemetry/opentelemetry-operator#controlling-instrumentation-capabilities
   - Splunk provides best-effort support for native OpenTelemetry libraries, and full support for Splunk library distributions. For used libraries, refer to the values.yaml under "operator.instrumentation.spec".
 {{- end }}
-{{- if and (not (eq (toString .Values.networkExplorer) "<nil>")) .Values.networkExplorer.enabled }}
-{{ fail "Network explorer is not part of this helm chart anymore. Please follow https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0870-to-0880 to replace it with the upstream OpenTelemetry eBPF helm chart." }}
-{{- end }}
 {{- if not (eq (toString .Values.networkExplorer) "<nil>")}}
 [WARNING] `networkExplorer` option is no longer supported. Please remove it from your custom values.yaml.
 {{- end }}


### PR DESCRIPTION
Remove networkExplorer deprecation note that can cause the chart installation to fail
