### PR TITLE
feat: add optional extra configs for agent and cluster receiver

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -249,6 +249,11 @@ spec:
         {{- else }}
         - /otelcol
         - --config=/conf/relay.yaml
+        {{- if $agent.extraConfigs.enabled }}
+        {{- range $key := $agent.extraConfigs.configMapKeys }}
+        {{ print "- --config=/conf-extra/" $key ".yaml" }}
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- if .Values.agent.featureGates }}
         - --feature-gates={{ .Values.agent.featureGates }}
@@ -357,6 +362,8 @@ spec:
         volumeMounts:
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: otel-configmap
+        - mountPath: {{ .Values.isWindows | ternary "C:\\conf-extra" "/conf-extra" }}
+          name: otel-configmap-extra
       {{- if and .Values.agent.discovery.enabled (not .Values.isWindows) }}
         - mountPath: /etc/otel/collector/config.d
           name: otel-discovery-properties-configmap
@@ -543,6 +550,16 @@ spec:
           items:
             - key: relay
               path: relay.yaml
+      {{- if $agent.extraConfigs.enabled }}
+      - name: otel-configmap-extra
+        configMap:
+          name: {{ $agent.extraConfigs.configMapName }}
+          items:
+            {{- range $key := $agent.extraConfigs.configMapKeys }}
+            {{ print "- key: " $key }}
+            {{ print "  path: " $key ".yaml" }}
+            {{- end }}
+      {{- end }}
       {{- if and .Values.agent.discovery.enabled (not .Values.isWindows) }}
       - name: otel-discovery-properties-configmap
         configMap:

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -119,6 +119,11 @@ spec:
         - --config=/splunk-messages/config.yaml
         {{- else }}
         - --config=/conf/relay.yaml
+        {{- if $clusterReceiver.extraConfigs.enabled }}
+        {{- range $key := $clusterReceiver.extraConfigs.configMapKeys }}
+        {{ print "- --config=/conf-extra/" $key ".yaml" }}
+        {{- end }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.clusterReceiver.featureGates }}
@@ -191,6 +196,8 @@ spec:
         {{- end }}
         - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
           name: collector-configmap
+        - mountPath: {{ .Values.isWindows | ternary "C:\\conf-extra" "/conf-extra" }}
+          name: collector-configmap-extra
         {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
         - mountPath: /splunk-messages
           name: messages
@@ -209,6 +216,16 @@ spec:
           items:
             - key: relay
               path: relay.yaml
+      {{- if $clusterReceiver.extraConfigs.enabled }}
+      - name: collector-configmap-extra
+        configMap:
+          name: {{ $clusterReceiver.extraConfigs.configMapName }}
+          items:
+            {{- range $key := $clusterReceiver.extraConfigs.configMapKeys }}
+            {{ print "- key: " $key }}
+            {{ print "  path: " $key ".yaml" }}
+            {{- end }}
+      {{- end }}
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -359,6 +359,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "extraConfigs": {
+          "type": "object"
+        },
         "enabled": {
           "type": "boolean"
         },
@@ -678,6 +681,9 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "extraConfigs": {
+          "type": "object"
         },
         "resources": {
           "type": "object",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -276,6 +276,10 @@ extraAttributes:
 ################################################################################
 
 agent:
+  extraConfigs:
+    enabled: false
+    configMapName: ""
+    configMapKeys: []
   enabled: true
 
   # Metric collection from k8s control plane components.
@@ -461,6 +465,10 @@ agent:
 # It has to be running on one pod, so it uses its own dedicated deployment with 1 replica.
 
 clusterReceiver:
+  extraConfigs:
+    enabled: false
+    configMapName: ""
+    configMapKeys: []
   enabled: true
 
   # Need to be adjusted based on size of the monitored cluster


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Now the chart has defined some configs in the `templates/config` folder, and allow users to override them in the `config` part of the `values.yaml` file. For most use cases, it works perfect. 

However, in our company there are more than 100 k8s clusters and the collector configuration differs here and there across these clusters. At the beginning we maintain the specific configs in each cluster's collector `values.yaml` file, but it quickly becomes a heavy burden. We need `templating` functionality for these extra configs, but helm doesn't support templating for values at the moment. So we come up with an idea: allow the user provide self-defined configmap as the collector configuration, which will be appended to the running command of the collector container.

For example, the command is `/otelcol --config=/conf/relay.yaml` now. If there exists extra configs, it will be `/otelcol --config=/conf/relay.yaml --config=/conf-extra/relay.yaml`




**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
