### PR TITLE
Fix autopilot deployment by removing the metrics-addr workaround

### DIFF
--- a/.chloggen/fix-autopilot-deployment.yaml
+++ b/.chloggen/fix-autopilot-deployment.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix GKE Autopilot deployment
+# One or more tracking issues related to the change
+issues: [1171]

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -50,7 +50,6 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        - --metrics-addr=0.0.0.0:8889
         ports:
         - name: jaeger-grpc
           containerPort: 14250

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -248,10 +248,6 @@ spec:
         {{- else }}
         - /otelcol
         - --config=/conf/relay.yaml
-        {{- if eq .Values.distribution "gke/autopilot" }}
-        {{- /* Temporary no-op argument required to run collector on GKE Autopilot */}}
-        - --metrics-addr=0.0.0.0:8889
-        {{- end }}
         {{- end }}
         {{- if .Values.agent.featureGates }}
         - --feature-gates={{ .Values.agent.featureGates }}


### PR DESCRIPTION
The metrics workaround added for GKE Autopilot is not needed anymore. It was fixed on GKE side in a way that it's required to remove it.
