### PR TITLE
Remove envvars

### DIFF
--- a/.chloggen/removeenvvars.yaml
+++ b/.chloggen/removeenvvars.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the use of environment variables when configuring hostmetricsreceiver. Use `root_path` instead.
+# One or more tracking issues related to the change
+issues: [1408]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -296,6 +296,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b60f03e2dfef1bd8dda7ddbca00d86cbbba40adc64aa4091d4c6a7dd5253ed4d
+        checksum/config: 8d96029544401cc2cbc1056b52dc0046d77d4818325786682aec72c88f1c0eea
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -245,6 +245,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 96dba830eda6992101a8e61d6068439011ae330eb7bf79fe7190c6df8d4b7bc7
+        checksum/config: 8f0ec5f63cbf96dde426ccbf8c01622cccfcfd7b8ac2345b9ba103e855c0b367
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6d40b57a1ecf887ac56d9687346e494b0a3d57ff7fa74c7b0d99abec481906cb
+        checksum/config: 8fafd58559471b2e59711562a3f4adc3f73c7a37841af415a1526baff7a9435b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -130,6 +130,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d8596d0b067377a254ca78f0a4fb1e209124011e57788e22c5442ce24fa8db6c
+        checksum/config: 79c9468691a3898084dbb7f14019a3280a3a01de9641072fc641e85a07706234
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -280,6 +280,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3da63d042437cabc6967432a15d6bdfa3c3c9c6c7fdaeced5bb00f4370bdafe2
+        checksum/config: f55a166de5f4af5003adff837f1dcefdc78a88797a59e373cf7b2d634a8ca662
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:
@@ -157,24 +157,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 96c6264ca82a10ee205ac6ec71eed96fad7989be6b0f8daf99952d51a98083ca
+        checksum/config: b8890b0829ba065967ac56e8ce7005a4db406f2d69c64422dd1974d4932dfcfa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -113,6 +113,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b7a0c4303b469382b6ee6f4d0f004dab9b6a9bfa1e7a8b2dfc9736f02a91bddf
+        checksum/config: 4a797d07cd1f98b47e75fd6bf968e12840866a85df7ef67611ef1e154dd3a1ba
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 96c6264ca82a10ee205ac6ec71eed96fad7989be6b0f8daf99952d51a98083ca
+        checksum/config: b8890b0829ba065967ac56e8ce7005a4db406f2d69c64422dd1974d4932dfcfa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 96c6264ca82a10ee205ac6ec71eed96fad7989be6b0f8daf99952d51a98083ca
+        checksum/config: b8890b0829ba065967ac56e8ce7005a4db406f2d69c64422dd1974d4932dfcfa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -335,6 +335,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 564496d18e887eb6ee97454172c3bf16bfaf96056537cd2f774efcbfed6a94b3
+        checksum/config: 95e67adf43ec5d9f10f0cce9e1d18ad4cfcb22535f92b6b013a4b6534f5ad9dc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_platform_hec_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 70963897302e7d42ad78b9d6cbf091547fefbc40c2dca1d35c36fb14ac740a89
+        checksum/config: c0875acc16d1bb5f0704a11af41a74d8d4c9ff2b666b5453462f2c5f8871588f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -116,24 +116,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
           - name: REDIS_USERNAME
             valueFrom:
               secretKeyRef:

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -129,6 +129,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3e94cbd4ea329b88ac6be828ba50e1504041cd656c06d85de7537046c70f5239
+        checksum/config: fd5bdba07e8a8d65b244591d515e21d4be69470e7ef5ff2690fcff694f51442b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -129,6 +129,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bee9823c3f33b24c0f04045c4cde4f50822449e57865217225308d22070af976
+        checksum/config: 8e09ef53963a0d87423492646a5e459dc7b0a252769ad24eb103c8cc402aec0f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -128,6 +128,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cdea1e44c673ee4781e6a160c7f88c70ef9be544642b44230103a5b168245f96
+        checksum/config: 09d99a2e61ece12a7d20427976fe0f5c813a0468703ef996d6925d6d94df1821
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -128,6 +128,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f9f367c094a879983375b0cea3f174d95064c9cfe27a73d7dbe8bc2380b2a173
+        checksum/config: c3b429737f5bcef3426414ee90968521d476ec82cb1d27d580ffe6f5d922ccf7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 280e0055519d9f2b13d35579035921930ff73c6f733b3d67a64b4830f7d15f67
+        checksum/config: 2b17b066566398d8836df474212d1b2ffe79c9549861628c9f5cd158c2b858ca
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -250,6 +250,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fb9b0280df6af206341a5ba9837fb30c6d545bf01b3cdeceafba39f2a26257c7
+        checksum/config: 6cdc4bedef735215539db063736d9a559c21d3dc5c162b2cc61947b92a9e9262
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -335,6 +335,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e1413dacc24a8ff27503b1519e9903ab8f2d4d977179258cad00916834bcb2c5
+        checksum/config: ac7afa798e7155c376629eeaf566d11c43e51046eac6efc4565f4691cde1dc0c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_platform_hec_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -128,6 +128,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b3c5acd235f759369bd3f795f0c569a5d04baa299afdefb9f7d0300af0ce1c20
+        checksum/config: 58ee1bcd3f5e1aaefa626e99f3e810d2cffe18b73fd456edfd36f9e7ffcf7522
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -145,6 +145,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2af2dd98a147486bca3d57c8fe7c9a835f3fa95cc9faca0c61bd291785401fac
+        checksum/config: aca315f4269e11271514cbed58cc40ab206d0bc1583d88f6b14fa50338e41d17
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -188,24 +188,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -145,6 +145,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 19b09574dcd7a4b8496f01009889d60af198b0b8d6d1db2fc97f538e8fe7ba48
+        checksum/config: eec3ba30b9faaf256effa887d5bac6ec1f2b705fb42aa26fa73506d565f86d6d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -188,24 +188,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -250,6 +250,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: C:\hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0d020bcd8e7a4e391d638a5f5c5c86a9a9421cc640d1aefdfd2abf1a1f1e1c8d
+        checksum/config: 8aecf6366f5036f5779b2208b58601f0c06cf6b1af92955b9622985419bea26b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet
@@ -123,19 +123,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: C:\hostfs\proc
-          - name: HOST_SYS
-            value: C:\hostfs\sys
-          - name: HOST_ETC
-            value: C:\hostfs\etc
-          - name: HOST_VAR
-            value: C:\hostfs\var
-          - name: HOST_RUN
-            value: C:\hostfs\run
-          - name: HOST_DEV
-            value: C:\hostfs\dev
 
         readinessProbe:
           initialDelaySeconds: 60

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -307,6 +307,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6641b2912d5df65e400a98a3954d3e908161a140b70f0488bcfecca1b9feb8e4
+        checksum/config: 3d36dc188e6bd567e8ac797d8b939c5379d580c3e1feea9e3b5b1e6b63f1f009
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -140,24 +140,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_platform_hec_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5a71e2a7f1a0b82a0c573b6cbff757496e9c173f3fc956a4ad67c1e8fd032b80
+        checksum/config: 39a0d281c05cf1febf5d1be8054f5e4d101fc84a646dc591d0b9378ef781ee32
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -99,24 +99,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_platform_hec_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a4162b5a998ad8b07cfa14b73cb1308366c57a3257006c8647cf9a562cb64431
+        checksum/config: 811aa5e9bdc0ac45e718c1bbd2eb5e5a3eacf71d7aa208ba1c63370bfddef69b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -99,24 +99,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -131,6 +131,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b6474a24f85a57926a5fb9b912c0e7ce7398a4b7269146134865364505e25ad9
+        checksum/config: 550c714ef042c5f0feffaa4f657828f911b1b13ca6192938c2ef0b74413cb655
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a98877e93941aa7fe3504e8a1ae000c4427a6ad628d4e58ea6caf67ef4d9b897
+        checksum/config: 2261b8b30b7b449ce71780be69d047acb0b3a5976ea60643c42881da1c885376
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 96c6264ca82a10ee205ac6ec71eed96fad7989be6b0f8daf99952d51a98083ca
+        checksum/config: b8890b0829ba065967ac56e8ce7005a4db406f2d69c64422dd1974d4932dfcfa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
           - name: HTTPS_PROXY
             value: 192.168.0.10
 

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4c0be8127a3ed47bd472b6231aba8a1cabb750923b60ce2fb74095a05091bda2
+        checksum/config: 99929534bddbacee4a37ea31abf92db33f829e065eb7cccc9386aa85ef0add7b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -40,6 +40,7 @@ receivers:
   {{- if (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
   hostmetrics:
     collection_interval: 10s
+    root_path: {{ .Values.isWindows | ternary "C:\\hostfs" "/hostfs" }}
     scrapers:
       cpu:
       disk:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -312,28 +312,6 @@ spec:
                 name: {{ include "splunk-otel-collector.secret" . }}
                 key: splunk_platform_hec_token
           {{- end }}
-          {{- if eq (include "splunk-otel-collector.metricsEnabled" .) "true" }}
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\proc" "/hostfs/proc" }}
-          - name: HOST_SYS
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\sys" "/hostfs/sys" }}
-          - name: HOST_ETC
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\etc" "/hostfs/etc" }}
-          - name: HOST_VAR
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\var" "/hostfs/var" }}
-          - name: HOST_RUN
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\run" "/hostfs/run" }}
-          - name: HOST_DEV
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\dev" "/hostfs/dev" }}
-          {{- if not .Values.isWindows }}
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
-          {{- end }}
-          {{- end }}
           {{- with $agent.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
**Description:** 
Remove the use of environment variables when configuring hostmetricsreceiver. Use `root_path` instead.
