### PR TITLE
Add example for "Deploy the Splunk Collector in agent mode and disable using the host network"

### DIFF
--- a/examples/collector-agent-host-network-disabled/README.md
+++ b/examples/collector-agent-host-network-disabled/README.md
@@ -1,0 +1,8 @@
+# Example of chart configuration
+
+## Deploy the Splunk Collector in agent mode and disable using the host network
+
+- This configuration will install the collector as an agent deployment only.
+- Disabling this value will affect monitoring of some control plane components.
+- Enabling the agent service is recommended and also done in this example. Kubernetes services will be deployed to use transmit collector related data.
+- Disregard for Windows (unsupported by k8s).

--- a/examples/collector-agent-host-network-disabled/README.md
+++ b/examples/collector-agent-host-network-disabled/README.md
@@ -4,5 +4,6 @@
 
 - This configuration will install the collector as an agent deployment only.
 - Disabling this value will affect monitoring of some control plane components.
+  - TODO: Add metrics that would be missing
 - Enabling the agent service, as done in this example, is recommended. In this case Kubernetes services will be deployed to transmit collector related data.
 - Disregard for Windows (unsupported by k8s).

--- a/examples/collector-agent-host-network-disabled/README.md
+++ b/examples/collector-agent-host-network-disabled/README.md
@@ -4,5 +4,5 @@
 
 - This configuration will install the collector as an agent deployment only.
 - Disabling this value will affect monitoring of some control plane components.
-- Enabling the agent service is recommended and also done in this example. Kubernetes services will be deployed to use transmit collector related data.
+- Enabling the agent service, as done in this example, is recommended. In this case Kubernetes services will be deployed to transmit collector related data.
 - Disregard for Windows (unsupported by k8s).

--- a/examples/collector-agent-host-network-disabled/collector-agent-host-network-disabled-values.yaml
+++ b/examples/collector-agent-host-network-disabled/collector-agent-host-network-disabled-values.yaml
@@ -1,0 +1,8 @@
+clusterName: CHANGEME
+splunkObservability:
+  realm: CHANGEME
+  accessToken: CHANGEME
+agent:
+  service:
+    enabled: true
+  hostNetwork: false

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/clusterRole.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm
 rules:

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/clusterRole.yaml
@@ -1,0 +1,92 @@
+---
+# Source: splunk-otel-collector/templates/clusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/proxy
+  - pods
+  - pods/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/clusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: splunk-otel-collector/templates/clusterRoleBinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-splunk-otel-collector
+subjects:
+- kind: ServiceAccount
+  name: default-splunk-otel-collector
+  namespace: default

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/clusterRoleBinding.yaml
@@ -6,12 +6,12 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm
 roleRef:

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/configmap-agent.yaml
@@ -1,0 +1,285 @@
+---
+# Source: splunk-otel-collector/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      sapm:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
+      signalfx:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        api_url: https://api.CHANGEME.signalfx.com
+        correlation: null
+        ingest_url: https://ingest.CHANGEME.signalfx.com
+        sync_host_metadata: true
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+      k8s_observer:
+        auth_type: serviceAccount
+        node: ${K8S_NODE_NAME}
+      zpages: null
+    processors:
+      batch: null
+      filter/logs:
+        logs:
+          exclude:
+            match_type: strict
+            resource_attributes:
+            - key: splunk.com/exclude
+              value: "true"
+      k8sattributes:
+        extract:
+          annotations:
+          - from: pod
+            key: splunk.com/sourcetype
+          - from: namespace
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: pod
+            key: splunk.com/exclude
+            tag_name: splunk.com/exclude
+          - from: namespace
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          - from: pod
+            key: splunk.com/index
+            tag_name: com.splunk.index
+          labels:
+          - key: app
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - container.id
+          - container.image.name
+          - container.image.tag
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: ip
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: host.name
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_agent_k8s:
+        attributes:
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/logs:
+        attributes:
+        - action: upsert
+          from_attribute: k8s.pod.annotations.splunk.com/sourcetype
+          key: com.splunk.sourcetype
+        - action: delete
+          key: k8s.pod.annotations.splunk.com/sourcetype
+        - action: delete
+          key: splunk.com/exclude
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 15s
+    receivers:
+      hostmetrics:
+        collection_interval: 10s
+        scrapers:
+          cpu: null
+          disk: null
+          filesystem: null
+          load: null
+          memory: null
+          network: null
+          paging: null
+          processes: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:14250
+          thrift_http:
+            endpoint: 0.0.0.0:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 10s
+        endpoint: ${K8S_NODE_IP}:10250
+        extra_metadata_labels:
+        - container.id
+        metric_groups:
+        - container
+        - pod
+        - node
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus/agent:
+        config:
+          scrape_configs:
+          - job_name: otel-agent
+            metric_relabel_configs:
+            - action: drop
+              regex: otelcol_rpc_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: otelcol_http_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: otelcol_processor_batch_.*
+              source_labels:
+              - __name__
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+      receiver_creator:
+        receivers:
+          smartagent/coredns:
+            config:
+              extraDimensions:
+                metric_source: k8s-coredns
+              port: 9153
+              type: coredns
+            rule: type == "pod" && labels["k8s-app"] == "kube-dns"
+          smartagent/kube-controller-manager:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-controller-manager
+              port: 10257
+              skipVerify: true
+              type: kube-controller-manager
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-controller-manager"
+          smartagent/kubernetes-apiserver:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-apiserver
+              skipVerify: true
+              type: kubernetes-apiserver
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "port" && port == 443 && pod.labels["k8s-app"] == "kube-apiserver"
+          smartagent/kubernetes-proxy:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-proxy
+              port: 10249
+              scrapeFailureLogLevel: debug
+              type: kubernetes-proxy
+            rule: type == "pod" && labels["k8s-app"] == "kube-proxy"
+          smartagent/kubernetes-scheduler:
+            config:
+              extraDimensions:
+                metric_source: kubernetes-scheduler
+              port: 10259
+              skipVerify: true
+              type: kubernetes-scheduler
+              useHTTPS: true
+              useServiceAccount: true
+            rule: type == "pod" && labels["k8s-app"] == "kube-scheduler"
+        watch_observers:
+        - k8s_observer
+      signalfx:
+        endpoint: 0.0.0.0:9943
+      smartagent/signalfx-forwarder:
+        listenAddress: 0.0.0.0:9080
+        type: signalfx-forwarder
+      zipkin:
+        endpoint: 0.0.0.0:9411
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      - zpages
+      pipelines:
+        metrics:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          - resource
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - otlp
+          - receiver_creator
+          - signalfx
+        metrics/agent:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_agent_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/agent
+        traces:
+          exporters:
+          - sapm
+          - signalfx
+          processors:
+          - memory_limiter
+          - k8sattributes
+          - batch
+          - resourcedetection
+          - resource
+          receivers:
+          - otlp
+          - jaeger
+          - smartagent/signalfx-forwarder
+          - zipkin
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/configmap-agent.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm
 data:

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm
 data:

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -1,0 +1,122 @@
+---
+# Source: splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm
+data:
+  relay: |
+    exporters:
+      signalfx:
+        access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        api_url: https://api.CHANGEME.signalfx.com
+        disable_default_translation_rules: true
+        ingest_url: https://ingest.CHANGEME.signalfx.com
+        timeout: 10s
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    processors:
+      batch:
+        send_batch_max_size: 32768
+      memory_limiter:
+        check_interval: 2s
+        limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+      resource:
+        attributes:
+        - action: insert
+          key: metric_source
+          value: kubernetes
+        - action: upsert
+          key: k8s.cluster.name
+          value: CHANGEME
+      resource/add_collector_k8s:
+        attributes:
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.uid
+          value: ${K8S_POD_UID}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+      resource/k8s_cluster:
+        attributes:
+        - action: insert
+          key: receiver
+          value: k8scluster
+      resourcedetection:
+        detectors:
+        - env
+        - system
+        override: true
+        timeout: 15s
+    receivers:
+      k8s_cluster:
+        auth_type: serviceAccount
+        metadata_exporters:
+        - signalfx
+      prometheus/k8s_cluster_receiver:
+        config:
+          scrape_configs:
+          - job_name: otel-k8s-cluster-receiver
+            metric_relabel_configs:
+            - action: drop
+              regex: otelcol_rpc_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: otelcol_http_.*
+              source_labels:
+              - __name__
+            - action: drop
+              regex: otelcol_processor_batch_.*
+              source_labels:
+              - __name__
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${K8S_POD_IP}:8889
+    service:
+      extensions:
+      - health_check
+      pipelines:
+        metrics:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource
+          - resource/k8s_cluster
+          receivers:
+          - k8s_cluster
+        metrics/collector:
+          exporters:
+          - signalfx
+          processors:
+          - memory_limiter
+          - batch
+          - resource/add_collector_k8s
+          - resourcedetection
+          - resource
+          receivers:
+          - prometheus/k8s_cluster_receiver
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8889

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/daemonset.yaml
@@ -1,0 +1,203 @@
+---
+# Source: splunk-otel-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        component: otel-collector-agent
+        release: default
+      annotations:
+        checksum/config: f7b14c2a6a74585e3650b6b506d343f67f0bcc8c13dab749a1530706435b6e93
+        kubectl.kubernetes.io/default-container: otel-collector
+        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
+    spec:
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        ports:
+        - name: jaeger-grpc
+          containerPort: 14250
+          hostPort: 14250
+          protocol: TCP
+        - name: jaeger-thrift
+          containerPort: 14268
+          hostPort: 14268
+          protocol: TCP
+        - name: otlp
+          containerPort: 4317
+          hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: otlp-http-old
+          containerPort: 55681
+          protocol: TCP
+        - name: sfx-forwarder
+          containerPort: 9080
+          hostPort: 9080
+          protocol: TCP
+        - name: signalfx
+          containerPort: 9943
+          hostPort: 9943
+          protocol: TCP
+        - name: zipkin
+          containerPort: 9411
+          hostPort: 9411
+          protocol: TCP
+        image: quay.io/signalfx/splunk-otel-collector:0.104.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NODE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: default-splunk-otel-collector
+                key: splunk_observability_access_token
+          # Env variables for host metrics receiver
+          - name: HOST_PROC
+            value: /hostfs/proc
+          - name: HOST_SYS
+            value: /hostfs/sys
+          - name: HOST_ETC
+            value: /hostfs/etc
+          - name: HOST_VAR
+            value: /hostfs/var
+          - name: HOST_RUN
+            value: /hostfs/run
+          - name: HOST_DEV
+            value: /hostfs/dev
+          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
+          # is resolved fall back to previous gopsutil mountinfo path:
+          # https://github.com/shirou/gopsutil/issues/1271
+          - name: HOST_PROC_MOUNTINFO
+            value: /proc/self/mountinfo
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-configmap
+        - mountPath: /hostfs/dev
+          name: host-dev
+          readOnly: true
+        - mountPath: /hostfs/etc
+          name: host-etc
+          readOnly: true
+        - mountPath: /hostfs/proc
+          name: host-proc
+          readOnly: true
+        - mountPath: /hostfs/run/udev/data
+          name: host-run-udev-data
+          readOnly: true
+        - mountPath: /hostfs/sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /hostfs/var/run/utmp
+          name: host-var-run-utmp
+          readOnly: true
+        - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+          name: run-collectd
+          readOnly: false
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: run-collectd
+        emptyDir:
+          sizeLimit: 25Mi
+      - name: host-dev
+        hostPath:
+          path: /dev
+      - name: host-etc
+        hostPath:
+          path: /etc
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-var-run-utmp
+        hostPath:
+          path: /var/run/utmp
+      - name: otel-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-agent
+          items:
+            - key: relay
+              path: relay.yaml

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/daemonset.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
     component: otel-collector-agent
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm
 spec:
@@ -32,9 +32,8 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f7b14c2a6a74585e3650b6b506d343f67f0bcc8c13dab749a1530706435b6e93
+        checksum/config: 96c6264ca82a10ee205ac6ec71eed96fad7989be6b0f8daf99952d51a98083ca
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -66,9 +65,6 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        - name: otlp-http-old
-          containerPort: 55681
-          protocol: TCP
         - name: sfx-forwarder
           containerPort: 9080
           hostPort: 9080
@@ -81,7 +77,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.104.0
+        image: quay.io/signalfx/splunk-otel-collector:0.105.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -1,0 +1,103 @@
+---
+# Source: splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: default-splunk-otel-collector-k8s-cluster-receiver
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    component: otel-k8s-cluster-receiver
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-k8s-cluster-receiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      component: otel-k8s-cluster-receiver
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        component: otel-k8s-cluster-receiver
+        release: default
+      annotations:
+        checksum/config: 3480abca7449ee547b3e41c526dc6a0329710dfa05606c21711a763d1b6332f8
+    spec:
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+          kubernetes.io/os: linux
+      containers:
+      - name: otel-collector
+        command:
+        - /otelcol
+        - --config=/conf/relay.yaml
+        image: quay.io/signalfx/splunk-otel-collector:0.104.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: default-splunk-otel-collector
+                key: splunk_observability_access_token
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: collector-configmap
+        - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+          name: run-collectd
+          readOnly: false
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: collector-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+          items:
+            - key: relay
+              path: relay.yaml
+      - name: run-collectd
+        emptyDir:
+          sizeLimit: 25Mi

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3480abca7449ee547b3e41c526dc6a0329710dfa05606c21711a763d1b6332f8
+        checksum/config: fa64806d6e77e77d65bce5dd3d96bac9676a60e6e25ec7d89c40f7ca5904555f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.104.0
+        image: quay.io/signalfx/splunk-otel-collector:0.105.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/secret-splunk.yaml
@@ -1,0 +1,20 @@
+---
+# Source: splunk-otel-collector/templates/secret-splunk.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-splunk-otel-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm
+type: Opaque
+data:
+  splunk_observability_access_token: Q0hBTkdFTUU=

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/secret-splunk.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm
 type: Opaque

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/service-agent.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: otlp-http-old
+    port: 55681
+    targetPort: otlp-http-old
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/service-agent.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/service-agent.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
     component: otel-collector-agent
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm
     app.kubernetes.io/component: otel-collector-agent
@@ -35,10 +35,6 @@ spec:
   - name: otlp-http
     port: 4318
     targetPort: otlp-http
-    protocol: TCP
-  - name: otlp-http-old
-    port: 55681
-    targetPort: otlp-http-old
     protocol: TCP
   - name: sfx-forwarder
     port: 9080

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/serviceAccount.yaml
@@ -1,0 +1,17 @@
+---
+# Source: splunk-otel-collector/templates/serviceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default-splunk-otel-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.104.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.104.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.104.0
+    release: default
+    heritage: Helm

--- a/examples/collector-agent-host-network-disabled/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-agent-host-network-disabled/rendered_manifests/serviceAccount.yaml
@@ -2,16 +2,17 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.104.0
+    helm.sh/chart: splunk-otel-collector-0.105.3
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.104.0"
+    app.kubernetes.io/version: "0.105.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.104.0
+    chart: splunk-otel-collector-0.105.3
     release: default
     heritage: Helm

--- a/functional_tests/testdata/values/test_values.yaml.tmpl
+++ b/functional_tests/testdata/values/test_values.yaml.tmpl
@@ -19,6 +19,9 @@ logsCollection:
     enabled: true
     directory: /run/log/journal
 agent:
+  service:
+    enabled: true
+  hostNetwork: false
   config:
     exporters:
       otlp:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- The use case this example shows has been reference several times in feedback, would like to add it to our rendered examples.
- The important Kubernetes manifest files to lookover are at daemonset.yaml, configmap-agent.yaml, and service-agent.yaml. The other rendered example Kubernetes manifest files do not have to be evaluated.
