### PR TITLE
[chore] Update functional tests to add v1.30 and drop v1.25 Kubernetes versions

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -11,14 +11,14 @@ jobs:
       fail-fast: false
       matrix:
         # The kubernetes_version matrix entries are currently following native Kubernetes version support and +1, see: https://endoflife.date/kubernetes
-        # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
+        # To check latest Minikube versions, see: https://raw.githubusercontent.com/kubernetes/minikube/master/pkg/minikube/constants/constants_kubernetes_versions.go
         # TODO: Automate updating this and expand/contract matrix coverage for other Kubernetes distributions
         kubernetes_version:
-          - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
-          - v1.28.4 # Support: 28 Aug 2024 - 28 Oct 2024
-          - v1.27.8  # Support: 28 Apr 2024 - 28 Jun 2024
-          - v1.26.11 # Support: 28 Dec 2023 - 28 Feb 2024
-          - v1.25.16 # Support: 27 Aug 2023 - 27 Oct 2023
+          - v1.30.0 # Support: 28 Apr 2025 - 28 Jun 2025
+          - v1.29.4 # Support: 28 Dec 2024 - 28 Feb 2025
+          - v1.28.9 # Support: 28 Aug 2024 - 28 Oct 2024
+          - v1.27.13  # Support: 28 Apr 2024 - 28 Jun 2024
+          - v1.26.15 # Support: 28 Dec 2023 - 28 Feb 2024
         container_runtime:
           - "docker"
           - "containerd"

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -18,13 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         # The kubernetes_version matrix entries are currently following native Kubernetes version support and +1, see: https://endoflife.date/kubernetes
-        # To check latest versions, see: https://hub.docker.com/r/kindest/node/tags
+        # To check latest Kind versions, see: https://hub.docker.com/r/kindest/node/tags
         k8s-version:
-          - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
-          - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
-          - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
-          - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024
-          - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
+          # TODO: Until Kind publishes more images, use 1.30 alpha image (that they recommend), see: https://github.com/kubernetes-sigs/kind/issues/3589
+          - v1.30.0-alpha.0.102_41890534532931 # Support: 28 Apr 2025 - 28 Jun 2025
+          - v1.29.2 # Support: 28 Dec 2024 - 28 Feb 2025
+          - v1.28.7 # Support: 28 Aug 2024 - 28 Oct 2024
+          - v1.27.11  # Support: 28 Apr 2024 - 28 Jun 2024
+          - v1.26.14 # Support: 28 Dec 2023 - 28 Feb 2024
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -20,8 +20,7 @@ jobs:
         # The kubernetes_version matrix entries are currently following native Kubernetes version support and +1, see: https://endoflife.date/kubernetes
         # To check latest Kind versions, see: https://hub.docker.com/r/kindest/node/tags
         k8s-version:
-          # TODO: Until Kind publishes more images, use 1.30 alpha image (that they recommend), see: https://github.com/kubernetes-sigs/kind/issues/3589
-          - v1.30.0-alpha.0.102_41890534532931 # Support: 28 Apr 2025 - 28 Jun 2025
+          - v1.30.0 # Support: 28 Apr 2025 - 28 Jun 2025
           - v1.29.2 # Support: 28 Dec 2024 - 28 Feb 2025
           - v1.28.7 # Support: 28 Aug 2024 - 28 Oct 2024
           - v1.27.11  # Support: 28 Apr 2024 - 28 Jun 2024


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Update Kubernetes versions used in CI/CD tests for recent release