### PR TITLE
Fix docker gateway ip discovery

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -22,11 +22,11 @@ jobs:
         k8s-version:
           # TODO: Add 1.30 support once Kind publishes an official 1.30 image
           - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
-          # - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
-          # - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
-          # - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024
-          # # Test current +1 out-of-date Kubernetes version to cover EKS's extended support version matrix
-          # - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
+          - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
+          - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
+          - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024
+          # Test current +1 out-of-date Kubernetes version to cover EKS's extended support version matrix
+          - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,15 +61,6 @@ jobs:
           make cert-manager
       - name: run functional tests
         run: |
-          echo ========================docker networks ============
-          docker network ls
-          echo ========================================
-          echo ========================docker inspect kind ============
-          docker network inspect kind
-          echo ============================================================
-          echo ==================from container ip route==================
-          docker exec kind-control-plane ip route show default
-          echo ==============================================================
           cd functional_tests
           go test -v
 

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -22,11 +22,11 @@ jobs:
         k8s-version:
           # TODO: Add 1.30 support once Kind publishes an official 1.30 image
           - v1.29.0 # Support: 28 Dec 2024 - 28 Feb 2025
-          - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
-          - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
-          - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024
-          # Test current +1 out-of-date Kubernetes version to cover EKS's extended support version matrix
-          - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
+          # - v1.28.0 # Support: 28 Aug 2024 - 28 Oct 2024
+          # - v1.27.3  # Support: 28 Apr 2024 - 28 Jun 2024
+          # - v1.26.6 # Support: 28 Dec 2023 - 28 Feb 2024
+          # # Test current +1 out-of-date Kubernetes version to cover EKS's extended support version matrix
+          # - v1.25.11 # Support: 27 Aug 2023 - 27 Oct 2023
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,6 +61,15 @@ jobs:
           make cert-manager
       - name: run functional tests
         run: |
+          echo ========================docker networks ============
+          docker network ls
+          echo ========================================
+          echo ========================docker inspect kind ============
+          docker network inspect kind
+          echo ============================================================
+          echo ==================from container ip route==================
+          docker exec kind-control-plane ip route show default
+          echo ==============================================================
           cd functional_tests
           go test -v
 

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -1318,7 +1318,9 @@ func hostEndpoint(t *testing.T) string {
 	network, err := client.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
 	require.NoError(t, err)
 	for _, ipam := range network.IPAM.Config {
-		return ipam.Gateway
+		if ipam.Gateway != "" {
+			return ipam.Gateway
+		}
 	}
 	require.Fail(t, "failed to find host endpoint")
 	return ""

--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -158,6 +158,12 @@ func deployChartsAndApps(t *testing.T) {
 	}
 
 	require.NoError(t, err)
+
+	hostEp := hostEndpoint(t)
+	if len(hostEp) == 0 {
+		require.Fail(t, "Host endpoint not found")
+	}
+
 	replacements := struct {
 		K8sClusterEndpoint    string
 		AgentEndpoint         string
@@ -168,13 +174,13 @@ func deployChartsAndApps(t *testing.T) {
 		LogObjectsHecEndpoint string
 		KubeTestEnv           string
 	}{
-		fmt.Sprintf("http://%s:%d", hostEndpoint(t), signalFxReceiverK8sClusterReceiverPort),
-		fmt.Sprintf("http://%s:%d", hostEndpoint(t), signalFxReceiverPort),
-		fmt.Sprintf("http://%s:%d", hostEndpoint(t), hecReceiverPort),
-		fmt.Sprintf("http://%s:%d/services/collector", hostEndpoint(t), hecMetricsReceiverPort),
-		fmt.Sprintf("%s:%d", hostEndpoint(t), otlpReceiverPort),
-		fmt.Sprintf("http://%s:%d", hostEndpoint(t), apiPort),
-		fmt.Sprintf("http://%s:%d/services/collector", hostEndpoint(t), hecLogsObjectsReceiverPort),
+		fmt.Sprintf("http://%s:%d", hostEp, signalFxReceiverK8sClusterReceiverPort),
+		fmt.Sprintf("http://%s:%d", hostEp, signalFxReceiverPort),
+		fmt.Sprintf("http://%s:%d", hostEp, hecReceiverPort),
+		fmt.Sprintf("http://%s:%d/services/collector", hostEp, hecMetricsReceiverPort),
+		fmt.Sprintf("%s:%d", hostEp, otlpReceiverPort),
+		fmt.Sprintf("http://%s:%d", hostEp, apiPort),
+		fmt.Sprintf("http://%s:%d/services/collector", hostEp, hecLogsObjectsReceiverPort),
 		kubeTestEnv,
 	}
 	tmpl, err := template.New("").Parse(string(valuesBytes))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Docker network inspect returns 2 entries for IPAM.Config with docker update on the `ubuntu-latest` runners. Only one of the return list has the Gateway ip entry. This PR fixes the function to return only if gateway ip is found.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
