### PR TITLE
Add an experimental feature gate to enable exporter batching

### DIFF
--- a/.chloggen/add-exporter-batcher-fg.yaml
+++ b/.chloggen/add-exporter-batcher-fg.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an experimental feature gate to use exporter batching instead of the batch processor
+# One or more tracking issues related to the change
+issues: [1387]

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -372,14 +372,26 @@ splunk_hec/platform_logs:
     enabled: {{ .Values.splunkPlatform.retryOnFailure.enabled }}
     initial_interval: {{ .Values.splunkPlatform.retryOnFailure.initialInterval }}
     max_interval: {{ .Values.splunkPlatform.retryOnFailure.maxInterval }}
+    {{- if .Values.featureGates.noDropLogsPipeline }}
+    max_elapsed_time: 0s
+    {{- else }}
     max_elapsed_time: {{ .Values.splunkPlatform.retryOnFailure.maxElapsedTime }}
+    {{- end }}
   sending_queue:
     enabled:  {{ .Values.splunkPlatform.sendingQueue.enabled }}
-    num_consumers: {{ .Values.splunkPlatform.sendingQueue.numConsumers }}
     queue_size: {{ .Values.splunkPlatform.sendingQueue.queueSize }}
     {{- if .addPersistentStorage }}
     storage: file_storage/persistent_queue
     {{- end }}
+  {{- if not .Values.featureGates.noDropLogsPipeline }}
+    num_consumers: {{ .Values.splunkPlatform.sendingQueue.numConsumers }}
+  {{- else }}
+    num_consumers: 25
+  batcher:
+    enabled: true
+    flush_timeout: 200ms
+    min_size_items: 2048
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -711,7 +711,9 @@ service:
         {{- if not $gatewayEnabled }}
         - filter/logs
         {{- end }}
+        {{- if not .Values.featureGates.noDropLogsPipeline }}
         - batch
+        {{- end }}
         - resourcedetection
         - resource
         {{- if not $gatewayEnabled }}
@@ -753,7 +755,9 @@ service:
         {{- end }}
       processors:
         - memory_limiter
+        {{- if not .Values.featureGates.noDropLogsPipeline }}
         - batch
+        {{- end }}
         {{- if eq (include "splunk-otel-collector.autoDetectClusterName" .) "true" }}
         - resourcedetection/k8s_cluster_name
         {{- end }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1283,3 +1283,7 @@ featureGates:
   # Light Prometheus Receiver is optimized for performance and reduced memory footprint.
   # From the other hand, it does not support all Prometheus configuration options.
   useLightPrometheusReceiver: false
+  # The feature gate enables experimental exporter batching instead of batch processor. This feature
+  # ensures the backpressure is propagated to the file readers and no data is dropped.
+  # Not recommended to use with enabled gateway.
+  noDropLogsPipeline: false


### PR DESCRIPTION
The feature gate enables experimental exporter batching instead of batch processor. This feature ensures the backpressure is propagated to the file readers and no data is dropped. Not recommended to use with enabled gateway.