### PR TITLE
 Removed memory_ballast from the helm chart

### DIFF
--- a/.chloggen/otl2702.yaml
+++ b/.chloggen/otl2702.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: 'chart'
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Removed memory_ballast property from all the configs'
+# One or more tracking issues related to the change
+issues: [1240]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -40,8 +40,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -409,7 +407,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0304962dfa2c0ce5add9efa008bdd24b1e79574244e3ff6d51e5ff156c6c8a39
+        checksum/config: fef34281f02a52f6b429974f5098ddedf3303148c6b4582cb7847db459dd9f4a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -40,8 +40,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -365,7 +363,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 53ac7617db554cbcaeaea63533061a995f2fdfee52e3fd162126c71a7adcd7ff
+        checksum/config: dba58d664dc4e0b9f212b375563066b4fc9a6d52650ef693007edd14145eda3c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -254,7 +252,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 743500f14c2524bc0b85af9648d8485f3208c04e00e90a596e2c9d96e3cd6b03
+        checksum/config: b5ef20b8d10af4ebb9f71c765882403b61a5465f91d6ba310eec7511ee6d4b7e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -242,7 +240,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2ca8f1b92c0ab23d58cd71612ae0cc37a7fa616c545dc7a65f9d685665a0cc9d
+        checksum/config: e75a3ccc9846b8509d1667c55bec05070d8d7147bc736aed02f30d00822721e3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -40,8 +40,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       attributes/istio:
@@ -401,7 +399,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ca5f63316e554ca6e870a3a4bd510934e0de9e3caef49dda796568d863d223ed
+        checksum/config: 4ace0a8a12bcc2eff613248dd301be7debfcf5b4793fba320efa0514d4f0e198
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -239,7 +237,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 10d44bef4d1609cf0a39e1c97b8dd6e62b9de6ffb9759a18a46cac2110994058
+        checksum/config: dd9fdf96c4d36e219f083db7bcccc844b1208a8a225cdccf8efb306668b22d47
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -33,8 +33,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -225,7 +223,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -34,8 +34,6 @@ data:
       http_forwarder:
         egress:
           endpoint: https://api.CHANGEME.signalfx.com
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -167,7 +165,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       - zpages
       - http_forwarder
       pipelines:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 83fc4441a8df54f52f3cf8f9413389be89572c6d57eac41727ab6c2afb6a55ef
+        checksum/config: 8f0b2bab10cf518d6913dd40e1e32959ea18126d41a21d470a45298962247326
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: e28b49145ebd43da8373b5176334722ba31fdf2e6d827ba305a2dddfb1b0afec
+        checksum/config: 699a7e9c577a602c3117905a4996b72a8b718ca18fbd572a457c47fd64bc0cc5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -32,8 +32,6 @@ data:
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -121,7 +119,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         logs/objects:
           exporters:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 89af43bdb4cd752c4a23e7919bd45b610b69a6ec653f8260db57d0085dafd1fa
+        checksum/config: cb88df0dc804545dc5af62a62afc4e7c3c212739730a099151d7cc11c1427f4c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -34,8 +34,6 @@ data:
       http_forwarder:
         egress:
           endpoint: https://api.CHANGEME.signalfx.com
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -167,7 +165,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       - zpages
       - http_forwarder
       pipelines:

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: e28b49145ebd43da8373b5176334722ba31fdf2e6d827ba305a2dddfb1b0afec
+        checksum/config: 699a7e9c577a602c3117905a4996b72a8b718ca18fbd572a457c47fd64bc0cc5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -239,7 +237,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 10d44bef4d1609cf0a39e1c97b8dd6e62b9de6ffb9759a18a46cac2110994058
+        checksum/config: dd9fdf96c4d36e219f083db7bcccc844b1208a8a225cdccf8efb306668b22d47
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -239,7 +237,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 10d44bef4d1609cf0a39e1c97b8dd6e62b9de6ffb9759a18a46cac2110994058
+        checksum/config: dd9fdf96c4d36e219f083db7bcccc844b1208a8a225cdccf8efb306668b22d47
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -101,8 +101,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -446,7 +444,6 @@ data:
       - file_storage/persistent_queue
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,8 +43,6 @@ data:
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -140,7 +138,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 65f96c6f54d31ea7889fc7b2e00556fb1268d0729826918d2794bd1aa4266b03
+        checksum/config: 0162ab05c200ce55004b2bd9dd6b8d02626b5bc56f80b095562f86822e7fec15
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 92cb3881c85533c134a7c37e2bb3d5d3094f6c7896f55326059d8fe1888cc367
+        checksum/config: 71fc5a7692e358121524378fdc7e87ae8febf962c4cb1394aefe2cb479b38b46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -239,7 +237,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4af9b0006f6220daea80f2e899197086355b899a0a6ba1ffc1075331a73d509d
+        checksum/config: 5e6af4d4b0dc8edf1492479d9e1ff325441db50e08b7c40bbe5a03cc1e4fedb5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -197,7 +195,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -98,7 +96,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 36ec02eec5945f10071a924afd354334ad58ceea4cc94d33584f84c47bda38ff
+        checksum/config: 37f23fc616b8ec963d539446cf602dfd1072d414e8f24a482b639cb920ab187b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fdae8463f9bddc5d36f89cf0adf4059a0c840700d2a726bdfc26471727407ee4
+        checksum/config: 3594ddb8bc4bd5d8ff22bbbbd6e372d2aa58de73f3024513ede94855242b5a31
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -29,8 +29,6 @@ data:
         auth_type: serviceAccount
         observe_nodes: true
         observe_pods: true
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -117,7 +115,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       - k8s_observer
       pipelines:
         metrics:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -34,8 +34,6 @@ data:
       http_forwarder:
         egress:
           endpoint: https://api.CHANGEME.signalfx.com
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -169,7 +167,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       - zpages
       - http_forwarder
       pipelines:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8ba4cebd9f49c35ac3d277e2fabf351b2ac50a24ad2259d3fbc07ab0983d1512
+        checksum/config: 2b409b7f686ae8bac37e114a52567bfa38473247be29e2a3dbe9dd7130120f8e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: cb228453ee647f99a651432827b632b87d72a2545a32a15f542ab1dccb8c4fc3
+        checksum/config: 0db5bfe05b0779358a17fe7fccfe1838903ea16d704d4f91748a04b42cc411ba
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -197,7 +195,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -116,7 +114,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 17bc86e574e0b6d1edb72e5281817b0d71227ff4c51b494d8e0783c9dcb3b2d7
+        checksum/config: e6304581a06dd8fa564dab56508d1dcfd7c1531f14f75222dbff6ff0f172e4f5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bce37efd08aed0d8c0869a1974d2927bbff03ffc0729a5bae9d27a793669b943
+        checksum/config: 148eedb5323aa3a348f921e9c7f67837cb9c35e52d73234676fb191c45171d54
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -196,7 +194,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -97,7 +95,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 825b2d707b77312154c5a4373e2e3d55f7548ca3db0c5d2176f11c400c603f8a
+        checksum/config: 05e4be681e3f1cd90fa8c74d6b909ab485ecc9e1b58ad7224702c4ceac53896a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 484ce267a2c63182dc20ff3b8d8f6d496c7e4e0cb48661bafad934df2710f731
+        checksum/config: 744df1a8e0d63209f113b93cc5c975fb56af15be189a7411f1a4c9a03b199a27
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -196,7 +194,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -97,7 +95,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 20f34754f361b2dd6d57b8d1620362dbee7ef910c1f7e06e234acce036b2d855
+        checksum/config: bf516abfd1b70c7a9dffc1217f1ed7c6c07a565c103b18219995a55e9f7e70cf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 484ce267a2c63182dc20ff3b8d8f6d496c7e4e0cb48661bafad934df2710f731
+        checksum/config: 744df1a8e0d63209f113b93cc5c975fb56af15be189a7411f1a4c9a03b199a27
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -247,7 +245,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -97,7 +95,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4a665e65d2d2b4e4f319190975767667100fbaf9219475859894e4b8fda18855
+        checksum/config: a7e63e8bc273d6cbd7d9e0c06bde7d0b29446d8b71bdbe22a95a49c5be72310a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 30e87a9b21a31ee7921c4d9fae8ceb4e3c29f15ed3ec3ef5d4bafe84c64641e0
+        checksum/config: 03a2676051ea0496c8a3ebca4689ebf5e31336cc86a2afb70a740f7307b98651
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -40,8 +40,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -363,7 +361,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c1309dcdb1e04bf66334acddde5146baf299fab0f03028e836bd1363fc58680e
+        checksum/config: e3eb7c5bbd3b7c168569c83efbc574fe102a7bf2e9ff8b51723661dee4e6c45e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5d8d501140279d979b0935fc3203cf2593146c423288527c6409472802eb9ce4
+        checksum/config: 07765a101cf908290211000e090385a9c0de2bad92fe5ee5ad7b5a2691093d87
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -101,8 +101,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -446,7 +444,6 @@ data:
       - file_storage/persistent_queue
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,8 +43,6 @@ data:
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -140,7 +138,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e89e82f14bd3eb2e509b37a9fd94b05bee98a5f0f8ba03580c864956cf9e92a5
+        checksum/config: 29a57ea2b199db2d0c5549d2389fdfe4065245caea345232f4ad457fde7a21e8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 92cb3881c85533c134a7c37e2bb3d5d3094f6c7896f55326059d8fe1888cc367
+        checksum/config: 71fc5a7692e358121524378fdc7e87ae8febf962c4cb1394aefe2cb479b38b46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -171,7 +169,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics/agent:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8adeb24259fde83e90185f7280320c73f40d794de3e10c7187fb4294682bfe1e
+        checksum/config: b312ee4c36a13aff008bbeab4699aa42e558581af06f64c986c7593d2ceaddb9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/enabled-pprof-extension-values.yaml
+++ b/examples/enabled-pprof-extension/enabled-pprof-extension-values.yaml
@@ -11,6 +11,5 @@ agent:
       extensions:
         - health_check
         - k8s_observer
-        - memory_ballast
         - zpages
         - pprof

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       pprof: null
       zpages: null
     processors:
@@ -240,7 +238,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       - pprof
       pipelines:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2c7c6a17f14e6f922bdd162f3f9c9c97effc0409d1bc1f3e9ad5c5f5863fce79
+        checksum/config: 292e5265554134a06cd6da735ca7b21721b9d5e4b58cdbc2c6de7d375ecc3ef8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -38,8 +38,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -257,7 +255,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fab264772cdc0e8c025362b53460b09393533c871c02eb0b2a5ccef80c1c4fea
+        checksum/config: 923d39860351f2028d8aaf87f24f4f460f632adb66c8bbcffc072075ea0b5561
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -38,8 +38,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -257,7 +255,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 00823f6e9e8346751ce8700255d1e2751b49332d7b980905fa6bd844e04f2e20
+        checksum/config: bfa2c128e77c7091bdf5636489d7787fc8d7d187e96093d451d857ff32836d7d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -40,8 +40,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -363,7 +361,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 91c9c622320d2464637b9cc20028169d07e23e684a4b0e78657e8d58287c595c
+        checksum/config: c8f2b8802de32898e320f0ab23bd9b737c4b755abfb86a42dd1b97d0d2e44454
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -73,8 +73,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -409,7 +407,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,8 +43,6 @@ data:
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -140,7 +138,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5705a833f244de2e1f93e8d2408b02c5e72cad9a38250ba295dd2d5a0492927e
+        checksum/config: 790da6bac384b7c7b4f534030c1117e99c7facf762162760d83bcb30d8d53a32
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 92cb3881c85533c134a7c37e2bb3d5d3094f6c7896f55326059d8fe1888cc367
+        checksum/config: 71fc5a7692e358121524378fdc7e87ae8febf962c4cb1394aefe2cb479b38b46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -35,8 +35,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -172,7 +170,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f6a47f60291b35cc3f21afd5e70f3e6355b6211258ef5c46fd630ed61c7c05b9
+        checksum/config: 3a0e4dc841c16d0635053750b6763e24d26b134e86f1ac344f1ad80cdac0b815
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -37,8 +37,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -308,7 +306,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3ffc60c89e43d53c4ddd9ebb3f1a1d24327bafc1c4e9f45f9b0cd884be4817c8
+        checksum/config: 8e30309f0cf0fea316fb36f1fbfbb1dbc9788b9bd514ff4928f86263683e7072
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -37,8 +37,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -301,7 +299,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5edfdef86ea0a8043e33555399e937f57bd305dab0409ad015fc7fe7b5814cac
+        checksum/config: 6eacecc85c3e4d71168432b9bb145db4a0929f9f5790ff9da7331fae3b88b535
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -46,8 +46,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -271,7 +269,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,8 +43,6 @@ data:
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -140,7 +138,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 71114b08a36e24d0940a9971c37bd5e6eaa252eb36211899fa27c781b43bbbd3
+        checksum/config: 731a4b13dae9357cce187b13f37b22e86f058458b7481811187e1dea52572712
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 92cb3881c85533c134a7c37e2bb3d5d3094f6c7896f55326059d8fe1888cc367
+        checksum/config: 71fc5a7692e358121524378fdc7e87ae8febf962c4cb1394aefe2cb479b38b46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -29,8 +29,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -225,7 +223,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 69943e390626e2d24e37d814b707f0de0f6ac9c1200036e73df04bdae5b40076
+        checksum/config: 1c43d795adca40af3a1c60545a8693099ce629c0e201402f307ff2f913e628bd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -168,7 +166,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics/agent:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4553c16216674da10ed4790a079406f81af24cdf7f225b1f95250caa8f708e24
+        checksum/config: 50450a9b0f2bb1463a8c6654f52a441ecd3eff6cc93c9d24061af22b0070f255
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -36,8 +36,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -243,7 +241,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8eabeceb5493f18c345e4534a05381338febce6a854a145473ae1ccbc1289627
+        checksum/config: 0a2ec83feb354ca447a3967d288f8ab41d4b00035e3e55e63bd051f03a2d9ab7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0251446929531e1282f0436b2405e0ea854567482b837a9f50e91175f8ee9b4e
+        checksum/config: 8271e69423ec71024d1d6bdfc0fc0d3dc3fb69910673508d668e1b5d62e48686
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -37,8 +37,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -273,7 +271,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 206dde18e34f4f76c8a8476c784f6d3d0caaf33b2737c5b69bce47dcf000a1d4
+        checksum/config: 7483e38152761643f1b83564141735fa72da15bc992c40d1f926abed5c3f29f8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -49,8 +49,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -288,7 +286,6 @@ data:
       - file_storage
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         logs:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a46c2bd51aac034743605c096f9e0095672ffa3a4db21fb1330410a8e06f0899
+        checksum/config: 66693b88c9a5c1cf240a5bfa7eb2c805a84084bff44d9cd566f7b5fc20d35411
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -32,8 +32,6 @@ data:
       k8s_observer:
         auth_type: serviceAccount
         node: ${K8S_NODE_NAME}
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
       zpages: null
     processors:
       batch: null
@@ -239,7 +237,6 @@ data:
       extensions:
       - health_check
       - k8s_observer
-      - memory_ballast
       - zpages
       pipelines:
         metrics:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,8 +26,6 @@ data:
         timeout: 10s
     extensions:
       health_check: null
-      memory_ballast:
-        size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
     processors:
       batch:
         send_batch_max_size: 32768
@@ -96,7 +94,6 @@ data:
     service:
       extensions:
       - health_check
-      - memory_ballast
       pipelines:
         metrics:
           exporters:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 10d44bef4d1609cf0a39e1c97b8dd6e62b9de6ffb9759a18a46cac2110994058
+        checksum/config: dd9fdf96c4d36e219f083db7bcccc844b1208a8a225cdccf8efb306668b22d47
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e4a139c316eb8f526a47e6cfc022e3e96a96b23c029f4aa461b541f57cb0de5
+        checksum/config: 3033e3284899c9a5935b8a1a7c6b51b30ddec87db975535d1ddb2f5506a664e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -17,8 +17,6 @@ extensions:
     timeout: 0
   {{- end }}
 
-  memory_ballast:
-    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
   health_check:
 
@@ -673,7 +671,6 @@ service:
     {{- end }}
     - health_check
     - k8s_observer
-    - memory_ballast
     - zpages
 
   # By default there are two pipelines sending metrics and traces to standalone otel-collector otlp format

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -12,8 +12,6 @@ extensions:
       endpoint: {{ include "splunk-otel-collector.o11yApiUrl" . }}
   {{- end }}
 
-  memory_ballast:
-    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
   zpages:
 
@@ -140,7 +138,6 @@ service:
       address: 0.0.0.0:8889
   extensions:
     - health_check
-    - memory_ballast
     - zpages
     {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
     - http_forwarder

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -7,8 +7,6 @@ The values can be overridden in .Values.clusterReceiver.config
 extensions:
   health_check:
 
-  memory_ballast:
-    size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
   {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
   # k8s_observer w/ pod and node detection for eks/fargate deployment
@@ -208,9 +206,9 @@ service:
     metrics:
       address: 0.0.0.0:8889
   {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
-  extensions: [health_check, memory_ballast, k8s_observer]
+  extensions: [health_check, k8s_observer]
   {{- else }}
-  extensions: [health_check, memory_ballast]
+  extensions: [health_check]
   {{- end }}
   pipelines:
     {{- if or (eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true") (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}


### PR DESCRIPTION
**Description:** Removed memory_ballast from the helm chart

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** unittest, local cluster deployment etc
**Documentation:** <Describe the documentation added.>
