### PR TITLE
Enable `retry_on_failure` for journald receiver too

### DIFF
--- a/.chloggen/oteljournaldretryonfailiure.yaml
+++ b/.chloggen/oteljournaldretryonfailiure.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable `retry_on_failure` for journald receiver
+# One or more tracking issues related to the change
+issues: [764]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: In case of temporary errors the journald receiver should slow down and retry the log delivery instead of dropping it.

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -430,6 +430,8 @@ receivers:
     directory: {{ $.Values.logsCollection.journald.directory }}
     units: [{{ $unit.name }}]
     priority: {{ $unit.priority }}
+    retry_on_failure:
+      enabled: true
     storage: file_storage
     operators:
     - type: add


### PR DESCRIPTION
**Description:** 

We observed the following log message with 0.97.0:

```
ConsumeLogs() failed. Enable retry_on_failure to slow down reading logs and avoid dropping.
{"kind": "receiver", "name": "journald/service-x", "data_type": "logs", "error": "data refused due to high memory usage"}
```

According docs, the `retry_on_failiure` is supported by `journaldreceiver`: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver

With #764 the option was enabled for filelogs (container logs).
