### PR TITLE
Increase default livenessProbe.initialDelaySeconds to 10 minutes

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Increase default livenessProbe.initialDelaySeconds to 10 minutes.
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1028,7 +1028,7 @@ priorityClassName: ""
 readinessProbe:
   initialDelaySeconds: 0
 livenessProbe:
-  initialDelaySeconds: 0
+  initialDelaySeconds: 600
 
 # Specifies whether to apply for k8s cluster with windows worker node.
 isWindows: false


### PR DESCRIPTION
**Description:** 

Increases the default for livenessProbe.initialDelaySeconds.

When the on-disk queue grows sufficiently, the agent pod enters a crashloop, with the liveness probe restarting the pod before it finishes startup. The agent pod is thus prevented from uploading any of the data in the queue.

The defaults should be chosen to avoid such problems.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
