### PR TITLE
[all] Set automountServiceAccountToken to true explicitly

### DIFF
--- a/.chloggen/automounttrue.yaml
+++ b/.chloggen/automounttrue.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: all
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set automountServiceAccountToken to true explicitly for the chart's defined service accounts.
+# One or more tracking issues related to the change
+issues: [1390]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-filter-processor/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/add-receiver-creator/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/add-sampler/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-sampler/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/autodetect-istio/rendered_manifests/serviceAccount.yaml
+++ b/examples/autodetect-istio/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/collector-agent-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-agent-only/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/collector-all-modes/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-all-modes/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/collector-gateway-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/crio-logging/rendered_manifests/serviceAccount.yaml
+++ b/examples/crio-logging/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/default/rendered_manifests/serviceAccount.yaml
+++ b/examples/default/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/discovery-mode/rendered_manifests/serviceAccount.yaml
+++ b/examples/discovery-mode/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/distribution-aks/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-aks/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/distribution-eks-fargate/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/distribution-eks/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-eks/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/distribution-gke/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-gke/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/distribution-openshift/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-openshift/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/enable-persistence-queue/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/enable-trace-sampling/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/enabled-pprof-extension/rendered_manifests/serviceAccount.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/serviceAccount.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/serviceAccount.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/multi-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/multi-metrics/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/only-logs-fluentd/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/only-logs-otel/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-otel/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/only-metrics-platform/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/only-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-metrics/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/only-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-traces/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/serviceAccount.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/secret-validation/rendered_manifests/serviceAccount.yaml
+++ b/examples/secret-validation/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/serviceAccount.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/target-allocator/rendered_manifests/serviceAccount.yaml
+++ b/examples/target-allocator/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/use-proxy/rendered_manifests/serviceAccount.yaml
+++ b/examples/use-proxy/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/with-target-allocator/rendered_manifests/serviceAccount.yaml
+++ b/examples/with-target-allocator/rendered_manifests/serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector
   namespace: default

--- a/examples/with-target-allocator/rendered_manifests/targetAllocator-serviceAccount.yaml
+++ b/examples/with-target-allocator/rendered_manifests/targetAllocator-serviceAccount.yaml
@@ -2,6 +2,7 @@
 # Source: splunk-otel-collector/templates/targetAllocator-serviceAccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: default-splunk-otel-collector-ta
   namespace: default

--- a/functional_tests/testdata/dotnet/deployment.yaml
+++ b/functional_tests/testdata/dotnet/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         instrumentation.opentelemetry.io/inject-dotnet: "true"
         instrumentation.opentelemetry.io/otel-dotnet-auto-runtime: "linux-musl-x64"
     spec:
+      automountServiceAccountToken: false
       containers:
         - image: quay.io/splunko11ytest/dotnet_test:latest
           name: dotnet-test

--- a/functional_tests/testdata/java/deployment.yaml
+++ b/functional_tests/testdata/java/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/inject-java: "true"
     spec:
+      automountServiceAccountToken: false
       containers:
         - image: quay.io/splunko11ytest/java_test:latest
           name: java-test

--- a/functional_tests/testdata/manifests/deployment_with_prometheus_annotations.yaml
+++ b/functional_tests/testdata/manifests/deployment_with_prometheus_annotations.yaml
@@ -17,6 +17,7 @@ spec:
         prometheus.io/port: "80"
         prometheus.io/path: "/metrics"
     spec:
+      automountServiceAccountToken: false
       containers:
         - image: quay.io/splunko11ytest/httpd:latest
           name: prometheus-annotation-test

--- a/functional_tests/testdata/manifests/test_jobs.yaml
+++ b/functional_tests/testdata/manifests/test_jobs.yaml
@@ -36,6 +36,7 @@ spec:
         splunk.com/sourcetype: "sourcetype-anno"
         splunk.com/customField: pod-value-1
     spec:
+      automountServiceAccountToken: false
       restartPolicy: Never
       containers:
       - name: pod-w-index-w-ns-index
@@ -62,6 +63,7 @@ spec:
       annotations:
         splunk.com/exclude: "false"
     spec:
+      automountServiceAccountToken: false
       restartPolicy: Never
       containers:
       - name: pod-wo-index-w-ns-index
@@ -89,6 +91,7 @@ spec:
         splunk.com/index: "pod-anno"
         splunk.com/customField: pod-value-2
     spec:
+      automountServiceAccountToken: false
       restartPolicy: Never
       containers:
       - name: pod-w-index-wo-ns-index
@@ -115,6 +118,7 @@ spec:
       annotations:
         splunk.com/index: "pod-anno"
     spec:
+      automountServiceAccountToken: false
       restartPolicy: Never
       containers:
       - name: pod-w-index-w-ns-exclude
@@ -141,6 +145,7 @@ spec:
       annotations:
         splunk.com/exclude: "true"
     spec:
+      automountServiceAccountToken: false
       restartPolicy: Never
       containers:
       - name: pod-w-index-w-ns-exclude
@@ -165,6 +170,7 @@ spec:
       labels:
         app: pod-wo-index-wo-ns-index
     spec:
+      automountServiceAccountToken: false
       restartPolicy: Never
       containers:
       - name: pod-wo-index-wo-ns-index

--- a/functional_tests/testdata/nodejs/deployment.yaml
+++ b/functional_tests/testdata/nodejs/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       annotations:
         instrumentation.opentelemetry.io/inject-nodejs: "true"
     spec:
+      automountServiceAccountToken: false
       containers:
         - image: quay.io/splunko11ytest/nodejs_test:latest
           name: nodejs-test

--- a/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml
+++ b/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml
@@ -7,6 +7,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: {{ template "splunk-otel-collector.serviceAccountName" . }}
   namespace: {{ template "splunk-otel-collector.namespace" . }}

--- a/helm-charts/splunk-otel-collector/templates/targetAllocator-serviceAccount.yaml
+++ b/helm-charts/splunk-otel-collector/templates/targetAllocator-serviceAccount.yaml
@@ -8,6 +8,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: {{ template "splunk-otel-collector.targetAllocatorServiceAccountName" . }}
   namespace: {{ template "splunk-otel-collector.namespace" . }}


### PR DESCRIPTION
To satisfy solutions such as Azure Defender, set automountServiceAccountToken to true explicitly on the service accounts used by the chart.

For test purposes, we also set automountServiceAccountToken to false for all pods and jobs deployed for testing purposes.