### PR TITLE
Remove apparmor pod annotation by enabled default

### DIFF
--- a/.chloggen/remove-apparmor-annotation.yaml
+++ b/.chloggen/remove-apparmor-annotation.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove apparmor pod annotation by enabled default
+# One or more tracking issues related to the change
+issues: [1378]

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: b18d0ea02dc6793509f59258d09779c4e02a0bc3314e030fc2c95d14b2cfeb20
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 94a4e65f7da945a78b51957920501f1034972cf515109586709c84083bbb1922
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 58150e1d71487c4c151939e4bdc5f40781b468f2628aa8c88419f501aee205a4
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 6b2800709e7bae5a6941502729465dcd710b89dc51001d69ec422b8db1bd5b69
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: f2b5a239c1c7406b070bd9ceefced3cdd80cdb3897cf9d2d7f402282f5a99e7c
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
         sidecar.istio.io/inject: "false"
     spec:
       hostNetwork: true

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 1e55cb021f3f329b7ffef1f1d68df8ddee8966916e494d80582febdc0e713e17
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 54fcba274a8f78a61178e8807de9932667ef4b576682e1c860ea15431834657e
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 1e55cb021f3f329b7ffef1f1d68df8ddee8966916e494d80582febdc0e713e17
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 1e55cb021f3f329b7ffef1f1d68df8ddee8966916e494d80582febdc0e713e17
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 612ba872d694afbafd3444952b6efde9d7815eda4ccaf37f1aa2dfdb620836bf
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 56cba1c3f10e4c27d0e7481b22008d607ac23de339f67f54238c2e90d4490feb
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 475ce9231a57b1b6ef7f416d4d70c2583cb3b0e190db88648a009cf1ba311ee7
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 9275cdaac88fdcf26fffbc65ad4e6cfcd6fd5021f3d74e7dbdf38946bbb5d716
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 4c04e24d1e5ce378aeacd4034a1bc3816fb2444e55eb3c6218217fa3ee3490b6
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 2279c63379e8431bb54347232bef1f2c95f82fccdcc6448b4ebdaae2ce3daae2
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 9d1910724dbfebb1524182f9821ed9edbbbb3ad3eeeae5f6b34c16ec0a9b5755
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 4708d593908d35084f5b718ac9d618a2f3eb15df3ff46e93107278df65e19b8a
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 405a28e02408d4b5a2c389fb67d2aacb46c986b58d3206f8ec1ac22222a22bf1
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: ae181943547a48a78aa270d084c7f73ec638e9faa3c67ac8ec937db310140e58
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 982650a7516bfe68a065359a71f4edaa95e86cdca120f5912bafe29559843389
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -35,7 +35,6 @@ spec:
       annotations:
         checksum/config: f3f0842f8e95929fcb224c76feb91b638c1a932a2c4af166a26041f81eff21d5
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -35,7 +35,6 @@ spec:
       annotations:
         checksum/config: c3cbfef1753868d86b65a222da2760154f05e8672c6a5d6fe3b2369ca8b69de6
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 15cb86c9ab484c669680f0cdaa306ef29b8996f418dfe3cbd908b8af81d986f3
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: default-splunk-otel-collector

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: c742abedac5c9f8b7d6d4421a0707f64dda0b320dd3e4e30d0956f4b68bac284
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -35,7 +35,6 @@ spec:
       annotations:
         checksum/config: 23b1895c5fea54d148ed1ef7f7460474fab861b6470f31ceb0d07647a1a98e08
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 8aefe7cd32bcdeb32cee6c4df6bcff1f5735487a64f71b4e431ec428460c0bf3
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 27332e3ddba327fd7e5fa5249f43e5ff4bf9c64a028bcd92616a3ae246ac7337
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: aba0e9159605718310d082e54f59d4e6adef6278712522d63cb9d223adc317fb
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 3170a1b5d8ccafb9b2c83f52cdbbdf7355c03c425dbe45c6d287e675077b0645
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 019e30742d8ac275b8bb79690d7d9628847a74fcba0b1f7a8c2b2c445cc04658
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 150b6335e449e567ed1de391f26dd1aae8a6f984da696680962036640e487447
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: bb6f2c2389ed0556b0448f2dc37c4ac90bf1a163604784014b93982f509d9b09
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 436136d7af003086ee2f773635e61532e1112fff17f48af7933681ae1e28abea
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: dc666341d57d185a8abc31b76331b2b0b8017616274fd84f28b1e2e7e5398383
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 1e55cb021f3f329b7ffef1f1d68df8ddee8966916e494d80582febdc0e713e17
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         checksum/config: 46ff59c550c0dc1426662dd32eedb928aef3f34d2f3147e630a6d575e22a423b
         kubectl.kubernetes.io/default-container: otel-collector
-        container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -413,10 +413,7 @@ agent:
 
   # OTel agent annotations
   annotations: {}
-  podAnnotations:
-    # This annotation is a workaround to avoid filling the syslog with warnings from appArmor such as:
-    # Apr 16 13:05:49 localhost kernel: [7954196.731418] audit: type=1400 audit(1713272749.057:5567969): apparmor="DENIED" operation="ptrace" class="ptrace" profile="cri-containerd.apparmor.d" pid=4151892 comm="otelcol" requested_mask="read" denied_mask="read" peer="unconfined"
-    container.apparmor.security.beta.kubernetes.io/otel-collector: unconfined
+  podAnnotations: {}
 
   # OTel agent extra pod labels
   podLabels: {}


### PR DESCRIPTION
It's being flagged by the Azure Defender. Keep it optional