### PR TITLE
Fix issue where SPLUNK_OTEL_AGENT env var was set before custom opeartor.instrumentation.spec.env

### DIFF
--- a/.chloggen/inst-update.yaml
+++ b/.chloggen/inst-update.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug
+change_type: bug_fix
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: operator
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).

--- a/.chloggen/inst-update.yaml
+++ b/.chloggen/inst-update.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: operator
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where SPLUNK_OTEL_AGENT env var was set before custom operator.instrumentation.spec.env env vars
+# One or more tracking issues related to the change
+issues: [1292]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
@@ -25,9 +25,6 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   env:
-    {{- with .Values.operator.instrumentation.spec.env }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
     {{- if .Values.splunkObservability.profilingEnabled }}
     {{- if eq (include "splunk-otel-collector.operator.env-has" (dict "env" .Values.operator.instrumentation.spec.env "envName" "SPLUNK_PROFILER_ENABLED")) "false" }}
     - name: SPLUNK_PROFILER_ENABLED
@@ -44,6 +41,9 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.hostIP
+    {{- end }}
+    {{- with .Values.operator.instrumentation.spec.env }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 {{ include "splunk-otel-collector.operator.instrumentation-libraries" . }}
 {{- end }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- This small bug fix makes it so customer provided env vars (using opeartor.instrumentation.spec.env) can use the env var SPLUNK_OTEL_AGENT with var substitution. 
- Before, SPLUNK_OTEL_AGENT was defined after the customer provided env vars and value var substitution was not possible.
