### PR TITLE
Remove SAPM exporter, use OTLP exporter

### DIFF
--- a/.chloggen/removesapm.yaml
+++ b/.chloggen/removesapm.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use OTLP for all trace ingest moving forward.
+# One or more tracking issues related to the change
+issues: [1249]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/README.md
+++ b/README.md
@@ -63,12 +63,8 @@ however, only the Splunk distributions are in scope for official Splunk support 
 This distribution currently supports:
 
 - [Splunk APM](https://www.splunk.com/en_us/products/apm-application-performance-monitoring.html) via the
-  [`sapm`
-  exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter).
-  The [`otlphttp`
-  exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)
-  can be used with a [custom
-  configuration](https://github.com/signalfx/splunk-otel-collector/blob/main/cmd/otelcol/config/collector/otlp_config_linux.yaml).
+  [`otlp`
+  exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter).
   More information available
   [here](https://docs.signalfx.com/en/latest/apm/apm-getting-started/apm-opentelemetry-collector.html).
 - [Splunk Infrastructure

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,16 @@
 # Upgrade guidelines
 
+# 0.97.0 to 0.98.0
+
+The `sapm` exporter is removed in favor of the `otlp` exporter.
+
+By default, only the `otlp` exporter is present in the list of exporters of the trace pipeline.
+
+If you had customized the `sapm` exporter configuration, you will need to change your Helm values to configure
+the OTLP exporter instead.
+
+If you were using the `sapm` exporter in a custom pipeline, please remove it and replace it with the `otlp` exporter.
+
 # 0.93.0 to 0.94.0
 
 The `networkExplorer` option is removed.

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -453,7 +454,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e934a42693d63f6ea776f9088eac9a2b337f588af64d56aab2934dfa782a9b8f
+        checksum/config: 627c302a931d749e2e9d735aea4b5c934838b5f2d7efe91e80e120fc90e509ec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -403,7 +404,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e93b49f0ff5cc9d757a7f186b6b97b4c91eb9bd78facdb8769b2e5eba66420e3
+        checksum/config: 6dd21ca9fd47a0f2ac9d712f4c9e6a08ba3023b6dc90f6baae5d9efd2e1548db
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -281,7 +282,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4601a4ac69a680111122f981152246de3cc73925588a7368655d550105908528
+        checksum/config: eaf74b7e14dcfbf911e511865b2aa207cadaf014fddec3c9f940970899998e9e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -269,7 +270,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ff9d385776bb693f98b3dec25b6828873f43c33607732204a6e39a486b0cd11e
+        checksum/config: 8ff7a35fc0457c07e4896403f6a6883065a8183476a2aa295e6493ef632f87e8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -445,7 +446,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 322dac5539f99f3f7721943f94d6c967fb180c803f06c2997c3c36822346ec6f
+        checksum/config: af301afc6d70f8dbce2b7daab93ce5eb134bdb572f0410c36aad4a16bf0f8796
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -266,7 +267,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a8594c717d99c038ccab837a333cf7d390c1af1646cb3045cd83b041cf4d6124
+        checksum/config: 6ce9c699acee17ba247abb7ba7db8b21dc2cdc7d1422cdb5e6fd10d276c1a3d0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         sending_queue:
           num_consumers: 32
       signalfx:
@@ -199,7 +200,7 @@ data:
           - prometheus/collector
         traces:
           exporters:
-          - sapm
+          - otlp
           processors:
           - memory_limiter
           - k8sattributes

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2653444c822d19d7b856c6cbdb6d8dc9697341f12e24ffc307c24be92c64daad
+        checksum/config: 0d3cb2dfc8254621284ffdea4cb103fb95296c62415be8ea1f4e46a093cd82d9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         sending_queue:
           num_consumers: 32
       signalfx:
@@ -199,7 +200,7 @@ data:
           - prometheus/collector
         traces:
           exporters:
-          - sapm
+          - otlp
           processors:
           - memory_limiter
           - k8sattributes

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2653444c822d19d7b856c6cbdb6d8dc9697341f12e24ffc307c24be92c64daad
+        checksum/config: 0d3cb2dfc8254621284ffdea4cb103fb95296c62415be8ea1f4e46a093cd82d9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -266,7 +267,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a8594c717d99c038ccab837a333cf7d390c1af1646cb3045cd83b041cf4d6124
+        checksum/config: 6ce9c699acee17ba247abb7ba7db8b21dc2cdc7d1422cdb5e6fd10d276c1a3d0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -266,7 +267,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a8594c717d99c038ccab837a333cf7d390c1af1646cb3045cd83b041cf4d6124
+        checksum/config: 6ce9c699acee17ba247abb7ba7db8b21dc2cdc7d1422cdb5e6fd10d276c1a3d0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -266,7 +267,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5b1a533ccbbbe3789ab9a019fc046c080c9daa53242d12829f305d6dd68a34a8
+        checksum/config: 6b41c34a2c18bfbb8888ff73faf4f00f6ab544717ae9b0d9448a0ae7e8da0a0c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -224,7 +225,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 82726100bcc5d7a8cb345507029fb458d6732c5765052b6e9dbf969e51cd9c44
+        checksum/config: 017a942a305923ffb09ecca842a9f5dacd07d0003f839d3abff40e5b3c6d5aa5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         sending_queue:
           num_consumers: 32
       signalfx:
@@ -201,7 +202,7 @@ data:
           - prometheus/collector
         traces:
           exporters:
-          - sapm
+          - otlp
           processors:
           - memory_limiter
           - k8sattributes

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: daa913ea74816e796c548a6105797b5a0376b9408672109b9e3e991a3ef47409
+        checksum/config: f16feaf0b1fd04da7c4f0bf48bca047ca75891b944de08a07fc11ac81a5f6c4b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -224,7 +225,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8f5023597b60a29bf7d069d01ee651ad9d07ce5e5da6a34976acb2eb22f8fc87
+        checksum/config: d25640e709980ea826e6066f01875d0324978001441f9b131db3c83fa7e1eb33
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -223,7 +224,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6f241b5fdeea6db1f85db288f750bf4b398c3d92f6db2008fe1a0cb79d76992e
+        checksum/config: e1f36fc1836049c93a532b40ecc133dee2c27b2dc7d5f5b02841a4fd138707da
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -223,7 +224,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 772364d7e81a2728a502895a3d3f911dd7a966596cafcc51d67601e83a4fabf9
+        checksum/config: 56946b5f70b4aa7474464772fd6d548a901a08b7278d0e81ffa9d5b5ec95a1d4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -274,7 +275,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e5d591984fe943ad97e9057abfdaf1ac5ae7976a39b6194c19ff64e93e4af7f5
+        checksum/config: 67b20946af4e2835c39750a16236ae0578a3a6f2571e34a00761f6a4ba4312cb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.us0.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.us0.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.us0.signalfx.com
@@ -406,7 +407,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 87e264d1e4558c65037069da9b7a9b31db3303ad0353f01a56d3ce6fcc68f996
+        checksum/config: 4552b2638422aaeaac15085d81e71e5e2e16890bba1e25895fb75471e533203b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -184,7 +185,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           processors:
           - memory_limiter
           - probabilistic_sampler

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d87abd65759135dcb984f7711ffa3927e478d05f01c95d5959018d21cd382469
+        checksum/config: 6bf3b6dbc1cb0320f828e37d408ee5cb23db6d9c53855784549b6d8e5a8bd16a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -268,7 +269,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e1ef6fa8dce2388098bb11a75ee733ec85d18518bbe54f3234c4cbe7e875e99b
+        checksum/config: 2689a843df71009e153bab22acb69183d051febe6cda6d330497e9e92ba4e880
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -299,7 +300,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c10c8e936bb91d9c3d898f2c0081835f8b3882ad5dbd5bec0b69cc85b7261378
+        checksum/config: f27532601c054a78dbcd4982291e8badbaa338229baf5c53126855c1a714674f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -299,7 +300,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 965d991c78907d4e029ada8b2d728ebd7ae705a131f7baf7d679004eca43c521
+        checksum/config: a3681f9c70bedbdd1c808ce5f205eedbace1796f54a71eb3db98b975714de588
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -406,7 +407,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bf6adeec03fa6b03102184f519d01331230967f6eb2fd7b5c211eb57197ad1c7
+        checksum/config: a7cebe3b80cb389c8e460dea042e74c9899c1130ccb7ad139d4d6b0ec00fe531
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -181,7 +182,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           processors:
           - memory_limiter
           - k8sattributes

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8dbe343034bc497d44ef23c7d086c2eddd429a0e304db404bec0737c5a77a414
+        checksum/config: d3bacd8292d2668ca7746bb541e44c346edebb3b9ad900c4be6d56d052a70442
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -20,11 +20,10 @@ data:
     exporters:
       otlp:
         endpoint: <custom-gateway-url>:4317
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         tls:
           insecure: true
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: http://<custom-gateway-url>:6060

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 03c26c221cd858a60ee5ec38d23b2d28dfe3fbdacb0718df76099b4ca5f21f23
+        checksum/config: 2023fa9fa4355863772768d8b280bedb93645e7a0965da2f75e8a547fce79a6d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/sapm-upgrade/README.md
+++ b/examples/sapm-upgrade/README.md
@@ -1,0 +1,6 @@
+# SAPM upgrade
+
+This example shows how an end user will be provided with a warning in NOTES.txt if they are using the SAPM exporter,
+which is now replaced by the OTLP exporter.
+
+Please refer to [UPGRADING.md](../../UPGRADING.md) for upgrade steps.

--- a/examples/sapm-upgrade/rendered_manifests/clusterRole.yaml
+++ b/examples/sapm-upgrade/rendered_manifests/clusterRole.yaml
@@ -1,0 +1,92 @@
+---
+# Source: splunk-otel-collector/templates/clusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.97.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.97.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.97.0
+    release: default
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/proxy
+  - pods
+  - pods/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/sapm-upgrade/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/sapm-upgrade/rendered_manifests/clusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: splunk-otel-collector/templates/clusterRoleBinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.97.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.97.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.97.0
+    release: default
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-splunk-otel-collector
+subjects:
+- kind: ServiceAccount
+  name: default-splunk-otel-collector
+  namespace: default

--- a/examples/sapm-upgrade/rendered_manifests/configmap-agent.yaml
+++ b/examples/sapm-upgrade/rendered_manifests/configmap-agent.yaml
@@ -1,0 +1,201 @@
+---
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.97.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.97.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.97.0
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+      sapm:
+        retry_on_failure: false
+      signalfx:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        api_url: https://api.CHANGEME.signalfx.com
+        correlation: null
+        ingest_url: https://ingest.CHANGEME.signalfx.com
+        sync_host_metadata: true
+    extensions:
+      health_check: null
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
+      zpages: null
+    processors:
+      batch: null
+      filter/logs:
+        logs:
+          exclude:
+            match_type: strict
+            resource_attributes:
+            - key: splunk.com/exclude
+              value: "true"
+      k8sattributes:
+        extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: namespace
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          - from: pod
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          labels:
+          - key: app
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: ip
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: host.name
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_agent_k8s:
+        attributes:
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 15s
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:14250
+          thrift_http:
+            endpoint: 0.0.0.0:14268
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus/agent:
+        config:
+          scrape_configs:
+          - job_name: otel-agent
+            metric_relabel_configs:
+            - action: drop
+              regex: otelcol_rpc_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: otelcol_http_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: otelcol_processor_batch_.*
+              source_labels:
+              - __name__
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+      smartagent/signalfx-forwarder:
+        listenAddress: 0.0.0.0:9080
+        type: signalfx-forwarder
+      zipkin:
+        endpoint: 0.0.0.0:9411
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      - zpages
+      pipelines:
+        metrics/agent:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_agent_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/agent
+        traces:
+          exporters:
+          - otlp
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - batch
+          - resourcedetection
+          - resource
+          receivers:
+          - otlp
+          - jaeger
+          - smartagent/signalfx-forwarder
+          - zipkin
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/examples/sapm-upgrade/rendered_manifests/daemonset.yaml
+++ b/examples/sapm-upgrade/rendered_manifests/daemonset.yaml
@@ -1,0 +1,146 @@
+---
+# Source: splunk-otel-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.97.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.97.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.97.0
+    release: default
+    heritage: Helm
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        component: otel-collector-agent
+        release: default
+      annotations:
+        checksum/config: a42b41d74ababefcdec1ac81b209e3728c467418bc5d762affd8eac09f53c1a3
+        kubectl.kubernetes.io/default-container: otel-collector
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        ports:
+        - name: jaeger-grpc
+          containerPort: 14250
+          hostPort: 14250
+          protocol: TCP
+        - name: jaeger-thrift
+          containerPort: 14268
+          hostPort: 14268
+          protocol: TCP
+        - name: otlp
+          containerPort: 4317
+          hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
+          protocol: TCP
+        - name: sfx-forwarder
+          containerPort: 9080
+          hostPort: 9080
+          protocol: TCP
+        - name: zipkin
+          containerPort: 9411
+          hostPort: 9411
+          protocol: TCP
+        image: quay.io/signalfx/splunk-otel-collector:0.97.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NODE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: default-splunk-otel-collector
+                key: splunk_observability_access_token
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-configmap
+        - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+          name: run-collectd
+          readOnly: false
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: run-collectd
+        emptyDir:
+          sizeLimit: 25Mi
+      - name: otel-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-agent
+          items:
+            - key: relay
+              path: relay.yaml

--- a/examples/sapm-upgrade/rendered_manifests/secret-splunk.yaml
+++ b/examples/sapm-upgrade/rendered_manifests/secret-splunk.yaml
@@ -1,0 +1,20 @@
+---
+# Source: splunk-otel-collector/templates/secret-splunk.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-splunk-otel-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.97.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.97.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.97.0
+    release: default
+    heritage: Helm
+type: Opaque
+data:
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/examples/sapm-upgrade/rendered_manifests/serviceAccount.yaml
+++ b/examples/sapm-upgrade/rendered_manifests/serviceAccount.yaml
@@ -1,0 +1,17 @@
+---
+# Source: splunk-otel-collector/templates/serviceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-splunk-otel-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.97.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.97.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.97.0
+    release: default
+    heritage: Helm

--- a/examples/sapm-upgrade/values.yaml
+++ b/examples/sapm-upgrade/values.yaml
@@ -1,0 +1,13 @@
+clusterName: CHANGEME
+splunkObservability:
+  realm: CHANGEME
+  accessToken: CHANGEME
+  metricsEnabled: false
+  logsEnabled: false
+  tracesEnabled: true
+
+agent:
+  config:
+    exporters:
+      sapm:
+        retry_on_failure: false

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -18,9 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
-      sapm:
-        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
-        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      otlp:
+        endpoint: https://ingest.CHANGEME.signalfx.com:443
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -266,7 +267,7 @@ data:
           - prometheus/agent
         traces:
           exporters:
-          - sapm
+          - otlp
           - signalfx
           processors:
           - memory_limiter

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a8594c717d99c038ccab837a333cf7d390c1af1646cb3045cd83b041cf4d6124
+        checksum/config: 6ce9c699acee17ba247abb7ba7db8b21dc2cdc7d1422cdb5e6fd10d276c1a3d0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -82,3 +82,7 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
   - Some libraries may be enabled by default. For current status, see: https://github.com/open-telemetry/opentelemetry-operator#controlling-instrumentation-capabilities
   - Splunk provides best-effort support for native OpenTelemetry libraries, and full support for Splunk library distributions. For used libraries, refer to the values.yaml under "operator.instrumentation.spec".
 {{- end }}
+{{- if and .Values.agent.config .Values.agent.config.exporters (not (eq (toString .Values.agent.config.exporters.sapm) "<nil>")) }}
+[WARNING] You are using the SAPM exporter. SAPM has been deprecated in favor of OTLP, which is now used by default for trace ingest.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0970-to-0980
+{{- end }}

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -82,7 +82,7 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
   - Some libraries may be enabled by default. For current status, see: https://github.com/open-telemetry/opentelemetry-operator#controlling-instrumentation-capabilities
   - Splunk provides best-effort support for native OpenTelemetry libraries, and full support for Splunk library distributions. For used libraries, refer to the values.yaml under "operator.instrumentation.spec".
 {{- end }}
-{{- if and .Values.agent.config .Values.agent.config.exporters (not (eq (toString .Values.agent.config.exporters.sapm) "<nil>")) }}
+{{- if not (eq (toString ((.Values.agent.config).exporters).sapm) "<nil>") }}
 [WARNING] You are using the SAPM exporter. SAPM has been deprecated in favor of OTLP, which is now used by default for trace ingest.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0970-to-0980
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -10,13 +10,14 @@ memory_limiter:
 {{- end }}
 
 {{/*
-Common config for the otel-collector sapm exporter
+Common config for the otel-collector OTLP exporter
 */}}
-{{- define "splunk-otel-collector.otelSapmExporter" -}}
+{{- define "splunk-otel-collector.otelOtlpExporter" -}}
 {{- if (eq (include "splunk-otel-collector.tracesEnabled" .) "true") }}
-sapm:
-  endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v2/trace
-  access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+otlp:
+  endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}:443
+  headers:
+    X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
 {{- end }}
 {{- end }}
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -608,8 +608,8 @@ processors:
         key: destination_canonical_revision
   {{- end }}
 
-# By default only SAPM exporter enabled. It will be pointed to collector deployment if enabled,
-# Otherwise it's pointed directly to signalfx backend based on the values provided in signalfx setting.
+# By default only OTLP exporter enabled. It will be pointed to collector deployment if enabled,
+# Otherwise it's pointed directly to o11y cloud backend based on the values provided in signalfx setting.
 # These values should not be specified manually and will be set in the templates.
 exporters:
 
@@ -622,7 +622,7 @@ exporters:
   {{- else }}
   # If gateway is disabled, data will be sent to directly to backends.
   {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
-  {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
+  {{- include "splunk-otel-collector.otelOtlpExporter" . | nindent 2 }}
   {{- end }}
   {{- if (eq (include "splunk-otel-collector.o11yLogsOrProfilingEnabled" .) "true") }}
   splunk_hec/o11y:
@@ -783,12 +783,9 @@ service:
         - resource/add_environment
         {{- end }}
       exporters:
-        {{- if $gatewayEnabled }}
+        {{- if or $gatewayEnabled (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
         - otlp
         {{- else }}
-        {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
-        - sapm
-        {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformTracesEnabled" .) "true") }}
         - splunk_hec/platform_traces
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -104,7 +104,7 @@ exporters:
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
-  {{- include "splunk-otel-collector.otelSapmExporter" . | nindent 2 }}
+  {{- include "splunk-otel-collector.otelOtlpExporter" . | nindent 2 }}
     sending_queue:
       num_consumers: 32
   {{- end }}
@@ -168,7 +168,7 @@ service:
         {{- end }}
       exporters:
         {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
-        - sapm
+        - otlp
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformTracesEnabled" .) "true") }}
         - splunk_hec/platform_traces


### PR DESCRIPTION
**Description:**
Remove the SAPM exporter and use OTLP exporter for all trace ingest.

**Testing:**
Regenerated examples. Functional tests already use otlp for trace exports.

**Documentation:**
Replaced mention in README.
Added upgrade guidelines, and a note in NOTES.txt to display. I also added an example showing a situation that will trigger the warning in NOTES.txt.
