### PR TITLE
Add .NET test application for functional tests

### DIFF
--- a/functional_tests/testdata/dotnet/Dockerfile
+++ b/functional_tests/testdata/dotnet/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+WORKDIR /app
+EXPOSE 3000
+
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+WORKDIR /src
+COPY ["DotNetTestApp.csproj", "./"]
+RUN dotnet restore "DotNetTestApp.csproj"
+COPY . .
+WORKDIR "/src/."
+RUN dotnet build "DotNetTestApp.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "DotNetTestApp.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENV OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED=true
+ENTRYPOINT ["dotnet", "DotNetTestApp.dll"]

--- a/functional_tests/testdata/dotnet/Dockerfile
+++ b/functional_tests/testdata/dotnet/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 3000
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["DotNetTestApp.csproj", "./"]
 RUN dotnet restore "DotNetTestApp.csproj"

--- a/functional_tests/testdata/dotnet/DotNetTestApp.csproj
+++ b/functional_tests/testdata/dotnet/DotNetTestApp.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+  </PropertyGroup>
+
+</Project>

--- a/functional_tests/testdata/dotnet/DotNetTestApp.csproj
+++ b/functional_tests/testdata/dotnet/DotNetTestApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/functional_tests/testdata/dotnet/Makefile
+++ b/functional_tests/testdata/dotnet/Makefile
@@ -1,0 +1,8 @@
+# Default image repository
+IMAGE_REPO ?= quay.io/splunko11ytest/dotnet_test
+
+# This .NET application cannot run on arm machines due to .NET runtime limitations
+# Was not able to use docker buildx with .NET
+.PHONY: push
+push:
+	docker build --file Dockerfile --no-cache	--tag $(IMAGE_REPO):latest --push .

--- a/functional_tests/testdata/dotnet/Program.cs
+++ b/functional_tests/testdata/dotnet/Program.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace DotNetTestApp
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var serverTask = CreateHostBuilder(args).Build().RunAsync();
+            var clientTask = RunClientAsync();
+
+            await Task.WhenAny(serverTask, clientTask);
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>().UseUrls("http://*:3000"); // Listen on port 3000
+                });
+
+        private static async Task RunClientAsync()
+        {
+            var client = new HttpClient();
+            while (true)
+            {
+                try
+                {
+                    var response = await client.GetAsync("http://localhost:3000");
+                    Console.WriteLine($"Received response: {response.StatusCode}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error: {ex.Message}");
+                }
+
+                await Task.Delay(1000); // Wait for 1 second
+            }
+        }
+    }
+}

--- a/functional_tests/testdata/dotnet/README.md
+++ b/functional_tests/testdata/dotnet/README.md
@@ -1,0 +1,15 @@
+# .Net test image
+
+This image is used for testing the auto-instrumentation of .Net application through the OpenTelemetry Operator.
+
+This image is pushed to https://quay.io/repository/splunko11ytest/dotnet_test.
+
+The container performs two separate functions:
+* It runs a .Net HTTP server on port 3000 of the container host.
+* It runs HTTP requests against the server every second.
+
+Running this container inside a Kubernetes cluster under observation of the operator therefore creates traces.
+
+## Develop
+
+Login to quay.io and push with `make push`

--- a/functional_tests/testdata/dotnet/Startup.cs
+++ b/functional_tests/testdata/dotnet/Startup.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotNetTestApp
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("Hello from .NET Test App!");
+                });
+            });
+        }
+    }
+}

--- a/functional_tests/testdata/dotnet/deployment.yaml
+++ b/functional_tests/testdata/dotnet/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dotnet-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dotnet-test
+  template:
+    metadata:
+      name: dotnet-test
+      labels:
+        app: dotnet-test
+      annotations:
+        instrumentation.opentelemetry.io/inject-dotnet: "true"
+        instrumentation.opentelemetry.io/otel-dotnet-auto-runtime: "linux-x64"
+    spec:
+      containers:
+        - image: quay.io/splunko11ytest/dotnet_test:latest
+          name: dotnet-test
+          imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Adds the files needed to create a Docker image containing a .NET test application
- The functional tests that will use this application will be added in a future PR.
- Created Image: https://quay.io/repository/splunko11ytest/dotnet_test?tab=tags&tag=latest