### PR TITLE
On demand Case changes

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
@@ -17,13 +17,13 @@ data:
   {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
   splunk_platform_hec_token: {{ .Values.splunkPlatform.token | b64enc }}
   {{- end }}
-  {{- with .Values.splunkPlatform.clientCert }}
+  {{- with .Values.splunkPlatform.clientCert | default nil }}
   splunk_platform_hec_client_cert: {{ . | b64enc }}
   {{- end }}
-  {{- with .Values.splunkPlatform.clientKey }}
+  {{- with .Values.splunkPlatform.clientKey | default nil }}
   splunk_platform_hec_client_key: {{ . | b64enc }}
   {{- end }}
-  {{- with .Values.splunkPlatform.caFile }}
+  {{- with .Values.splunkPlatform.caFile | default nil }}
   splunk_platform_hec_ca_file: {{ . | b64enc }}
   {{- end }}
 {{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
@@ -17,13 +17,13 @@ data:
   {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
   splunk_platform_hec_token: {{ .Values.splunkPlatform.token | b64enc }}
   {{- end }}
-  {{- with .Values.splunkPlatform.clientCert | default nil }}
+  {{- with .Values.splunkPlatform.clientCert | default "" }}
   splunk_platform_hec_client_cert: {{ . | b64enc }}
   {{- end }}
-  {{- with .Values.splunkPlatform.clientKey | default nil }}
+  {{- with .Values.splunkPlatform.clientKey | default "" }}
   splunk_platform_hec_client_key: {{ . | b64enc }}
   {{- end }}
-  {{- with .Values.splunkPlatform.caFile | default nil }}
+  {{- with .Values.splunkPlatform.caFile | default "" }}
   splunk_platform_hec_ca_file: {{ . | b64enc }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
**Description:** default to falsy when these values do know exist in the relevant block

Bug in secret-splunk.yaml - Forces usage of client key and cert even when forwarding logs to a http event endpoint for a saas instance. Doubly problematic as we inject secrets into these pods 

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** working with professional services who are consulting internal dev to test

