### PR TITLE
[chore] update golang version used in testing

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ~1.21.8
+          go-version: ~1.22.5
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
In preparation of importing dependencies requiring go 1.22. This is only affecting test code.