### PR TITLE
[chore] make small improvements for docker image update github workflow

### DIFF
--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -80,7 +80,7 @@ jobs:
         run: |
           # Apply the version update, update the rendered examples with the version update, and create a changelog entry
           # We run `make update-docker-image` again here because the open_pr peter-evans/create-pull-request step before clears out the update changes locally
-          make update-docker-image FILE_PATH=${{ matrix.yaml_file_path }} QUERY_STRING='${{ matrix.yaml_value_path }}' DEBUG_MODE=$DEBUG_MODE
+          make update-docker-image FILE_PATH=${{ matrix.yaml_file_path }} QUERY_STRING='${{ matrix.yaml_value_path }}' FILTER='${{ matrix.filter }}' DEBUG_MODE=$DEBUG_MODE
           make render
           make chlog-new FILENAME="update-${{ matrix.name }}" CHANGE_TYPE=enhancement COMPONENT=${{ matrix.component }} NOTE="Bump ${{ matrix.name }} to ${{ steps.check_for_update.outputs.LATEST_TAG }} in ${{ matrix.yaml_file_path }}" ISSUES=[${{ steps.open_pr.outputs.pull-request-number }}]
 

--- a/ci_scripts/base_util.sh
+++ b/ci_scripts/base_util.sh
@@ -209,7 +209,7 @@ get_latest_tag() {
         local owner="${BASH_REMATCH[1]}"
         local repo_name="${BASH_REMATCH[2]}"
         local latest_api="https://quay.io/api/v1/repository/$owner/$repo_name/tag/?limit=1&onlyActiveTags=true"
-        if [! -z "$filter" ]; then
+        if [ -n "$filter" ]; then
             latest_api+="&filter_tag_name=$filter"
         fi
         local tag_name=$(curl -sL "$latest_api" | jq -r '.tags[0].name')
@@ -223,8 +223,8 @@ get_latest_tag() {
         local full_repo_name="${BASH_REMATCH[1]}"
         local latest_api="https://api.github.com/repos/${full_repo_name}/tags"
         local tag_name=$(curl -sL -H 'Accept: application/vnd.github+json' "$latest_api" | jq -r '.[0].name')
-        if [! -z "$filter" ]; then
-            tag_name=$(curl -sL -H 'Accept: application/vnd.github+json' "$latest_api" | jq -r "first(.[] | select(.name | startswith("$filter"))).name")
+        if [ -n "$filter" ]; then
+            tag_name=$(curl -sL -H 'Accept: application/vnd.github+json' "$latest_api" | jq -r --arg filter "$filter" 'first(.[] | select(.name | startswith($filter))).name')
         fi
         if [ -z "$tag_name" ]; then
             echo "Error: No tag found or failed to fetch tag from ghcr.io" >&2
@@ -233,7 +233,7 @@ get_latest_tag() {
         echo "$tag_name"
     # Default for Docker Hub repositories
     else
-        if [ -z "$filter" ]; then
+        if [ -n "$filter" ]; then
             # TODO support getting a specific tag from docker hub
             echo "Error: filters are not supported for docker hub yet"
             exit 1


### PR DESCRIPTION
Description:
Some of the filter logic added recently to only use certain latest versions of docker images needed to be updated.

Testing:
Validated the filter logic works in my forked repo for a [Java update](https://github.com/jvoravong/splunk-otel-collector-chart/pull/167).