### PR TITLE
[agent] appArmor unconfined

### DIFF
--- a/.chloggen/annotateapparmor.yaml
+++ b/.chloggen/annotateapparmor.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a pod annotation that designates the otel-collector as unconfined for appArmor-protected environments
+# One or more tracking issues related to the change
+issues: [1313]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 8fa4b47252a08e89082a4476920c396266ccb36b95eb35794691b954c3156f10
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: faa3296a24a58ef60a72f76c90b8262f2edf0553225abdd174b5b7ec17e6c94f
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 444732f854ef3dbd0b0ffa2b1fbd399cf0c6d8d7d41e1bfc433529a215131eae
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 46e99e5675a633efe27752f9e102c1a3e33fb13eeed4c20f3241793353f08a9b
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 3d7d5fc8652d3a4b6d829a8c4f188ea94fa02187afd99773ea3133efa8ef833d
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
         sidecar.istio.io/inject: "false"
     spec:
       hostNetwork: true

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 3e887578d6d871c2e7726d65acebe699a49705f56427309e064561409c736f21
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: fa899f7275d4b35fa47c911f932a88f5e7f25ba264539d7b2a637e18db1e4f5d
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 3e887578d6d871c2e7726d65acebe699a49705f56427309e064561409c736f21
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 3e887578d6d871c2e7726d65acebe699a49705f56427309e064561409c736f21
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: bd71fac206a20ef70c4692274b01bad764fa7a99044d779049f90cfd95d8afbd
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: da8ae2fd6b22aa20ad5737b2e383aed88b3d0341a5131e5feaff29f5c5ab2a0c
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: fbc726d32732596bc38a4739d34f83b9d49720a2eaee8d9a9464929dbfff2e37
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 586ef92781c48e3b6ad63c8969444eee141a7ec82d7994b7c2371e7c3137caee
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: a4a7bd0788e842e18e315d9a38b21e40792fdb82aaf4d39dde78e3bac9b0d475
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 7baa63ed19f78659b2eeb9d1d947a824b06c986e17546741f054640a9dd35385
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 6123b8e893b047d838f73b2132e85bf6debb209ab6eebdd686595d8540a88b58
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 4e5a974d5000922a39686d6fdd83faab7b9056e32d80de0876c04e505d5edd69
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: df9703a5cf22d32784c641d8791d85a3fcfe00bff37a06805eedbd07443e6091
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 7bea516862272011ca1739b6bacc8fd07d872d23ed296be93da59a286bd2ac1c
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 5752ae4bf8c5d1b211b363a04008ae6de6d93cf31526f40864482b34202f48f0
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -35,6 +35,7 @@ spec:
       annotations:
         checksum/config: 7c771eaa997f016f5bb47fa68b8462918b4105f33043e7c1933f18ebe5d2e487
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -35,6 +35,7 @@ spec:
       annotations:
         checksum/config: 9bc476a8211b658f37508e45b8e4e62e3011e820b4928ff422592e785ca20671
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: d94e6957ef84581a74c66de01a71db6762a67752f01a73dc4ffe9b1a7b6d8395
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: default-splunk-otel-collector

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 7226028e8b5f5a25935253c6aa3ede69eafe7f030bc72d4e14eb70c918bebd48
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -35,6 +35,7 @@ spec:
       annotations:
         checksum/config: 87d70cbefe2f8de08900d4885c60da6f0d763a59ae22f79a33f0ba8f4afe7630
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 8da0988064fba47690f795db0d165360d46b854fc190eaccadb17e56a24dc96c
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: b2694f02afc62705d8081a77f0de44cbd688cf213e7a420d27cc3aacb0319be9
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: c07a4073385340237e5d68e8eab87838558bcc936c99933f306c6a8a10b7cd0a
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 48adf66385402f9f8fee084475a4344528fe99eaac24ad7c8bf2c4d369dfd307
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: c076b14e6fdd8894e4dcb47d0779698dbd030d108826c4b6adec56e2405f8833
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 1464a4d56c1acd06f894e1986b4704301c3d37ffe79e272e8e9e4cffb381fb3d
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 0922547e8c368c1bac85f8e3b40da0643aa6db82483b678cea9581a3187d3b03
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 94c6eb170021170ac09ed969fe90cfde3c54c6eaa0b106e7c878c259c4f758f6
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         checksum/config: 3e887578d6d871c2e7726d65acebe699a49705f56427309e064561409c736f21
         kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -417,7 +417,10 @@ agent:
 
   # OTel agent annotations
   annotations: {}
-  podAnnotations: {}
+  podAnnotations:
+    # This annotation is a workaround to avoid filling the syslog with warnings from appArmor such as:
+    # Apr 16 13:05:49 localhost kernel: [7954196.731418] audit: type=1400 audit(1713272749.057:5567969): apparmor="DENIED" operation="ptrace" class="ptrace" profile="cri-containerd.apparmor.d" pid=4151892 comm="otelcol" requested_mask="read" denied_mask="read" peer="unconfined"
+    container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
 
   # OTel agent extra pod labels
   podLabels: {}


### PR DESCRIPTION
**Description:**
In some environments, the hostmetricsreceiver running as part of the daemonset's deployed collector creates warnings when appArmor is also running on the node.

To fix this, we must annotate the pod with an instruction to mark the container unconfined.

This PR adds this annotation to the default configuration.
