### PR TITLE
Bring back the default translations for kubelet metrics in EKS Fargate

### DIFF
--- a/.chloggen/fix-metrics-in-eks-fargate.yaml
+++ b/.chloggen/fix-metrics-in-eks-fargate.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bring back the default translations for kubelet metrics in EKS Fargate
+# One or more tracking issues related to the change
+issues: [1174]

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -20,7 +20,6 @@ data:
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
-        disable_default_translation_rules: true
         ingest_url: https://ingest.CHANGEME.signalfx.com
         timeout: 10s
     extensions:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d3643e9b340c14bccb45710fb7b6e67b5567254fa1c328d5af935ac13c8388bc
+        checksum/config: 32aa4177abaaf5dc6ff30813a4511cbfd7974b2a99c85da9a798175df36e8a18
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -177,7 +177,9 @@ exporters:
     api_url: {{ include "splunk-otel-collector.o11yApiUrl" . }}
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     timeout: 10s
+    {{- if not (eq (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
     disable_default_translation_rules: true
+    {{- end}}
   {{- end }}
 
   {{- if and (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true") }}


### PR DESCRIPTION
The translations disabled in https://github.com/signalfx/splunk-otel-collector-chart/pull/915 caused a regression in EKS Fargate where we create kubelet stats receiver is created dynamically. This change brings the translations back for EKS Fargate 