### PR TITLE
[chore] restrict Java app to be deployed on a Linux environment only

### DIFF
--- a/functional_tests/testdata/dotnet/deployment.yaml
+++ b/functional_tests/testdata/dotnet/deployment.yaml
@@ -20,3 +20,5 @@ spec:
         - image: quay.io/splunko11ytest/dotnet_test:latest
           name: dotnet-test
           imagePullPolicy: IfNotPresent
+      nodeSelector:
+        kubernetes.io/os: "linux"

--- a/functional_tests/testdata/java/deployment.yaml
+++ b/functional_tests/testdata/java/deployment.yaml
@@ -19,3 +19,5 @@ spec:
         - image: quay.io/splunko11ytest/java_test:latest
           name: java-test
           imagePullPolicy: IfNotPresent
+      nodeSelector:
+        kubernetes.io/os: "linux"

--- a/functional_tests/testdata/manifests/deployment_with_prometheus_annotations.yaml
+++ b/functional_tests/testdata/manifests/deployment_with_prometheus_annotations.yaml
@@ -24,3 +24,5 @@ spec:
           ports:
             - name: web
               containerPort: 80
+      nodeSelector:
+        kubernetes.io/os: "linux"

--- a/functional_tests/testdata/nodejs/deployment.yaml
+++ b/functional_tests/testdata/nodejs/deployment.yaml
@@ -19,3 +19,5 @@ spec:
         - image: quay.io/splunko11ytest/nodejs_test:latest
           name: nodejs-test
           imagePullPolicy: IfNotPresent
+      nodeSelector:
+        kubernetes.io/os: "linux"

--- a/functional_tests/testdata/values/aks_test_values.yaml.tmpl
+++ b/functional_tests/testdata/values/aks_test_values.yaml.tmpl
@@ -75,3 +75,5 @@ operator:
       enabled: false
     autoGenerateCert:
       enabled: true
+  nodeSelector:
+    kubernetes.io/os: "linux"


### PR DESCRIPTION
Change the deployment of test applications and the operator test environment to only select Linux nodes.