### PR TITLE
Added fsyncEnabled option to the config

### DIFF
--- a/.chloggen/addfsyncflagconfig.yaml
+++ b/.chloggen/addfsyncflagconfig.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added `fsyncFlag` configuration to allow users to enable fsync on the filestorage.
+# One or more tracking issues related to the change
+issues: [1425]

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -9,12 +9,18 @@ extensions:
   {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (eq .Values.logsEngine "otel") }}
   file_storage:
     directory: {{ .Values.logsCollection.checkpointPath }}
+    {{- if not (eq (toString .Values.splunkPlatform.fsyncEnabled) "<nil>") }}
+    fsync: {{ .Values.splunkPlatform.fsyncEnabled }}
+    {{- end }}
   {{- end }}
 
   {{- if .Values.splunkPlatform.sendingQueue.persistentQueue.enabled }}
   file_storage/persistent_queue:
     directory: {{ .Values.splunkPlatform.sendingQueue.persistentQueue.storagePath }}/agent
     timeout: 0
+    {{- if not (eq (toString .Values.splunkPlatform.fsyncEnabled) "<nil>") }}
+    fsync: {{ .Values.splunkPlatform.fsyncEnabled }}
+    {{- end }}
   {{- end }}
 
 

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -154,6 +154,9 @@
               }
             }
           }
+        },
+        "fsyncEnabled": {
+          "type": "boolean"
         }
       },
       "anyOf": [

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -121,6 +121,11 @@ splunkPlatform:
       enabled: false
       storagePath: "/var/addon/splunk/exporter_queue"
 
+  # Option to set fsync value for filestorage extension used by the agent. Enabling this option will ensure
+  # database integrity at the cost of performance. If not set it will use default value for this extension.
+  # Refer to: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/storage/filestorage#file-storage
+  # fsyncEnabled: true
+
 ################################################################################
 # Splunk Observability configuration
 ################################################################################


### PR DESCRIPTION
**Description:** Added fsyncEnabled flag, it is passed to file storage used by the agent. This is related to the issue:
https://splunk.atlassian.net/browse/ADDON-71899

With this flag enabled we can avoid issues with data corruption in the future.

**Testing:** Manual testing

**Documentation:** Flag is described in values.yaml
