### PR TITLE
Remove the use of environment variables in the daemonset container

### DIFF
--- a/.chloggen/removeenvvars.yaml
+++ b/.chloggen/removeenvvars.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the use of environment variables when configuring hostmetricsreceiver. Use `root_path` instead.
+# One or more tracking issues related to the change
+issues: [1408]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -296,6 +296,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -300,12 +300,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -438,6 +441,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6fe8488db7c37cac8ddc2ab6eb259a11e79be1e0b30d2deccd2a8e01610d7d15
+        checksum/config: fbd70ac93c9294a5dbc5f81495d3fb3372aac6dacec0235f6f0230b2672c576b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fbd70ac93c9294a5dbc5f81495d3fb3372aac6dacec0235f6f0230b2672c576b
+        checksum/config: 6871ba3d8c4a740071f3369f0423619ca9ea0008e66647ef0dde4140c0772329
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -249,12 +249,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -245,6 +245,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 257c8673bbe03dc39b0e44ea7329ce085b67ff5e2a2e60733d016e60b142b23e
+        checksum/config: b97f64f6b3f842ed85f45a68c36f501bc4269b4f2e625a6c6daf2013649ebadf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bfb54db69288c8e9f42aaabc9d594027e4b720724c74e88757e47b9c88f0c4f6
+        checksum/config: 257c8673bbe03dc39b0e44ea7329ce085b67ff5e2a2e60733d016e60b142b23e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -266,6 +269,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7ceb9c933d99ac7fc06865b198dfbb1639b38db9cc1f22c0eb5cb56b9296b308
+        checksum/config: 642388f8271fb73a40fbcf89870c0616f6ff37ed6c6959d620a2923be6802870
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 642388f8271fb73a40fbcf89870c0616f6ff37ed6c6959d620a2923be6802870
+        checksum/config: bb68deee40574389e6b7f79fd1672d27642bf3637d0709029d8d9ff77311aeae
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -130,6 +130,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -134,12 +134,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -254,6 +257,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5668903aad40539f404af91d0a107b2c206b727f32143e6eca9171fcf1b2c380
+        checksum/config: 9aba2a1dcb5e2662c1ce8b4b2b693ecd17b282d7407f0f7fb9e03d7d627a13c3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 01e45f5e1ba9251c0476e935360970e28b07321eb860fea41723ec8a3afc5064
+        checksum/config: 5668903aad40539f404af91d0a107b2c206b727f32143e6eca9171fcf1b2c380
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -280,6 +280,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -284,12 +284,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -430,6 +433,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 95d77cfd6fd31e9c356984ef94500390b2963353462ec2df06051a78a32d9918
+        checksum/config: e4c94d02622678e40afdfffd0280e80d273ae9b73ad621527ddc711e4ea555b5
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:
@@ -157,24 +157,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e4c94d02622678e40afdfffd0280e80d273ae9b73ad621527ddc711e4ea555b5
+        checksum/config: ba8d0acffe96d83f9924bdea3180a3bbf98f48695052621689b16bee1c79161d
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -251,6 +254,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 60aa06bfcb080c769f77047ef5c7d14232089748eaa54188d6d37144b3d00e75
+        checksum/config: 2fb5cc591e6f9d6a90ef6bd4aac95e3d7e1e4418b1430231c9c3986fa7820b14
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2fb5cc591e6f9d6a90ef6bd4aac95e3d7e1e4418b1430231c9c3986fa7820b14
+        checksum/config: cafdd63866dcc175e5b0316d3a2b1e57735aba208deb9b4a0ed5a3e5e8618b91
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -113,6 +113,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -117,12 +117,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -237,6 +240,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6550d2eec588231adb9c7fd5cf870cf0b3df06cd6047104a59cbdda87ded9abf
+        checksum/config: e349003a8b871cc7050165e02cb7a54872d40ba0b1e3284f0caababd6aa940b8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e349003a8b871cc7050165e02cb7a54872d40ba0b1e3284f0caababd6aa940b8
+        checksum/config: 8981631528d4c4e409bc91c8d501a8669e795b5837c20af1801b24384b495c3e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -132,6 +132,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -136,12 +136,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -281,6 +284,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - signalfx

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3d3238906a6339f6ddaa693ce1e5755ed3fac22e10651706d18e061a300ce60e
+        checksum/config: 773bb3fc54e5eb73179000945f6e50913400709e2eef17ad074f3563f7f5f49c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 773bb3fc54e5eb73179000945f6e50913400709e2eef17ad074f3563f7f5f49c
+        checksum/config: 100bff34b484fc9e7f0de158d01866309100d74aab5a07b6c3145fb5401d5fb5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -251,6 +254,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 60aa06bfcb080c769f77047ef5c7d14232089748eaa54188d6d37144b3d00e75
+        checksum/config: 2fb5cc591e6f9d6a90ef6bd4aac95e3d7e1e4418b1430231c9c3986fa7820b14
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2fb5cc591e6f9d6a90ef6bd4aac95e3d7e1e4418b1430231c9c3986fa7820b14
+        checksum/config: cafdd63866dcc175e5b0316d3a2b1e57735aba208deb9b4a0ed5a3e5e8618b91
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -251,6 +254,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 60aa06bfcb080c769f77047ef5c7d14232089748eaa54188d6d37144b3d00e75
+        checksum/config: 2fb5cc591e6f9d6a90ef6bd4aac95e3d7e1e4418b1430231c9c3986fa7820b14
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2fb5cc591e6f9d6a90ef6bd4aac95e3d7e1e4418b1430231c9c3986fa7820b14
+        checksum/config: cafdd63866dcc175e5b0316d3a2b1e57735aba208deb9b4a0ed5a3e5e8618b91
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -335,6 +335,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -339,12 +339,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -474,6 +477,7 @@ data:
           - k8sattributes/metrics
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b70e64b3c74004e43f7726a7ab7b6297e5f52984b80414e0858db863623ce97e
+        checksum/config: 0b8dc3ed442c70aaa86defc5b9867baa9fcdded5fbf0d18292381079b57cce3a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 068897d39969e321b5a814179eddd2f7f737785ba8ff107c45979bcd2a1e788b
+        checksum/config: b70e64b3c74004e43f7726a7ab7b6297e5f52984b80414e0858db863623ce97e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_platform_hec_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -251,6 +254,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2aa2c705ccfa6677a984984b331a4acb69af6708f76146a76bd5eec11b91736a
+        checksum/config: 79c5d385c2cc328448633fe130bc99999743162fe7313a8c5c103543f7290bb2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9cc9033772495e6a471def3989cbc3ca7f75918b86487f2ee6053cd3bacf9992
+        checksum/config: 2aa2c705ccfa6677a984984b331a4acb69af6708f76146a76bd5eec11b91736a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -116,24 +116,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
           - name: REDIS_USERNAME
             valueFrom:
               secretKeyRef:

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -129,6 +129,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -133,12 +133,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -209,6 +212,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d539d84a965b9006baa565f83244b98371055dd86afca658068486da6ba80bd2
+        checksum/config: 15e059b73b59e0685546b3dd50e6cba3fd3b7c7c3365e9b080366e831b4982a9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4c6092608da5bb02ccf6dc4c81701525879cb2557bf880eb833f8bb6487f604c
+        checksum/config: d539d84a965b9006baa565f83244b98371055dd86afca658068486da6ba80bd2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -129,6 +129,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -133,12 +133,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -209,6 +212,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bb0f4b0af1d655da2b0e5f2b19db55ba2c7a6793d13e481735a63cfa6dc2e8a5
+        checksum/config: 821e2357f34c63b630a98f2d402f9afe150cfa211cdcebdb7c75cd82a4824b1d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 821e2357f34c63b630a98f2d402f9afe150cfa211cdcebdb7c75cd82a4824b1d
+        checksum/config: a2a7ee750775e431445064fda04113f53ad8d003a3e6b6ec10d99cd4a68811f8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -128,6 +128,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -132,12 +132,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -208,6 +211,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bb624529222d55d820caffcef1d2db84c2c38d64875bb8ed85a6bd36b0f28dbf
+        checksum/config: cbfa2d7ae4e674a814489da54022a730f44e35431eb3c793faa87b668688f861
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cbfa2d7ae4e674a814489da54022a730f44e35431eb3c793faa87b668688f861
+        checksum/config: 79abc52d270dd5a403fa08a16127ef82075b1a9d81b343c7ac9cc7c81cdde3d2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -128,6 +128,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -132,12 +132,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -208,6 +211,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 030f8ee67a03f7f0ed7b0ea7cd338b40a8c064063a847e0f9a5fb8787c4c7a46
+        checksum/config: d8c0a1a0c7bd5cfdc7d2a6c8ba45b83e09b8c7481f5bed0cc4c60cbb4c04299d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d8c0a1a0c7bd5cfdc7d2a6c8ba45b83e09b8c7481f5bed0cc4c60cbb4c04299d
+        checksum/config: 801a01bed85bfe0fb4846c482d83c1563e30a747bd52d81656cb1062f9ce641f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -259,6 +262,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f97ad99df70c23e0ab394ba77fd457697f83537e4c9f5539a05ef3df5c4d0982
+        checksum/config: e11759b834b5eecfdb6a56b6c0ed820cad9d0df12a9854df14628a9bd1f1e419
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e11759b834b5eecfdb6a56b6c0ed820cad9d0df12a9854df14628a9bd1f1e419
+        checksum/config: c4696de5c577213618c62a00de906d934a88989296bc84dbba6075301c850ba0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -250,6 +250,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -254,12 +254,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -391,6 +394,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c1aec6c9c77573317a9e883d01d10561487a12760e10da34302f29ddf9084fee
+        checksum/config: 7add5facb7a7606567a9e39296bced5dd3f62bf9e370644cb98fdcf2af02267d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 99b79fe28a085939d1da3489ad78866fbf5cb8264482a183c77c796c1107d973
+        checksum/config: c1aec6c9c77573317a9e883d01d10561487a12760e10da34302f29ddf9084fee
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -335,6 +335,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -339,12 +339,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -474,6 +477,7 @@ data:
           - k8sattributes/metrics
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d69f9db836d22e283a64c6638a62abcdd3df88cd1e3d4f0982d47e323be9e4e6
+        checksum/config: fb9f13526e9f35d05ca3fd410948fefeda7181536a9387c9b747112ac474506a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 05ef4a80e4010dc707c37364538d5fa1caea6e4ec70e47d40b05d4854604d02a
+        checksum/config: d69f9db836d22e283a64c6638a62abcdd3df88cd1e3d4f0982d47e323be9e4e6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -156,24 +156,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_platform_hec_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -132,12 +132,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -253,6 +256,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -128,6 +128,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fcdd3468ecd14984d25aabb476afaca707377fda992bb22c848148b93effceec
+        checksum/config: b7cccb8f81e2573da1de4d6a88e4896234ef64b35f49103e4ae3ac2d2056f845
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 30b576d2e73592acc6cfe8959fa90d23ea9a7d46bb2d454a82d39b32ad24db4c
+        checksum/config: fcdd3468ecd14984d25aabb476afaca707377fda992bb22c848148b93effceec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -145,6 +145,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -149,12 +149,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -284,6 +287,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e35ef3e779a2fb6eee312aaf00b95ded104224a490bca46f749705d6961574db
+        checksum/config: 999aadc1e41f9c8abd158dda243d8f6662b4a5d8bbf368f2804776874f181fcb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8603a27ced4e339d1370ba08e61e0e9f08cefcf10dc8fd9f3f71b59c312cee73
+        checksum/config: e35ef3e779a2fb6eee312aaf00b95ded104224a490bca46f749705d6961574db
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -188,24 +188,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -145,6 +145,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -149,12 +149,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -284,6 +287,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 98cec2956dd693db8fda00d979e51e7ec96e4a3656c266527bac8963c88ec94d
+        checksum/config: de28b01de57a0d6c60235fe42fc3236f1c095292dbe2126fa506154feed03c39
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -188,24 +188,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: de28b01de57a0d6c60235fe42fc3236f1c095292dbe2126fa506154feed03c39
+        checksum/config: 708285d7bf5f4aebdd391488c755fc69016cb7f548bf12fbc8f03046d70db68e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -254,12 +254,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -391,6 +394,7 @@ data:
           - metricstransform
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -250,6 +250,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: C:\hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f4ff6c3833bc151410474578db8459674d03f3af89ed142d63488bd34ad96890
+        checksum/config: f95ae29e0b138bff1a41dd9ad58e9d7754008cf9c4212808332d62867f20d349
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet
@@ -123,19 +123,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: C:\hostfs\proc
-          - name: HOST_SYS
-            value: C:\hostfs\sys
-          - name: HOST_ETC
-            value: C:\hostfs\etc
-          - name: HOST_VAR
-            value: C:\hostfs\var
-          - name: HOST_RUN
-            value: C:\hostfs\run
-          - name: HOST_DEV
-            value: C:\hostfs\dev
 
         readinessProbe:
           initialDelaySeconds: 60

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f95ae29e0b138bff1a41dd9ad58e9d7754008cf9c4212808332d62867f20d349
+        checksum/config: fa529297a92fece88e53787db63f4a5d56989ff9b63c5799ca61420fa1b4748f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -311,12 +311,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       kubeletstats:
         auth_type: serviceAccount
         collection_interval: 10s
@@ -437,6 +440,7 @@ data:
           - k8sattributes/metrics
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -307,6 +307,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 04a0e3b736a587c8b43856bac6cd9878f7fab1432b9e81c36673858253dbfab4
+        checksum/config: b5c8689d82db1d889eb6344ef2eed238a42fd52d586f06d045313d7bf979be15
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5fe75d65f83fde093bd36e84d7176c1ed4887c3ce0516aceaf06a25f367ac88f
+        checksum/config: 04a0e3b736a587c8b43856bac6cd9878f7fab1432b9e81c36673858253dbfab4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -140,24 +140,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_platform_hec_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -174,12 +174,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       kubeletstats:
         auth_type: serviceAccount
         collection_interval: 10s
@@ -284,6 +287,7 @@ data:
           - k8sattributes/metrics
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9348c1a698d37b4c86a762074fa7fbdcf45d1ddb2f45a3969619db14adc34a82
+        checksum/config: 22d3a658c4cbcfcd7839430f5b4a6fc9d4c4ad7a2e1a473d47a80c9a3cd12149
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c1d5086a46b85ca0828c7fdd4d35e1b421db0eedbb9ac7b525ebb1a87262f77a
+        checksum/config: 9348c1a698d37b4c86a762074fa7fbdcf45d1ddb2f45a3969619db14adc34a82
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -99,24 +99,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_platform_hec_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -128,12 +128,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       kubeletstats:
         auth_type: serviceAccount
         collection_interval: 10s
@@ -237,6 +240,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -124,6 +124,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 07869702b969e378ff570783ff1cc9a8b324a7b819cce58dbac0c722ab0e5eeb
+        checksum/config: 0ebf8605d832c0986871d54a2982cdb1739e0766281d6cecfca6963dd5693879
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ff74075250fdf750fd6d9138f7ca47065de2bd5edcc9c25a98a23319195b745a
+        checksum/config: 07869702b969e378ff570783ff1cc9a8b324a7b819cce58dbac0c722ab0e5eeb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -99,24 +99,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -135,12 +135,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -258,6 +261,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -131,6 +131,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7ab874c850749983241bbc99fc42bfec3590ce6a73798084ed42c7a06a6fb3af
+        checksum/config: 867f791348f56791350ccfdf68b5c03d3ef4b6443e40d395a6e3530bca9e6f28
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f5dbd222b32887e0bfbba8c0fdea45941498cf6343d66af4a1dbbaf5e2dc310d
+        checksum/config: 7ab874c850749983241bbc99fc42bfec3590ce6a73798084ed42c7a06a6fb3af
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a4b40f1bf1301d616b0a9077f222281768699551580bdf94bbdada8388277ddf
+        checksum/config: a741c5d4f8ae18783db672dbe09dba3004425aa67006e32bcc3f7e6f9b397101
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ce027723588acdb45daed6b94df7ffb80f96b2f5ee4abd87663e5260efb897bc
+        checksum/config: a4b40f1bf1301d616b0a9077f222281768699551580bdf94bbdada8388277ddf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -251,6 +254,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2fb5cc591e6f9d6a90ef6bd4aac95e3d7e1e4418b1430231c9c3986fa7820b14
+        checksum/config: cafdd63866dcc175e5b0316d3a2b1e57735aba208deb9b4a0ed5a3e5e8618b91
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 60aa06bfcb080c769f77047ef5c7d14232089748eaa54188d6d37144b3d00e75
+        checksum/config: 2fb5cc591e6f9d6a90ef6bd4aac95e3d7e1e4418b1430231c9c3986fa7820b14
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
           - name: HTTPS_PROXY
             value: 192.168.0.10
 

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -127,6 +127,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -131,12 +131,15 @@ data:
         scrapers:
           cpu: null
           disk: null
-          filesystem: null
           load: null
           memory: null
           network: null
           paging: null
           processes: null
+      hostmetrics/filesystem:
+        collection_interval: 10s
+        scrapers:
+          filesystem: null
       jaeger:
         protocols:
           grpc:
@@ -259,6 +262,7 @@ data:
           - resource
           receivers:
           - hostmetrics
+          - hostmetrics/filesystem
           - kubeletstats
           - otlp
           - receiver_creator

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e092b88e9b476d09338125497dad58d1b0b37be030f2d3e3947dd7d6d7a97453
+        checksum/config: 36fd153471cc69381fffbeecb9a6a10fe189ca535be130dc37fe9825acd3f445
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ce5bfb976b854d61a40ec8fe6413f9b9fe0e263a6eb8803d50ab5bf62e896713
+        checksum/config: e092b88e9b476d09338125497dad58d1b0b37be030f2d3e3947dd7d6d7a97453
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -115,24 +115,6 @@ spec:
               secretKeyRef:
                 name: default-splunk-otel-collector
                 key: splunk_observability_access_token
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: /hostfs/proc
-          - name: HOST_SYS
-            value: /hostfs/sys
-          - name: HOST_ETC
-            value: /hostfs/etc
-          - name: HOST_VAR
-            value: /hostfs/var
-          - name: HOST_RUN
-            value: /hostfs/run
-          - name: HOST_DEV
-            value: /hostfs/dev
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
 
         readinessProbe:
           httpGet:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -44,7 +44,6 @@ receivers:
     scrapers:
       cpu:
       disk:
-      filesystem:
       memory:
       network:
       # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)
@@ -55,6 +54,10 @@ receivers:
       processes:
       # System processes metrics, disabled by default
       # process:
+  hostmetrics/filesystem:
+    collection_interval: 10s
+    scrapers:
+      filesystem:
 
   receiver_creator:
     watch_observers: [k8s_observer]
@@ -964,6 +967,7 @@ service:
     metrics:
       receivers:
         - hostmetrics
+        - hostmetrics/filesystem
         - kubeletstats
         - otlp
         {{- if not .Values.featureGates.useControlPlaneMetricsHistogramData }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -40,6 +40,7 @@ receivers:
   {{- if (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
   hostmetrics:
     collection_interval: 10s
+    root_path: {{ .Values.isWindows | ternary "C:\\hostfs" "/hostfs" }}
     scrapers:
       cpu:
       disk:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -315,28 +315,6 @@ spec:
                 name: {{ include "splunk-otel-collector.secret" . }}
                 key: splunk_platform_hec_token
           {{- end }}
-          {{- if eq (include "splunk-otel-collector.metricsEnabled" .) "true" }}
-          # Env variables for host metrics receiver
-          - name: HOST_PROC
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\proc" "/hostfs/proc" }}
-          - name: HOST_SYS
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\sys" "/hostfs/sys" }}
-          - name: HOST_ETC
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\etc" "/hostfs/etc" }}
-          - name: HOST_VAR
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\var" "/hostfs/var" }}
-          - name: HOST_RUN
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\run" "/hostfs/run" }}
-          - name: HOST_DEV
-            value: {{ .Values.isWindows | ternary "C:\\hostfs\\dev" "/hostfs/dev" }}
-          {{- if not .Values.isWindows }}
-          # until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879
-          # is resolved fall back to previous gopsutil mountinfo path:
-          # https://github.com/shirou/gopsutil/issues/1271
-          - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
-          {{- end }}
-          {{- end }}
           {{- with $agent.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
**Description:** 
Remove the use of environment variables when configuring hostmetricsreceiver. Use root_path instead.

This PR separates the use of hostmetricsreceiver in 2 receivers, one for all scrapers except filesystem using the /hostfs path, and one for the filesystem scraper using the container filesystem.