### PR TITLE
Update OpenShift security context constraints to support the operator service account

### DIFF
--- a/.chloggen/update-security-context-contraints.yaml
+++ b/.chloggen/update-security-context-contraints.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updated Security Context Constraints for OpenShift support to fix formatting issues and add support for the operator service account
+# One or more tracking issues related to the change
+issues: [1325]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
+++ b/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
@@ -15,7 +15,7 @@ metadata:
     release: default
     heritage: Helm
 users:
-- system:serviceaccount:default:default-splunk-otel-collector
+  - system:serviceaccount:default:default-splunk-otel-collector
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
@@ -25,7 +25,7 @@ allowPrivilegedContainer: false
 allowedCapabilities: []
 defaultAddCapabilities: []
 fsGroup:
-  type: MustRunAs
+  type: RunAsAny
 priority: 10
 readOnlyRootFilesystem: true
 requiredDropCapabilities:

--- a/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
+++ b/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
@@ -15,7 +15,7 @@ metadata:
     release: default
     heritage: Helm
 users:
-  - system:serviceaccount:default:default-splunk-otel-collector
+- system:serviceaccount:default:default-splunk-otel-collector
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -10,11 +10,11 @@ allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowPrivilegedContainer: false
 volumes:
-- configMap
-- downwardAPI
-- emptyDir
-- hostPath
-- secret
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - secret
 # Allow podman/crio socket and /proc access
 seLinuxContext:
   type: MustRunAs
@@ -26,14 +26,14 @@ seLinuxContext:
 allowedCapabilities: []
 defaultAddCapabilities: []
 fsGroup:
-  type: MustRunAs
+  type: RunAsAny
 readOnlyRootFilesystem: true
 runAsUser:
   type: RunAsAny
 supplementalGroups:
   type: RunAsAny
 requiredDropCapabilities:
-- ALL
+  - ALL
 {{- end -}}
 
 {{- if and (eq (include "splunk-otel-collector.distribution" .) "openshift") .Values.securityContextConstraints.create  }}
@@ -48,8 +48,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 users:
-- system:serviceaccount:{{ template "splunk-otel-collector.namespace" . }}:{{ template "splunk-otel-collector.serviceAccountName" . }}
-
+  - system:serviceaccount:{{ template "splunk-otel-collector.namespace" . }}:{{ template "splunk-otel-collector.serviceAccountName" . }}
+{{- if .Values.operator.enabled }}
+  - system:serviceaccount:{{ include "splunk-otel-collector.namespace" . }}:operator
+{{- end }}
 {{- $config := include "splunk-otel-collector.defaultSecurityContextConstraints" . | fromYaml }}
 {{ .Values.securityContextConstraintsOverwrite | mustMergeOverwrite $config | toYaml }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -50,7 +50,7 @@ metadata:
 users:
 - system:serviceaccount:{{ template "splunk-otel-collector.namespace" . }}:{{ template "splunk-otel-collector.serviceAccountName" . }}
 {{- if .Values.operator.enabled }}
-- system:serviceaccount:{{ include "splunk-otel-collector.namespace" . }}:operator
+- system:serviceaccount:{{ include "splunk-otel-collector.namespace" . }}:{{ template "opentelemetry-operator.serviceAccountName" .Subcharts.operator }}
 {{- end }}
 {{- $config := include "splunk-otel-collector.defaultSecurityContextConstraints" . | fromYaml }}
 {{ .Values.securityContextConstraintsOverwrite | mustMergeOverwrite $config | toYaml }}

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -10,11 +10,11 @@ allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowPrivilegedContainer: false
 volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - hostPath
-  - secret
+- configMap
+- downwardAPI
+- emptyDir
+- hostPath
+- secret
 # Allow podman/crio socket and /proc access
 seLinuxContext:
   type: MustRunAs
@@ -33,7 +33,7 @@ runAsUser:
 supplementalGroups:
   type: RunAsAny
 requiredDropCapabilities:
-  - ALL
+- ALL
 {{- end -}}
 
 {{- if and (eq (include "splunk-otel-collector.distribution" .) "openshift") .Values.securityContextConstraints.create  }}
@@ -48,9 +48,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 users:
-  - system:serviceaccount:{{ template "splunk-otel-collector.namespace" . }}:{{ template "splunk-otel-collector.serviceAccountName" . }}
+- system:serviceaccount:{{ template "splunk-otel-collector.namespace" . }}:{{ template "splunk-otel-collector.serviceAccountName" . }}
 {{- if .Values.operator.enabled }}
-  - system:serviceaccount:{{ include "splunk-otel-collector.namespace" . }}:operator
+- system:serviceaccount:{{ include "splunk-otel-collector.namespace" . }}:operator
 {{- end }}
 {{- $config := include "splunk-otel-collector.defaultSecurityContextConstraints" . | fromYaml }}
 {{ .Values.securityContextConstraintsOverwrite | mustMergeOverwrite $config | toYaml }}


### PR DESCRIPTION
**Description:**
- **Bug Fix:** Addressed an issue where the Operator was not always deployable to OpenShift environments due to the lack of a validating Security Context Constraint.
- **Updates:**
  - Enhanced Security Context Constraints (SCC) for OpenShift to fix formatting issues and include support for the operator service account.
  - Changed the SCC `fsGroup` type from `MustRunAs` to `RunAsAny` to avoid issues with dynamic default `fsGroup` constraint value ranges, which could prevent the operator from deploying in OpenShift environments. Users can still override SCC settings using the [`securityContextConstraintsOverwrite`](https://github.com/signalfx/splunk-otel-collector-chart/blob/320b40a492bc479b12beb4aad20a85e1a9fd12c1/helm-charts/splunk-otel-collector/values.yaml#L1052) value.
  - Refer to the OpenShift documentation for details: [OpenShift SCC Strategies](https://docs.openshift.com/container-platform/4.15/authentication/managing-security-context-constraints.html#authorization-SCC-strategies_configuring-internal-oauth)
    - _FSGroup - MustRunAs - Requires at least one range to be specified if not using pre-allocated values. Uses the minimum value of the first range as the default. Validates against the first ID in the first range._

**Testing:**
- Reproduced the bug and tested the fix with OpenShift 4.12.11 (Kubernetes v1.25.7) to ensure successful deployment of the Operator. Testing other OpenShift versions as well.