### PR TITLE
Enable validation of `enable` field

### DIFF
--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -8,6 +8,10 @@
   "title": "Values",
   "additionalProperties": false,
   "properties": {
+    "enabled": {
+      "description": "Flag to enable splunk-otel-collector used as a subchart in other charts.",
+      "type": "boolean"
+    },
     "global": {
       "type": "object"
     },


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Since `additionalProperties: false` in the `values.schema.json` file, it is not possible to use common pattern to include `splunk-otel-collector` as a subchart using `condition` field in the parent charts `charts.yaml` (as explained in the helm documentation https://helm.sh/docs/topics/charts/#tags-and-condition-fields-in-dependencies). 

This PR adds a validation for `enabled` boolean field to solve the issue.

