### PR TITLE
[agent] mount the whole node filesystem to scrape its mount points usage

### DIFF
--- a/.chloggen/mountfilesystem.yaml
+++ b/.chloggen/mountfilesystem.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mount the node filesystem to scrape its mount points usage
+# One or more tracking issues related to the change
+issues: [1437]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -173,7 +173,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -190,23 +190,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - name: varlog
           mountPath: /var/log
@@ -234,24 +219,9 @@ spec:
         hostPath:
           path: /var/addon/splunk/otel_pos
           type: DirectoryOrCreate
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -173,7 +173,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -190,23 +190,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - name: varlog
           mountPath: /var/log
@@ -234,24 +219,9 @@ spec:
         hostPath:
           path: /var/addon/splunk/otel_pos
           type: DirectoryOrCreate
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -174,7 +174,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -191,23 +191,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - name: varlog
           mountPath: /var/log
@@ -235,24 +220,9 @@ spec:
         hostPath:
           path: /var/addon/splunk/otel_pos
           type: DirectoryOrCreate
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -173,7 +173,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -190,23 +190,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - name: varlog
           mountPath: /var/log
@@ -240,24 +225,9 @@ spec:
         hostPath:
           path: /var/addon/splunk/exporter_queue/agent
           type: DirectoryOrCreate
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -133,7 +133,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
           - name: REDIS_USERNAME
             valueFrom:
               secretKeyRef:
@@ -162,23 +162,8 @@ spec:
           name: otel-configmap
         - mountPath: /etc/otel/collector/config.d
           name: otel-discovery-properties-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -188,24 +173,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -173,7 +173,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -190,23 +190,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - name: varlog
           mountPath: /var/log
@@ -234,24 +219,9 @@ spec:
         hostPath:
           path: /var/addon/splunk/otel_pos
           type: DirectoryOrCreate
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -173,7 +173,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -190,23 +190,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - name: varlog
           mountPath: /var/log
@@ -240,24 +225,9 @@ spec:
         hostPath:
           path: /var/addon/splunk/exporter_queue/agent
           type: DirectoryOrCreate
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -205,7 +205,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -222,23 +222,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -270,24 +255,9 @@ spec:
           name: default-splunk-otel-collector-fluentd-json
       - name: tmp
         emptyDir: {}
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -205,7 +205,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -222,23 +222,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -270,24 +255,9 @@ spec:
           name: default-splunk-otel-collector-fluentd-json
       - name: tmp
         emptyDir: {}
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -157,7 +157,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -174,23 +174,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - name: varlog
           mountPath: /var/log
@@ -218,24 +203,9 @@ spec:
         hostPath:
           path: /var/addon/splunk/otel_pos
           type: DirectoryOrCreate
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -116,7 +116,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -133,23 +133,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -159,24 +144,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -116,7 +116,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -133,23 +133,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -159,24 +144,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
           - name: HTTPS_PROXY
             value: 192.168.0.10
 
@@ -151,23 +151,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -177,24 +162,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -132,7 +132,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
 
         readinessProbe:
           httpGet:
@@ -149,23 +149,8 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
@@ -175,24 +160,9 @@ spec:
       - name: run-collectd
         emptyDir:
           sizeLimit: 25Mi
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       - name: otel-configmap
         configMap:
           name: default-splunk-otel-collector-otel-agent

--- a/functional_tests/testdata/expected_kind_values/expected_hostmetrics_metrics.yaml
+++ b/functional_tests/testdata/expected_kind_values/expected_hostmetrics_metrics.yaml
@@ -2,6 +2,2661 @@ resourceMetrics:
   - resource: {}
     scopeMetrics:
       - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "555286528"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: buffered
+                  timeUnixNano: "1000000"
+                - asInt: "7360237568"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: cached
+                  timeUnixNano: "1000000"
+                - asInt: "1607397376"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                  timeUnixNano: "1000000"
+                - asInt: "352149504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: slab_reclaimable
+                  timeUnixNano: "1000000"
+                - asInt: "125636608"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: slab_unreclaimable
+                  timeUnixNano: "1000000"
+                - asInt: "3010281472"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                  timeUnixNano: "1000000"
+            name: system.memory.usage
+          - gauge:
+              dataPoints:
+                - asInt: "12533202944"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: memory.total
+          - gauge:
+              dataPoints:
+                - asDouble: 24.01845310771982
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: memory.utilization
+          - name: system.paging.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "36295622656"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: page_in
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: major
+                  timeUnixNano: "1000000"
+                - asInt: "80193937408"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: page_out
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: major
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: vmpage_io.swap.in
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "8861236"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: vmpage_io.swap.out
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "19578598"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: system.disk.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "6111726"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vda
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "17839562"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vda
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "6111655"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vda1
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "17839562"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vda1
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "93545"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vdb
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vdb
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "246372"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vdc
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vdc
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: system.disk.operations.total
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "12563298"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "35679124"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: system.disk.io.total
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "170604316672"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "468214996992"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asInt: "188"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: disk_ops.total
+          - gauge:
+              dataPoints:
+                - asDouble: 3.86
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: system.cpu.load_average.15m
+          - gauge:
+              dataPoints:
+                - asDouble: 4.82
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: system.cpu.load_average.1m
+          - gauge:
+              dataPoints:
+                - asDouble: 4.26
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: system.cpu.load_average.5m
+          - gauge:
+              dataPoints:
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/lib/docker/containers
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/lib/docker/containers
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/log
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/log
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev/termination-log
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev/termination-log
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/hostname
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/hostname
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/hosts
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/hosts
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/resolv.conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/resolv.conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/hostname
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/hostname
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/hosts
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/hosts
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/resolv.conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/resolv.conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/var
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/var
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "46325813248"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/addon/splunk/otel_pos
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "95338668032"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/addon/splunk/otel_pos
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vdb
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/usr/lib/modules
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: erofs
+                  timeUnixNano: "1000000"
+                - asInt: "140513280"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vdb
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/usr/lib/modules
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: erofs
+                  timeUnixNano: "1000000"
+            name: system.filesystem.usage
+          - gauge:
+              dataPoints:
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/lib/docker/containers
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/log
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev/termination-log
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/hostname
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/hosts
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /etc/resolv.conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/hostname
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/hosts
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/etc/resolv.conf
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/var
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 67.29892148728729
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vda1
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /var/addon/splunk/otel_pos
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: ext4
+                  timeUnixNano: "1000000"
+                - asDouble: 100
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: /dev/vdb
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /hostfs/usr/lib/modules
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: type
+                      value:
+                        stringValue: erofs
+                  timeUnixNano: "1000000"
+            name: disk.utilization
+          - gauge:
+              dataPoints:
+                - asDouble: 67.33132468870919
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: disk.summary_utilization
           - name: system.network.errors
             sum:
               aggregationTemporality: 2
@@ -748,7 +3403,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth1e913d8a
+                        stringValue: veth16caedde
                     - key: direction
                       value:
                         stringValue: receive
@@ -781,7 +3436,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth1e913d8a
+                        stringValue: veth16caedde
                     - key: direction
                       value:
                         stringValue: transmit
@@ -814,7 +3469,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2225d150
+                        stringValue: veth2cb56e74
                     - key: direction
                       value:
                         stringValue: receive
@@ -847,7 +3502,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2225d150
+                        stringValue: veth2cb56e74
                     - key: direction
                       value:
                         stringValue: transmit
@@ -880,7 +3535,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2d9ec93e
+                        stringValue: veth39980571
                     - key: direction
                       value:
                         stringValue: receive
@@ -913,7 +3568,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2d9ec93e
+                        stringValue: veth39980571
                     - key: direction
                       value:
                         stringValue: transmit
@@ -946,7 +3601,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2f51a925
+                        stringValue: veth43c67e97
                     - key: direction
                       value:
                         stringValue: receive
@@ -979,7 +3634,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2f51a925
+                        stringValue: veth43c67e97
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1012,7 +3667,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth354cdbdd
+                        stringValue: veth77cc1ffe
                     - key: direction
                       value:
                         stringValue: receive
@@ -1045,7 +3700,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth354cdbdd
+                        stringValue: veth77cc1ffe
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1078,7 +3733,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth463f90e2
+                        stringValue: veth79ea4a11
                     - key: direction
                       value:
                         stringValue: receive
@@ -1111,7 +3766,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth463f90e2
+                        stringValue: veth79ea4a11
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1144,7 +3799,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth509b126a
+                        stringValue: veth7d1daab7
                     - key: direction
                       value:
                         stringValue: receive
@@ -1177,7 +3832,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth509b126a
+                        stringValue: veth7d1daab7
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1210,7 +3865,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth57daa14a
+                        stringValue: veth9b9d410a
                     - key: direction
                       value:
                         stringValue: receive
@@ -1243,7 +3898,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth57daa14a
+                        stringValue: veth9b9d410a
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1276,7 +3931,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth5fd44bce
+                        stringValue: vetha5ad68c5
                     - key: direction
                       value:
                         stringValue: receive
@@ -1309,7 +3964,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth5fd44bce
+                        stringValue: vetha5ad68c5
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1342,7 +3997,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth69e8787b
+                        stringValue: vethae1d1bd3
                     - key: direction
                       value:
                         stringValue: receive
@@ -1375,7 +4030,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth69e8787b
+                        stringValue: vethae1d1bd3
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1408,7 +4063,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth825660a6
+                        stringValue: vethaf8176bf
                     - key: direction
                       value:
                         stringValue: receive
@@ -1441,7 +4096,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth825660a6
+                        stringValue: vethaf8176bf
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1474,7 +4129,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth936e0af8
+                        stringValue: vethb34eba16
                     - key: direction
                       value:
                         stringValue: receive
@@ -1507,7 +4162,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth936e0af8
+                        stringValue: vethb34eba16
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1540,7 +4195,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth9607eeb8
+                        stringValue: vethba0f00de
                     - key: direction
                       value:
                         stringValue: receive
@@ -1573,7 +4228,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth9607eeb8
+                        stringValue: vethba0f00de
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1606,7 +4261,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth9e0a3c2a
+                        stringValue: vethba4d8055
                     - key: direction
                       value:
                         stringValue: receive
@@ -1639,7 +4294,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth9e0a3c2a
+                        stringValue: vethba4d8055
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1672,7 +4327,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethcc50f106
+                        stringValue: vethc30e2f4b
                     - key: direction
                       value:
                         stringValue: receive
@@ -1705,7 +4360,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethcc50f106
+                        stringValue: vethc30e2f4b
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1738,7 +4393,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethd25e2456
+                        stringValue: vethc6620063
                     - key: direction
                       value:
                         stringValue: receive
@@ -1771,7 +4426,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethd25e2456
+                        stringValue: vethc6620063
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1804,7 +4459,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethd706a88f
+                        stringValue: vethe2c04ea3
                     - key: direction
                       value:
                         stringValue: receive
@@ -1837,7 +4492,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethd706a88f
+                        stringValue: vethe2c04ea3
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1870,7 +4525,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethdabe0ec3
+                        stringValue: vethf9f77f50
                     - key: direction
                       value:
                         stringValue: receive
@@ -1903,7 +4558,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethdabe0ec3
+                        stringValue: vethf9f77f50
                     - key: direction
                       value:
                         stringValue: transmit
@@ -1936,7 +4591,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethf102b532
+                        stringValue: vethfd2c5ee4
                     - key: direction
                       value:
                         stringValue: receive
@@ -1969,7 +4624,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethf102b532
+                        stringValue: vethfd2c5ee4
                     - key: direction
                       value:
                         stringValue: transmit
@@ -2057,7 +4712,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "493520958"
+                - asInt: "639762438"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2090,7 +4745,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "377657541"
+                - asInt: "50164037"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2519,7 +5174,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "396045583"
+                - asInt: "93754672"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2552,7 +5207,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "396045583"
+                - asInt: "93754672"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2717,7 +5372,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "656"
+                - asInt: "304273"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2733,7 +5388,73 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth1e913d8a
+                        stringValue: veth16caedde
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "398849"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: veth16caedde
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "726"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: veth2cb56e74
                     - key: direction
                       value:
                         stringValue: receive
@@ -2766,7 +5487,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth1e913d8a
+                        stringValue: veth2cb56e74
                     - key: direction
                       value:
                         stringValue: transmit
@@ -2783,7 +5504,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1342091"
+                - asInt: "69849"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2799,7 +5520,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2225d150
+                        stringValue: veth39980571
                     - key: direction
                       value:
                         stringValue: receive
@@ -2816,7 +5537,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "2878038"
+                - asInt: "3772"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2832,7 +5553,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2225d150
+                        stringValue: veth39980571
                     - key: direction
                       value:
                         stringValue: transmit
@@ -2849,7 +5570,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "656"
+                - asInt: "113401"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2865,7 +5586,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2d9ec93e
+                        stringValue: veth43c67e97
                     - key: direction
                       value:
                         stringValue: receive
@@ -2882,7 +5603,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "446"
+                - asInt: "5476"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2898,7 +5619,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2d9ec93e
+                        stringValue: veth43c67e97
                     - key: direction
                       value:
                         stringValue: transmit
@@ -2915,7 +5636,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10873848"
+                - asInt: "726"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2931,73 +5652,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth2f51a925
-                    - key: direction
-                      value:
-                        stringValue: receive
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "5815402"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: veth2f51a925
-                    - key: direction
-                      value:
-                        stringValue: transmit
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "586"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: veth354cdbdd
+                        stringValue: veth77cc1ffe
                     - key: direction
                       value:
                         stringValue: receive
@@ -3030,7 +5685,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth354cdbdd
+                        stringValue: veth77cc1ffe
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3047,7 +5702,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "16030"
+                - asInt: "24055"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3063,7 +5718,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth463f90e2
+                        stringValue: veth79ea4a11
                     - key: direction
                       value:
                         stringValue: receive
@@ -3080,7 +5735,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1858"
+                - asInt: "187070"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3096,7 +5751,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth463f90e2
+                        stringValue: veth79ea4a11
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3113,7 +5768,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "30608"
+                - asInt: "36517"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3129,7 +5784,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth509b126a
+                        stringValue: veth7d1daab7
                     - key: direction
                       value:
                         stringValue: receive
@@ -3146,7 +5801,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "2101"
+                - asInt: "167814"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3162,7 +5817,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth509b126a
+                        stringValue: veth7d1daab7
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3179,7 +5834,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10822944"
+                - asInt: "1752152"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3195,7 +5850,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth57daa14a
+                        stringValue: veth9b9d410a
                     - key: direction
                       value:
                         stringValue: receive
@@ -3212,7 +5867,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "5777953"
+                - asInt: "2151292"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3228,7 +5883,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth57daa14a
+                        stringValue: veth9b9d410a
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3245,7 +5900,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "656"
+                - asInt: "329107"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3261,7 +5916,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth5fd44bce
+                        stringValue: vetha5ad68c5
                     - key: direction
                       value:
                         stringValue: receive
@@ -3278,7 +5933,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "446"
+                - asInt: "330396"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3294,7 +5949,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth5fd44bce
+                        stringValue: vetha5ad68c5
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3311,7 +5966,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "53631"
+                - asInt: "54245"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3327,7 +5982,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth69e8787b
+                        stringValue: vethae1d1bd3
                     - key: direction
                       value:
                         stringValue: receive
@@ -3344,7 +5999,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "9163"
+                - asInt: "5009"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3360,7 +6015,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth69e8787b
+                        stringValue: vethae1d1bd3
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3377,7 +6032,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "656"
+                - asInt: "235102"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3393,7 +6048,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth825660a6
+                        stringValue: vethaf8176bf
                     - key: direction
                       value:
                         stringValue: receive
@@ -3410,7 +6065,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "446"
+                - asInt: "237946"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3426,7 +6081,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth825660a6
+                        stringValue: vethaf8176bf
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3443,7 +6098,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "47578"
+                - asInt: "726"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3459,139 +6114,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth936e0af8
-                    - key: direction
-                      value:
-                        stringValue: receive
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "103219"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: veth936e0af8
-                    - key: direction
-                      value:
-                        stringValue: transmit
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "42221"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: veth9607eeb8
-                    - key: direction
-                      value:
-                        stringValue: receive
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "2480"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: veth9607eeb8
-                    - key: direction
-                      value:
-                        stringValue: transmit
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "656"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: veth9e0a3c2a
+                        stringValue: vethb34eba16
                     - key: direction
                       value:
                         stringValue: receive
@@ -3624,7 +6147,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: veth9e0a3c2a
+                        stringValue: vethb34eba16
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3641,7 +6164,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "970862"
+                - asInt: "726"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3657,7 +6180,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethcc50f106
+                        stringValue: vethba0f00de
                     - key: direction
                       value:
                         stringValue: receive
@@ -3674,7 +6197,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "8288857"
+                - asInt: "446"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3690,7 +6213,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethcc50f106
+                        stringValue: vethba0f00de
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3707,7 +6230,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "32051"
+                - asInt: "295613"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3723,7 +6246,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethd25e2456
+                        stringValue: vethba4d8055
                     - key: direction
                       value:
                         stringValue: receive
@@ -3740,7 +6263,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "183344"
+                - asInt: "3474240"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3756,7 +6279,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethd25e2456
+                        stringValue: vethba4d8055
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3773,7 +6296,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "996902"
+                - asInt: "12235"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3789,7 +6312,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethd706a88f
+                        stringValue: vethc30e2f4b
                     - key: direction
                       value:
                         stringValue: receive
@@ -3806,7 +6329,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1017701"
+                - asInt: "25590"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3822,7 +6345,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethd706a88f
+                        stringValue: vethc30e2f4b
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3839,7 +6362,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "15559"
+                - asInt: "726"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3855,7 +6378,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethdabe0ec3
+                        stringValue: vethc6620063
                     - key: direction
                       value:
                         stringValue: receive
@@ -3872,7 +6395,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "335312"
+                - asInt: "446"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3888,7 +6411,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethdabe0ec3
+                        stringValue: vethc6620063
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3905,7 +6428,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "2820952"
+                - asInt: "120064"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3921,7 +6444,7 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethf102b532
+                        stringValue: vethe2c04ea3
                     - key: direction
                       value:
                         stringValue: receive
@@ -3938,7 +6461,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1823820"
+                - asInt: "19587"
                   attributes:
                     - key: cluster_name
                       value:
@@ -3954,7 +6477,139 @@ resourceMetrics:
                         stringValue: dev
                     - key: device
                       value:
-                        stringValue: vethf102b532
+                        stringValue: vethe2c04ea3
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "726"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vethf9f77f50
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "446"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vethf9f77f50
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "233872"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vethfd2c5ee4
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "236660"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: device
+                      value:
+                        stringValue: vethfd2c5ee4
                     - key: direction
                       value:
                         stringValue: transmit
@@ -3976,7 +6631,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1215764"
+                - asInt: "341881"
                   attributes:
                     - key: cluster_name
                       value:
@@ -4006,7 +6661,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1234588"
+                - asInt: "316232"
                   attributes:
                     - key: cluster_name
                       value:
@@ -4041,7 +6696,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "917635684"
+                - asInt: "737101951"
                   attributes:
                     - key: cluster_name
                       value:
@@ -4071,7 +6726,7 @@ resourceMetrics:
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "799945048"
+                - asInt: "151165086"
                   attributes:
                     - key: cluster_name
                       value:
@@ -4106,7 +6761,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1717580732"
+                - asInt: "888267037"
                   attributes:
                     - key: cluster_name
                       value:
@@ -4136,7 +6791,7 @@ resourceMetrics:
               isMonotonic: true
           - gauge:
               dataPoints:
-                - asDouble: 3.5806987057057404
+                - asDouble: 3.3071702794208306
                   attributes:
                     - key: cluster_name
                       value:
@@ -4198,7 +6853,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "856153596"
+                - asInt: "1086677609"
                   attributes:
                     - key: cluster_name
                       value:
@@ -4226,2413 +6881,4 @@ resourceMetrics:
                         stringValue: linux
                   timeUnixNano: "1000000"
               isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/lib/docker/containers
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/lib/docker/containers
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/log
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/log
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /dev/termination-log
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /dev/termination-log
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/hostname
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/hostname
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/hosts
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/hosts
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/resolv.conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/resolv.conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/hostname
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/hostname
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/hosts
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/hosts
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/resolv.conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/resolv.conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "46328107008"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/addon/splunk/otel_pos
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asInt: "95336374272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/addon/splunk/otel_pos
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-            name: system.filesystem.usage
-          - gauge:
-              dataPoints:
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/lib/docker/containers
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: ro
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/log
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /dev/termination-log
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/hostname
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/hosts
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /etc/resolv.conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/hostname
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/hosts
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /hostfs/etc/resolv.conf
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: /dev/vda1
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: mode
-                      value:
-                        stringValue: rw
-                    - key: mountpoint
-                      value:
-                        stringValue: /var/addon/splunk/otel_pos
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: ext4
-                  timeUnixNano: "1000000"
-            name: disk.utilization
-          - gauge:
-              dataPoints:
-                - asDouble: 67.29730233760398
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-            name: disk.summary_utilization
-          - name: system.paging.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "36292501504"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: direction
-                      value:
-                        stringValue: page_in
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: major
-                  timeUnixNano: "1000000"
-                - asInt: "80193785856"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: direction
-                      value:
-                        stringValue: page_out
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: type
-                      value:
-                        stringValue: major
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: vmpage_io.swap.in
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "8860474"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: vmpage_io.swap.out
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "19578561"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 4.14
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-            name: system.cpu.load_average.15m
-          - gauge:
-              dataPoints:
-                - asDouble: 4.07
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-            name: system.cpu.load_average.1m
-          - gauge:
-              dataPoints:
-                - asDouble: 4.09
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-            name: system.cpu.load_average.5m
-          - gauge:
-              dataPoints:
-                - asInt: "545402880"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: buffered
-                  timeUnixNano: "1000000"
-                - asInt: "6886641664"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: cached
-                  timeUnixNano: "1000000"
-                - asInt: "1949896704"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: free
-                  timeUnixNano: "1000000"
-                - asInt: "326721536"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: slab_reclaimable
-                  timeUnixNano: "1000000"
-                - asInt: "123252736"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: slab_unreclaimable
-                  timeUnixNano: "1000000"
-                - asInt: "3151261696"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: state
-                      value:
-                        stringValue: used
-                  timeUnixNano: "1000000"
-            name: system.memory.usage
-          - gauge:
-              dataPoints:
-                - asInt: "12533202944"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-            name: memory.total
-          - gauge:
-              dataPoints:
-                - asDouble: 25.143307022795785
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-            name: memory.utilization
-          - name: system.disk.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "6109379"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: vda
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "15016995"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: vda
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "6109308"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: vda1
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "15016995"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: vda1
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "93544"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: vdb
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: vdb
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "246351"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: vdc
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: device
-                      value:
-                        stringValue: vdc
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: system.disk.operations.total
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "12558582"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "30033990"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: system.disk.io.total
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "170574985216"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "398679777280"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asInt: "674"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-            name: disk_ops.total
         scope: {}

--- a/functional_tests/testdata/expected_kind_values/expected_internal_metrics.yaml
+++ b/functional_tests/testdata/expected_kind_values/expected_internal_metrics.yaml
@@ -2,11 +2,11 @@ resourceMetrics:
   - resource: {}
     scopeMetrics:
       - metrics:
-          - name: otelcol_processor_dropped_log_records
+          - name: otelcol_processor_accepted_log_records
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asDouble: 0
+                - asDouble: 7511
                   attributes:
                     - key: cluster_name
                       value:
@@ -34,10 +34,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -50,6 +50,12 @@ resourceMetrics:
                     - key: processor
                       value:
                         stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -58,2604 +64,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_processor_dropped_spans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
+                        stringValue: v0.105.0
+                    - key: url.scheme
                       value:
                         stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: processor
-                      value:
-                        stringValue: memory_limiter
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_receiver_accepted_spans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 96
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: otlp
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                    - key: transport
-                      value:
-                        stringValue: grpc
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_receiver_refused_spans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: otlp
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                    - key: transport
-                      value:
-                        stringValue: grpc
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 96
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                  timeUnixNano: "1000000"
-            name: scrape_series_added
-          - name: otelcol_exporter_sent_metric_points
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 5985
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: signalfx
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 5985
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: splunk_hec/platform_metrics
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_otelsvc_k8s_namespace_added
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 36
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 0.008026458
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                  timeUnixNano: "1000000"
-            name: scrape_duration_seconds
-          - gauge:
-              dataPoints:
-                - asDouble: 96
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                  timeUnixNano: "1000000"
-            name: scrape_samples_post_metric_relabeling
-          - gauge:
-              dataPoints:
-                - asDouble: 1000
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: otlp
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 1000
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: signalfx
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 5000
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: splunk_hec/platform_logs
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 5000
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: splunk_hec/platform_metrics
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-            name: otelcol_exporter_queue_capacity
-          - gauge:
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: otlp
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: signalfx
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: splunk_hec/platform_logs
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: splunk_hec/platform_metrics
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-            name: otelcol_exporter_queue_size
-          - name: otelcol_exporter_send_failed_log_records
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 121
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: splunk_hec/platform_logs
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_otelsvc_k8s_ip_lookup_miss
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 357
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 4.94807416e+08
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-            name: otelcol_process_runtime_total_sys_memory_bytes
-          - name: otelcol_processor_refused_spans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: processor
-                      value:
-                        stringValue: memory_limiter
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 96
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                  timeUnixNano: "1000000"
-            name: scrape_samples_scraped
-          - name: otelcol_exporter_sent_spans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 96
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: otlp
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_otelsvc_k8s_pod_updated
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 180
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_process_cpu_seconds
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 2.1799999999999997
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_processor_accepted_spans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 96
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: processor
-                      value:
-                        stringValue: memory_limiter
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_processor_refused_log_records
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: processor
-                      value:
-                        stringValue: memory_limiter
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_receiver_refused_log_records
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: filelog
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: journald/containerd
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: journald/kubelet
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_scraper_scraped_metric_points
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 7
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: scraper
-                      value:
-                        stringValue: cpu
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 49
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: scraper
-                      value:
-                        stringValue: disk
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 14
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: scraper
-                      value:
-                        stringValue: filesystem
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 21
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: scraper
-                      value:
-                        stringValue: load
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 7
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: scraper
-                      value:
-                        stringValue: memory
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 35
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: scraper
-                      value:
-                        stringValue: network
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 21
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: scraper
-                      value:
-                        stringValue: paging
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 14
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: scraper
-                      value:
-                        stringValue: processes
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 2843
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: kubeletstats
-                    - key: scraper
-                      value:
-                        stringValue: kubeletstats
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 73
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-            name: otelcol_otelsvc_k8s_pod_table_size
-          - gauge:
-              dataPoints:
-                - asDouble: 2.91491872e+08
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-            name: otelcol_process_runtime_heap_alloc_bytes
-          - name: otelcol_processor_accepted_metric_points
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 5985
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: processor
-                      value:
-                        stringValue: memory_limiter
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
                   timeUnixNano: "1000000"
               isMonotonic: true
           - name: otelcol_processor_refused_metric_points
@@ -2690,10 +108,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -2706,6 +124,12 @@ resourceMetrics:
                     - key: processor
                       value:
                         stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -2714,699 +138,19 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
               isMonotonic: true
-          - name: otelcol_receiver_accepted_log_records
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 405
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: filelog
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 392
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: journald/containerd
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 193
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: journald/kubelet
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_receiver_accepted_metric_points
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 2326
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: hostmetrics
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 3099
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: kubeletstats
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 448
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: prometheus/agent
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                    - key: transport
-                      value:
-                        stringValue: http
-                  timeUnixNano: "1000000"
-                - asDouble: 56
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: smartagent/coredns/receiver_creator{endpoint="10.244.0.3"}/k8s_observer/000a54ec-c41b-4298-a2e5-1cc477e755d2
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                    - key: transport
-                      value:
-                        stringValue: internal
-                  timeUnixNano: "1000000"
-                - asDouble: 56
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: smartagent/coredns/receiver_creator{endpoint="10.244.0.5"}/k8s_observer/67bf5661-dff3-4ed3-881e-735a6a797aa6
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                    - key: transport
-                      value:
-                        stringValue: internal
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - gauge:
-              dataPoints:
-                - asDouble: 9.433088e+06
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-            name: otelcol_process_memory_rss
-          - name: otelcol_process_runtime_total_alloc_bytes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 7.31633328e+08
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_process_uptime
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 70.312969005
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_receiver_refused_metric_points
+          - name: otelcol_receiver_refused_spans
             sum:
               aggregationTemporality: 2
               dataPoints:
@@ -3438,10 +182,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -3453,7 +197,13 @@ resourceMetrics:
                         stringValue: linux
                     - key: receiver
                       value:
-                        stringValue: hostmetrics
+                        stringValue: otlp
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -3462,13 +212,19 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: grpc
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -3498,10 +254,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -3513,67 +269,13 @@ resourceMetrics:
                         stringValue: linux
                     - key: receiver
                       value:
-                        stringValue: kubeletstats
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
+                        stringValue: otlp
+                    - key: server.address
                       value:
                         stringValue: 172.18.0.2
-                    - key: net.host.port
+                    - key: server.port
                       value:
                         stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: prometheus/agent
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -3582,272 +284,19 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
                     - key: transport
                       value:
                         stringValue: http
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
+                    - key: url.scheme
                       value:
                         stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: smartagent/coredns/receiver_creator{endpoint="10.244.0.3"}/k8s_observer/000a54ec-c41b-4298-a2e5-1cc477e755d2
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                    - key: transport
-                      value:
-                        stringValue: internal
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: receiver
-                      value:
-                        stringValue: smartagent/coredns/receiver_creator{endpoint="10.244.0.5"}/k8s_observer/67bf5661-dff3-4ed3-881e-735a6a797aa6
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                    - key: transport
-                      value:
-                        stringValue: internal
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_exporter_sent_log_records
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 849
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: exporter
-                      value:
-                        stringValue: splunk_hec/platform_logs
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
-                  timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_processor_filter_logs_filtered
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 20
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: filter
-                      value:
-                        stringValue: filter/logs
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
-                      value:
-                        stringValue: 172.18.0.2
-                    - key: net.host.port
-                      value:
-                        stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                    - key: service_instance_id
-                      value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
-                    - key: service_name
-                      value:
-                        stringValue: otelcol
-                    - key: service_version
-                      value:
-                        stringValue: v0.92.0
                   timeUnixNano: "1000000"
               isMonotonic: true
           - name: otelcol_scraper_errored_metric_points
@@ -3882,10 +331,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -3901,6 +350,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: cpu
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -3909,13 +364,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -3945,10 +403,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -3964,6 +422,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: disk
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -3972,13 +436,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4008,10 +475,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4027,6 +494,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: filesystem
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4035,13 +508,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4071,10 +547,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4090,6 +566,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: load
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4098,13 +580,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4134,10 +619,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4153,6 +638,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: memory
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4161,13 +652,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4197,10 +691,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4216,6 +710,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: network
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4224,13 +724,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4260,10 +763,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4279,6 +782,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: paging
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4287,13 +796,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4323,10 +835,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4342,6 +854,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: processes
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4350,13 +868,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4386,10 +907,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4405,6 +926,12 @@ resourceMetrics:
                     - key: scraper
                       value:
                         stringValue: kubeletstats
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4413,13 +940,796 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 0.00264525
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: scrape_duration_seconds
+          - gauge:
+              dataPoints:
+                - asDouble: 1000
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: otlp
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 1000
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: signalfx
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 1000
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: splunk_hec/platform_logs
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 1000
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: splunk_hec/platform_metrics
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: otelcol_exporter_queue_capacity
+          - name: otelcol_exporter_send_failed_log_records
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 5996
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: splunk_hec/platform_logs
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_processor_inserted_spans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: processor
+                      value:
+                        stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_receiver_accepted_log_records
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 6535
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: filelog
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 468
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: journald/containerd
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 222
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: journald/kubelet
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 286
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: otlp
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
               isMonotonic: true
           - gauge:
@@ -4452,10 +1762,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4465,59 +1775,12 @@ resourceMetrics:
                     - key: os.type
                       value:
                         stringValue: linux
-                    - key: service.instance.id
-                      value:
-                        stringValue: 172.18.0.2:8889
-                    - key: service.name
-                      value:
-                        stringValue: otel-agent
-                  timeUnixNano: "1000000"
-            name: up
-          - name: otelcol_otelsvc_k8s_pod_added
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asDouble: 92
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: http.scheme
-                      value:
-                        stringValue: http
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
-                    - key: net.host.name
+                    - key: server.address
                       value:
                         stringValue: 172.18.0.2
-                    - key: net.host.port
+                    - key: server.port
                       value:
                         stringValue: "8889"
-                    - key: os.type
-                      value:
-                        stringValue: linux
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4526,20 +1789,21 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
-              isMonotonic: true
-          - name: otelcol_processor_accepted_log_records
-            sum:
-              aggregationTemporality: 2
+            name: up
+          - gauge:
               dataPoints:
-                - asDouble: 990
+                - asDouble: 93
                   attributes:
                     - key: cluster_name
                       value:
@@ -4567,10 +1831,150 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: scrape_samples_post_metric_relabeling
+          - gauge:
+              dataPoints:
+                - asDouble: 3.50496072e+08
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: otelcol_process_runtime_total_sys_memory_bytes
+          - name: otelcol_processor_dropped_log_records
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4583,6 +1987,12 @@ resourceMetrics:
                     - key: processor
                       value:
                         stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4591,13 +2001,16 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
               isMonotonic: true
           - name: otelcol_processor_dropped_metric_points
@@ -4632,10 +2045,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-tg5xw
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: d220b04c-095f-47c9-bc2b-b784f002548d
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
                     - key: net.host.name
                       value:
                         stringValue: 172.18.0.2
@@ -4648,6 +2061,12 @@ resourceMetrics:
                     - key: processor
                       value:
                         stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
                     - key: service.instance.id
                       value:
                         stringValue: 172.18.0.2:8889
@@ -4656,13 +2075,4899 @@ resourceMetrics:
                         stringValue: otel-agent
                     - key: service_instance_id
                       value:
-                        stringValue: 7aa2bc6b-3bad-4bb8-acc5-cb41e55d03e2
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
                     - key: service_name
                       value:
                         stringValue: otelcol
                     - key: service_version
                       value:
-                        stringValue: v0.92.0
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_processor_inserted_log_records
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: processor
+                      value:
+                        stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_processor_inserted_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: processor
+                      value:
+                        stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_receiver_refused_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: kubeletstats
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: otlp
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: prometheus/agent
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: prometheus/ta
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: prometheus_simple//receiver_creator{endpoint="10.244.0.104:80"}/k8s_observer/18f906ef-53af-4efc-bda3-76de173b69ac
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: prometheus_simple//receiver_creator{endpoint="10.244.0.3:9402"}/k8s_observer/fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: smartagent/coredns/receiver_creator{endpoint="10.244.0.2"}/k8s_observer/bb3e0f4c-b1dd-4a87-8569-0295e59f0172
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: internal
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: smartagent/coredns/receiver_creator{endpoint="10.244.0.7"}/k8s_observer/2a107f01-3923-4761-bff8-a52f236e5427
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: internal
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: smartagent/kubernetes-proxy/receiver_creator{endpoint="172.18.0.2"}/k8s_observer/065f1562-205d-48d7-b333-756581f19889
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: internal
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_scraper_scraped_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 9
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: scraper
+                      value:
+                        stringValue: cpu
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 63
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: scraper
+                      value:
+                        stringValue: disk
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 18
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: scraper
+                      value:
+                        stringValue: filesystem
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 27
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: scraper
+                      value:
+                        stringValue: load
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 9
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: scraper
+                      value:
+                        stringValue: memory
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 45
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: scraper
+                      value:
+                        stringValue: network
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 27
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: scraper
+                      value:
+                        stringValue: paging
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 18
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: scraper
+                      value:
+                        stringValue: processes
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 4223
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: kubeletstats
+                    - key: scraper
+                      value:
+                        stringValue: kubeletstats
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_exporter_sent_log_records
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 1405
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: splunk_hec/platform_logs
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: otelcol_fileconsumer_reading_files
+          - gauge:
+              dataPoints:
+                - asDouble: 65
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: otelcol_otelsvc_k8s_pod_table_size
+          - name: otelcol_otelsvc_k8s_pod_updated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 120
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 7.654924e+07
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: otelcol_process_runtime_heap_alloc_bytes
+          - name: otelcol_process_runtime_total_alloc_bytes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 7.96805008e+08
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_process_uptime
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 88.358873041
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_processor_dropped_spans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: processor
+                      value:
+                        stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: otlp
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: signalfx
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: splunk_hec/platform_logs
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: splunk_hec/platform_metrics
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: otelcol_exporter_queue_size
+          - name: otelcol_otelsvc_k8s_ip_lookup_miss
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 567
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 26
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: otelcol_fileconsumer_open_files
+          - name: otelcol_process_cpu_seconds
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 6.13
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_processor_accepted_spans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 246
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: processor
+                      value:
+                        stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 93
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: scrape_series_added
+          - name: otelcol_exporter_send_failed_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: signalfx
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: splunk_hec/platform_metrics
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_exporter_sent_spans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 246
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: otlp
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_processor_accepted_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 10776
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: processor
+                      value:
+                        stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_processor_filter_logs_filtered
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 110
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: filter
+                      value:
+                        stringValue: filter/logs
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_receiver_accepted_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 3947
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: hostmetrics
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 4645
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: kubeletstats
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 95
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: otlp
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 710
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: prometheus/agent
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 13
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: prometheus/ta
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 78
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: prometheus_simple//receiver_creator{endpoint="10.244.0.104:80"}/k8s_observer/18f906ef-53af-4efc-bda3-76de173b69ac
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 208
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: prometheus_simple//receiver_creator{endpoint="10.244.0.3:9402"}/k8s_observer/fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 81
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: smartagent/coredns/receiver_creator{endpoint="10.244.0.2"}/k8s_observer/bb3e0f4c-b1dd-4a87-8569-0295e59f0172
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: internal
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 81
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: smartagent/coredns/receiver_creator{endpoint="10.244.0.7"}/k8s_observer/2a107f01-3923-4761-bff8-a52f236e5427
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: internal
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 918
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: smartagent/kubernetes-proxy/receiver_creator{endpoint="172.18.0.2"}/k8s_observer/065f1562-205d-48d7-b333-756581f19889
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: internal
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_receiver_accepted_spans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 67
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: otlp
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: grpc
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 179
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: otlp
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_otelsvc_k8s_namespace_added
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 36
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_otelsvc_k8s_pod_added
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 104
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_processor_refused_spans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: processor
+                      value:
+                        stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_exporter_send_failed_spans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: otlp
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_exporter_sent_metric_points
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 10776
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: signalfx
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 10776
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: exporter
+                      value:
+                        stringValue: splunk_hec/platform_metrics
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - name: otelcol_receiver_refused_log_records
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: filelog
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: journald/containerd
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: journald/kubelet
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: receiver
+                      value:
+                        stringValue: otlp
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: transport
+                      value:
+                        stringValue: http
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+              isMonotonic: true
+          - gauge:
+              dataPoints:
+                - asDouble: 120
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: scrape_samples_scraped
+          - gauge:
+              dataPoints:
+                - asDouble: 1.1665408e+07
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
+                  timeUnixNano: "1000000"
+            name: otelcol_process_memory_rss
+          - name: otelcol_processor_refused_log_records
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: http.scheme
+                      value:
+                        stringValue: http
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-nf5v4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 17bda870-7845-44af-88ac-bde7f3f11140
+                    - key: net.host.name
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: net.host.port
+                      value:
+                        stringValue: "8889"
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                    - key: processor
+                      value:
+                        stringValue: memory_limiter
+                    - key: server.address
+                      value:
+                        stringValue: 172.18.0.2
+                    - key: server.port
+                      value:
+                        stringValue: "8889"
+                    - key: service.instance.id
+                      value:
+                        stringValue: 172.18.0.2:8889
+                    - key: service.name
+                      value:
+                        stringValue: otel-agent
+                    - key: service_instance_id
+                      value:
+                        stringValue: 1af51e77-473a-4efe-9dfe-d3a7069cd219
+                    - key: service_name
+                      value:
+                        stringValue: otelcol
+                    - key: service_version
+                      value:
+                        stringValue: v0.105.0
+                    - key: url.scheme
+                      value:
+                        stringValue: http
                   timeUnixNano: "1000000"
               isMonotonic: true
         scope: {}

--- a/functional_tests/testdata/expected_kind_values/expected_kubeletstats_metrics.yaml
+++ b/functional_tests/testdata/expected_kind_values/expected_kubeletstats_metrics.yaml
@@ -40,10 +40,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
@@ -82,10 +82,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
                     - key: os.type
                       value:
                         stringValue: linux
@@ -124,10 +124,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
                     - key: k8s.pod.uid
                       value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
                     - key: os.type
                       value:
                         stringValue: linux
@@ -166,10 +166,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: java-test-566495f78-6nhnc
+                        stringValue: dotnet-test-5479c475fc-z54vg
                     - key: k8s.pod.uid
                       value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
                     - key: os.type
                       value:
                         stringValue: linux
@@ -208,10 +208,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: nodejs-test-d454cf769-n4whd
+                        stringValue: java-test-5c4d6479b8-xzsgh
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
                     - key: os.type
                       value:
                         stringValue: linux
@@ -250,10 +250,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
                     - key: os.type
                       value:
                         stringValue: linux
@@ -292,10 +292,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
                     - key: os.type
                       value:
                         stringValue: linux
@@ -334,10 +334,136 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
+                        stringValue: sock-operator-786c6c9777-phk4x
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
                     - key: os.type
                       value:
                         stringValue: linux
@@ -376,10 +502,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-ttp4s
+                        stringValue: coredns-5dd5756b68-cjfpv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
                     - key: os.type
                       value:
                         stringValue: linux
@@ -418,10 +544,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-x8jcx
+                        stringValue: coredns-5dd5756b68-t987l
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
                     - key: os.type
                       value:
                         stringValue: linux
@@ -463,7 +589,7 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
                     - key: os.type
                       value:
                         stringValue: linux
@@ -502,10 +628,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-wrk68
+                        stringValue: kindnet-rcfnj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
                     - key: os.type
                       value:
                         stringValue: linux
@@ -547,7 +673,7 @@ resourceMetrics:
                         stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
                     - key: os.type
                       value:
                         stringValue: linux
@@ -589,7 +715,7 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
                     - key: os.type
                       value:
                         stringValue: linux
@@ -628,10 +754,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kube-proxy-zmds8
+                        stringValue: kube-proxy-6vc2p
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
                     - key: os.type
                       value:
                         stringValue: linux
@@ -673,7 +799,7 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
                     - key: os.type
                       value:
                         stringValue: linux
@@ -712,10 +838,262 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
                     - key: os.type
                       value:
                         stringValue: linux
@@ -754,10 +1132,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
@@ -796,10 +1174,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
                     - key: os.type
                       value:
                         stringValue: linux
@@ -838,10 +1216,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
                     - key: k8s.pod.uid
                       value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
                     - key: os.type
                       value:
                         stringValue: linux
@@ -880,10 +1258,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: java-test-566495f78-6nhnc
+                        stringValue: dotnet-test-5479c475fc-z54vg
                     - key: k8s.pod.uid
                       value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
                     - key: os.type
                       value:
                         stringValue: linux
@@ -922,10 +1300,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: nodejs-test-d454cf769-n4whd
+                        stringValue: java-test-5c4d6479b8-xzsgh
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
                     - key: os.type
                       value:
                         stringValue: linux
@@ -964,10 +1342,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1006,10 +1384,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1048,10 +1426,136 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
+                        stringValue: sock-operator-786c6c9777-phk4x
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1090,10 +1594,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-ttp4s
+                        stringValue: coredns-5dd5756b68-cjfpv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1132,10 +1636,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-x8jcx
+                        stringValue: coredns-5dd5756b68-t987l
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1177,7 +1681,7 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1216,10 +1720,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-wrk68
+                        stringValue: kindnet-rcfnj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1261,7 +1765,7 @@ resourceMetrics:
                         stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1303,7 +1807,7 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1342,10 +1846,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kube-proxy-zmds8
+                        stringValue: kube-proxy-6vc2p
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1387,7 +1891,7 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1426,10 +1930,262 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
                     - key: os.type
                       value:
                         stringValue: linux
@@ -1439,7 +2195,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "165169"
+                - asInt: "1609209"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1473,15 +2229,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1961606"
+                - asInt: "17854445"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1515,15 +2271,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "314682"
+                - asInt: "1029164"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1557,15 +2313,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
                     - key: k8s.pod.uid
                       value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1700"
+                - asInt: "5114"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1599,15 +2355,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: java-test-566495f78-6nhnc
+                        stringValue: dotnet-test-5479c475fc-z54vg
                     - key: k8s.pod.uid
                       value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "8109"
+                - asInt: "2957"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1641,15 +2397,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: nodejs-test-d454cf769-n4whd
+                        stringValue: java-test-5c4d6479b8-xzsgh
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "418247"
+                - asInt: "17369"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1683,15 +2439,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "448608530"
+                - asInt: "3756"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1725,15 +2481,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "2628682"
+                - asInt: "163645"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1767,15 +2523,141 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
+                        stringValue: sock-operator-786c6c9777-phk4x
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "55831"
+                - asInt: "659135065"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "2225716"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "187572"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "1545679"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1809,15 +2691,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-ttp4s
+                        stringValue: coredns-5dd5756b68-cjfpv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "56169"
+                - asInt: "1537597"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1851,15 +2733,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-x8jcx
+                        stringValue: coredns-5dd5756b68-t987l
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "448622310"
+                - asInt: "659148806"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1896,12 +2778,12 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "448613705"
+                - asInt: "659147490"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1935,15 +2817,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-wrk68
+                        stringValue: kindnet-rcfnj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "448619227"
+                - asInt: "659141084"
                   attributes:
                     - key: cluster_name
                       value:
@@ -1980,12 +2862,12 @@ resourceMetrics:
                         stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "448612472"
+                - asInt: "659146596"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2022,12 +2904,12 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "448600146"
+                - asInt: "659151552"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2061,15 +2943,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kube-proxy-zmds8
+                        stringValue: kube-proxy-6vc2p
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "448593837"
+                - asInt: "659141524"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2106,12 +2988,12 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "8485"
+                - asInt: "94163"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2145,15 +3027,267 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "104298"
+                - asInt: "446"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "446"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "446"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "446"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "446"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "446"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: receive
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "1446918"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2187,15 +3321,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "130013"
+                - asInt: "1512158"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2229,15 +3363,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "392751"
+                - asInt: "1091585"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2271,15 +3405,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
                     - key: k8s.pod.uid
                       value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "20081"
+                - asInt: "104192"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2313,15 +3447,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: java-test-566495f78-6nhnc
+                        stringValue: dotnet-test-5479c475fc-z54vg
                     - key: k8s.pod.uid
                       value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "35283"
+                - asInt: "51724"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2355,15 +3489,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: nodejs-test-d454cf769-n4whd
+                        stringValue: java-test-5c4d6479b8-xzsgh
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "48461"
+                - asInt: "108849"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2397,15 +3531,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "11089099"
+                - asInt: "38959"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2439,15 +3573,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1192006"
+                - asInt: "33874"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2481,15 +3615,141 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
+                        stringValue: sock-operator-786c6c9777-phk4x
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "45510"
+                - asInt: "328993012"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "1612291"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "23901"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "1662011"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2523,15 +3783,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-ttp4s
+                        stringValue: coredns-5dd5756b68-cjfpv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "43608"
+                - asInt: "1651825"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2565,15 +3825,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-x8jcx
+                        stringValue: coredns-5dd5756b68-t987l
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "11764064"
+                - asInt: "330017571"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2610,12 +3870,12 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "11525429"
+                - asInt: "330009614"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2649,15 +3909,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-wrk68
+                        stringValue: kindnet-rcfnj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "11658390"
+                - asInt: "329600726"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2694,12 +3954,12 @@ resourceMetrics:
                         stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "11520408"
+                - asInt: "329834797"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2736,12 +3996,12 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10856516"
+                - asInt: "330194631"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2775,15 +4035,15 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kube-proxy-zmds8
+                        stringValue: kube-proxy-6vc2p
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10786169"
+                - asInt: "329602181"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2820,12 +4080,12 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "4939"
+                - asInt: "43290"
                   attributes:
                     - key: cluster_name
                       value:
@@ -2859,10 +4119,262 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "726"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "726"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "656"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "726"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "726"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "726"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: direction
+                      value:
+                        stringValue: transmit
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: interface
+                      value:
+                        stringValue: eth0
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
                     - key: os.type
                       value:
                         stringValue: linux
@@ -2870,14 +4382,14 @@ resourceMetrics:
               isMonotonic: true
           - gauge:
               dataPoints:
-                - asInt: "10294927360"
+                - asInt: "46327087104"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 0200fab216c7ccb291be3d1799f862bd8488cb786b4b1f50abc4e778dc130a3d
+                        stringValue: 04a9e15354b63850372c24d01717fb45a584eeeb5df32639f07b753665f0133c
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -2907,19 +4419,61 @@ resourceMetrics:
                         stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10294927360"
+                - asInt: "46327087104"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 021327b7039db9dd913ba2beb4625bf3f2d522805decbeb30d3844953d689895
+                        stringValue: 04b9ef1239f4dd659aa48887c488d69ef2e1eb4ab0c558ad303788fd41c79fab
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: targetallocator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 18f56251ddf0003eaa7a3f9dad5151d8be06cb53fa24bc0abe58fc6b5be798c6
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -2946,358 +4500,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10294927360"
+                - asInt: "46327087104"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 0a1903dcb4d0fdd4279b401318013e772a755df50a54714195cf5b81132ae688
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0b7de24593b9e9b9c4dcb6424f1e829e3232aac96921586aa5b4876e34fffead
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: nodejs-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: nodejs-test-d454cf769-n4whd
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0f663224843198b71d0acbd6738008173478ad97f79ed2411ba7a3d6014f69f4
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-cainjector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2118c058c65a24bcf948d3b082c7d24a957ee636d8bfc9a31dec1c700912daf2
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-5dd5756b68-ttp4s
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2188e5dbd44970ada6bb9b4adc1190534cec2034ed4bbbefe39b998b762c8090
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-controller-manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-controller-manager-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 23c653fde53fcb3b3dd7f586ed165f5621f786f1bd68f9ed18caaa132177a05e
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 3c4c69e6395265782987df7e1a9ad2ce992b5fdce80124c6608594c54d069b4a
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: local-path-provisioner
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: local-path-storage
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 450386c43051a8d554ba7b41fb6fd35740fad2ee77f6a5be5f7d7b366934fa37
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: etcd
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: etcd-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 47a8c0881856e8eebf6dead289f5605bf7e6e159131148313ff44b43f93792ab
+                        stringValue: 1a9416b266db5076bdc7a4a552bbd5382cc9c9f09a00d32274c3324381ff687f
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3324,232 +4542,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10294927360"
+                - asInt: "46327087104"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 49285c01fa935e13e79252d57fb188b1c72b317328df453f855fd7307bf6166a
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-5dd5756b68-x8jcx
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 4bd3dfa8576441902eb944836f6752aeb3d5fbd24b17e3984e9f88b205096130
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-proxy-zmds8
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 63c80e0ba2de4a1f83678a6dd53d96b507a07a8a18a45b9819e10498c9d851f0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: java-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: java-test-566495f78-6nhnc
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 9eec542c85daa232c5488c4f587671a6cf01f52ccddf663abd74b8b2f158e962
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-rbac-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: cdf2eb0fde3a64bdcb49a31753d8030ee0d3c9d55e27099c582ed524e7fa58e3
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-webhook
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "10294927360"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: dd4fd2423e56794193a5ccb18b4fd39dbf27ed97eacb1f282e92d108bc0bb2e9
+                        stringValue: 1b1930185f75d7381c08c4aa95a5f3307e9cb4fab444d43972b1c6d8fbf2f7e0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3579,19 +4587,439 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10294927360"
+                - asInt: "46327087104"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f42485d9874a9b0458270281ba2b5c76679bf622b30c92c54b696a5a81b5d7c0
+                        stringValue: 2d009e1adcdf71017ba9bf6fd7c8619f65828f628731e240f9d6e4bdf8d2ef05
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-cjfpv
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 2d9b25eac7f522173184bab2706990f23069ec4f5c8eeb7b9bb5b5ba58353cb7
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-proxy
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-proxy-6vc2p
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 43d2186cb60b7090e5c7d77884c1b20760d820388acbdf1290a722017176667f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-webhook
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 4ace844b6d5dd4b77bf14d96fe98860916d7c04d6201a8126c369da1f827dd4d
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 5f96c636d73fd8b023b305c11c9f8639c1fcf9ac86d8026eaa6cdaa246d6daf5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6eba76e8e8b34c5b6752f8bddb3e6ec85ee418a9c7ad68e92c9941d73d2db6bb
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-controller-manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-controller-manager-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 7318f6ee73f6b12fa94da8dbd1e376a09a53a2555dff9890414dd14b817ebea4
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: local-path-provisioner
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: local-path-storage
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 80ebc82669280f1b7b75fe421dc688767e8e3a8d994c03586774ac60ab0bbcef
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-786c6c9777-phk4x
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 87aa0b7b0a21f922d64ae695ebaf92223a716dcbacaa3ab86acf1844350daede
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: dotnet-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: dotnet-test-5479c475fc-z54vg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 8e39e2ef0bd7c184c7fd92ffe57859eed2e83b2e623643b241b7a30c5486e2e6
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 92f92bf46126ea0711d2d226d0c7e9341a49228e406ea399c973fe620a4568ac
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3618,10 +5046,472 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-wrk68
+                        stringValue: kindnet-rcfnj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 9fc249d17a20e04b5111ffba1b7385e386d1079dbcced79c07b1c23238a0805f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-t987l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: a523b442f64ec462b3df12c58bbb5e008c29821d5e51f2081010a0fbc25a72ca
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: etcd
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: etcd-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: ac13e7a1f72ee47bc2dfa61763a7435541d55c4e55b56e6769d9f939747ec3cd
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: nodejs-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: b06077b599f13110494440544cd40c2154f1374cbec3dc347e21c7be4022844e
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bcc4f3a6b60298430fc56c2ad850940155bd2890d77d6fa7421281d61047f437
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bfabcd9fcca4b4fcca79b128f9baa1d5b21081e2b2a0a1244da303977823b5cd
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cf04df7f2aa2fd14983011fda7ee61603a9f366aff018a6193e0c2e7c635bea5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-cainjector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cfca01a7f060f4dc3ce9c9c8ce2e61aa6889f8271a56618c301ddee2a6f392c3
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dc67528efcf8c0b26e7a5a1c1130c6878b1dfc1f633f598949a8b8c4a5becd55
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-rbac-proxy
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-786c6c9777-phk4x
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: e478d92439bba6b65361da3ec55c78dd82c464bc912e1a2cc6e17fd7bd2ed29d
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: java-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: java-test-5c4d6479b8-xzsgh
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "46327087104"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: f03951f790e0a191ae8980950ca870e3cd48881b24d313b1ea71068bc2f25cdb
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: prometheus-annotation-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
                     - key: os.type
                       value:
                         stringValue: linux
@@ -3629,14 +5519,14 @@ resourceMetrics:
             name: container.filesystem.available
           - gauge:
               dataPoints:
-                - asInt: "125658222592"
+                - asInt: "149281173504"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 0200fab216c7ccb291be3d1799f862bd8488cb786b4b1f50abc4e778dc130a3d
+                        stringValue: 04a9e15354b63850372c24d01717fb45a584eeeb5df32639f07b753665f0133c
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3666,19 +5556,61 @@ resourceMetrics:
                         stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "125658222592"
+                - asInt: "149281173504"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 021327b7039db9dd913ba2beb4625bf3f2d522805decbeb30d3844953d689895
+                        stringValue: 04b9ef1239f4dd659aa48887c488d69ef2e1eb4ab0c558ad303788fd41c79fab
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: targetallocator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 18f56251ddf0003eaa7a3f9dad5151d8be06cb53fa24bc0abe58fc6b5be798c6
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3705,358 +5637,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "125658222592"
+                - asInt: "149281173504"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 0a1903dcb4d0fdd4279b401318013e772a755df50a54714195cf5b81132ae688
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0b7de24593b9e9b9c4dcb6424f1e829e3232aac96921586aa5b4876e34fffead
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: nodejs-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: nodejs-test-d454cf769-n4whd
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0f663224843198b71d0acbd6738008173478ad97f79ed2411ba7a3d6014f69f4
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-cainjector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2118c058c65a24bcf948d3b082c7d24a957ee636d8bfc9a31dec1c700912daf2
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-5dd5756b68-ttp4s
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2188e5dbd44970ada6bb9b4adc1190534cec2034ed4bbbefe39b998b762c8090
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-controller-manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-controller-manager-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 23c653fde53fcb3b3dd7f586ed165f5621f786f1bd68f9ed18caaa132177a05e
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 3c4c69e6395265782987df7e1a9ad2ce992b5fdce80124c6608594c54d069b4a
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: local-path-provisioner
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: local-path-storage
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 450386c43051a8d554ba7b41fb6fd35740fad2ee77f6a5be5f7d7b366934fa37
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: etcd
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: etcd-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 47a8c0881856e8eebf6dead289f5605bf7e6e159131148313ff44b43f93792ab
+                        stringValue: 1a9416b266db5076bdc7a4a552bbd5382cc9c9f09a00d32274c3324381ff687f
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -4083,232 +5679,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "125658222592"
+                - asInt: "149281173504"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 49285c01fa935e13e79252d57fb188b1c72b317328df453f855fd7307bf6166a
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-5dd5756b68-x8jcx
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 4bd3dfa8576441902eb944836f6752aeb3d5fbd24b17e3984e9f88b205096130
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-proxy-zmds8
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 63c80e0ba2de4a1f83678a6dd53d96b507a07a8a18a45b9819e10498c9d851f0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: java-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: java-test-566495f78-6nhnc
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 9eec542c85daa232c5488c4f587671a6cf01f52ccddf663abd74b8b2f158e962
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-rbac-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: cdf2eb0fde3a64bdcb49a31753d8030ee0d3c9d55e27099c582ed524e7fa58e3
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-webhook
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "125658222592"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: dd4fd2423e56794193a5ccb18b4fd39dbf27ed97eacb1f282e92d108bc0bb2e9
+                        stringValue: 1b1930185f75d7381c08c4aa95a5f3307e9cb4fab444d43972b1c6d8fbf2f7e0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -4338,19 +5724,439 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "125658222592"
+                - asInt: "149281173504"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f42485d9874a9b0458270281ba2b5c76679bf622b30c92c54b696a5a81b5d7c0
+                        stringValue: 2d009e1adcdf71017ba9bf6fd7c8619f65828f628731e240f9d6e4bdf8d2ef05
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-cjfpv
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 2d9b25eac7f522173184bab2706990f23069ec4f5c8eeb7b9bb5b5ba58353cb7
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-proxy
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-proxy-6vc2p
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 43d2186cb60b7090e5c7d77884c1b20760d820388acbdf1290a722017176667f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-webhook
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 4ace844b6d5dd4b77bf14d96fe98860916d7c04d6201a8126c369da1f827dd4d
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 5f96c636d73fd8b023b305c11c9f8639c1fcf9ac86d8026eaa6cdaa246d6daf5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6eba76e8e8b34c5b6752f8bddb3e6ec85ee418a9c7ad68e92c9941d73d2db6bb
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-controller-manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-controller-manager-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 7318f6ee73f6b12fa94da8dbd1e376a09a53a2555dff9890414dd14b817ebea4
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: local-path-provisioner
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: local-path-storage
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 80ebc82669280f1b7b75fe421dc688767e8e3a8d994c03586774ac60ab0bbcef
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-786c6c9777-phk4x
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 87aa0b7b0a21f922d64ae695ebaf92223a716dcbacaa3ab86acf1844350daede
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: dotnet-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: dotnet-test-5479c475fc-z54vg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 8e39e2ef0bd7c184c7fd92ffe57859eed2e83b2e623643b241b7a30c5486e2e6
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 92f92bf46126ea0711d2d226d0c7e9341a49228e406ea399c973fe620a4568ac
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -4377,10 +6183,472 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-wrk68
+                        stringValue: kindnet-rcfnj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 9fc249d17a20e04b5111ffba1b7385e386d1079dbcced79c07b1c23238a0805f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-t987l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: a523b442f64ec462b3df12c58bbb5e008c29821d5e51f2081010a0fbc25a72ca
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: etcd
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: etcd-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: ac13e7a1f72ee47bc2dfa61763a7435541d55c4e55b56e6769d9f939747ec3cd
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: nodejs-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: b06077b599f13110494440544cd40c2154f1374cbec3dc347e21c7be4022844e
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bcc4f3a6b60298430fc56c2ad850940155bd2890d77d6fa7421281d61047f437
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bfabcd9fcca4b4fcca79b128f9baa1d5b21081e2b2a0a1244da303977823b5cd
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cf04df7f2aa2fd14983011fda7ee61603a9f366aff018a6193e0c2e7c635bea5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-cainjector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cfca01a7f060f4dc3ce9c9c8ce2e61aa6889f8271a56618c301ddee2a6f392c3
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dc67528efcf8c0b26e7a5a1c1130c6878b1dfc1f633f598949a8b8c4a5becd55
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-rbac-proxy
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-786c6c9777-phk4x
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: e478d92439bba6b65361da3ec55c78dd82c464bc912e1a2cc6e17fd7bd2ed29d
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: java-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: java-test-5c4d6479b8-xzsgh
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149281173504"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: f03951f790e0a191ae8980950ca870e3cd48881b24d313b1ea71068bc2f25cdb
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: prometheus-annotation-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
                     - key: os.type
                       value:
                         stringValue: linux
@@ -4395,7 +6663,7 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 0200fab216c7ccb291be3d1799f862bd8488cb786b4b1f50abc4e778dc130a3d
+                        stringValue: 04a9e15354b63850372c24d01717fb45a584eeeb5df32639f07b753665f0133c
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -4425,19 +6693,61 @@ resourceMetrics:
                         stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "143360"
+                - asInt: "49152"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 021327b7039db9dd913ba2beb4625bf3f2d522805decbeb30d3844953d689895
+                        stringValue: 04b9ef1239f4dd659aa48887c488d69ef2e1eb4ab0c558ad303788fd41c79fab
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: targetallocator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "102400"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 18f56251ddf0003eaa7a3f9dad5151d8be06cb53fa24bc0abe58fc6b5be798c6
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -4464,94 +6774,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "57344"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0a1903dcb4d0fdd4279b401318013e772a755df50a54714195cf5b81132ae688
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "32768"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0b7de24593b9e9b9c4dcb6424f1e829e3232aac96921586aa5b4876e34fffead
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: nodejs-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: nodejs-test-d454cf769-n4whd
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
                     - key: os.type
                       value:
                         stringValue: linux
@@ -4563,259 +6789,7 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 0f663224843198b71d0acbd6738008173478ad97f79ed2411ba7a3d6014f69f4
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-cainjector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "49152"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2118c058c65a24bcf948d3b082c7d24a957ee636d8bfc9a31dec1c700912daf2
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-5dd5756b68-ttp4s
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "73728"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2188e5dbd44970ada6bb9b4adc1190534cec2034ed4bbbefe39b998b762c8090
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-controller-manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-controller-manager-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "49152"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 23c653fde53fcb3b3dd7f586ed165f5621f786f1bd68f9ed18caaa132177a05e
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "40960"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 3c4c69e6395265782987df7e1a9ad2ce992b5fdce80124c6608594c54d069b4a
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: local-path-provisioner
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: local-path-storage
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "40960"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 450386c43051a8d554ba7b41fb6fd35740fad2ee77f6a5be5f7d7b366934fa37
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: etcd
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: etcd-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "36864"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 47a8c0881856e8eebf6dead289f5605bf7e6e159131148313ff44b43f93792ab
+                        stringValue: 1a9416b266db5076bdc7a4a552bbd5382cc9c9f09a00d32274c3324381ff687f
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -4842,220 +6816,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "49152"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 49285c01fa935e13e79252d57fb188b1c72b317328df453f855fd7307bf6166a
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-5dd5756b68-x8jcx
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "69632"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 4bd3dfa8576441902eb944836f6752aeb3d5fbd24b17e3984e9f88b205096130
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-proxy-zmds8
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "229376"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 63c80e0ba2de4a1f83678a6dd53d96b507a07a8a18a45b9819e10498c9d851f0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: java-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: java-test-566495f78-6nhnc
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "36864"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 9eec542c85daa232c5488c4f587671a6cf01f52ccddf663abd74b8b2f158e962
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-rbac-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "36864"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: cdf2eb0fde3a64bdcb49a31753d8030ee0d3c9d55e27099c582ed524e7fa58e3
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-webhook
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
@@ -5067,7 +6831,7 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: dd4fd2423e56794193a5ccb18b4fd39dbf27ed97eacb1f282e92d108bc0bb2e9
+                        stringValue: 1b1930185f75d7381c08c4aa95a5f3307e9cb4fab444d43972b1c6d8fbf2f7e0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5097,7 +6861,49 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "49152"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 2d009e1adcdf71017ba9bf6fd7c8619f65828f628731e240f9d6e4bdf8d2ef05
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-cjfpv
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
                     - key: os.type
                       value:
                         stringValue: linux
@@ -5109,7 +6915,7 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f42485d9874a9b0458270281ba2b5c76679bf622b30c92c54b696a5a81b5d7c0
+                        stringValue: 2d9b25eac7f522173184bab2706990f23069ec4f5c8eeb7b9bb5b5ba58353cb7
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5127,7 +6933,7 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: kindnet-cni
+                        stringValue: kube-proxy
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5136,25 +6942,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-wrk68
+                        stringValue: kube-proxy-6vc2p
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-            name: container.filesystem.usage
-          - gauge:
-              dataPoints:
-                - asInt: "409710592"
+                - asInt: "36864"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 0200fab216c7ccb291be3d1799f862bd8488cb786b4b1f50abc4e778dc130a3d
+                        stringValue: 43d2186cb60b7090e5c7d77884c1b20760d820388acbdf1290a722017176667f
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5172,31 +6975,73 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: kube-apiserver
+                        stringValue: cert-manager-webhook
                     - key: k8s.namespace.name
                       value:
-                        stringValue: kube-system
+                        stringValue: cert-manager
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kube-apiserver-kind-control-plane
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "208982016"
+                - asInt: "323584"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 021327b7039db9dd913ba2beb4625bf3f2d522805decbeb30d3844953d689895
+                        stringValue: 4ace844b6d5dd4b77bf14d96fe98860916d7c04d6201a8126c369da1f827dd4d
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "49152"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 5f96c636d73fd8b023b305c11c9f8639c1fcf9ac86d8026eaa6cdaa246d6daf5
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5223,190 +7068,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "20529152"
+                - asInt: "73728"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 0a1903dcb4d0fdd4279b401318013e772a755df50a54714195cf5b81132ae688
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "43945984"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0b7de24593b9e9b9c4dcb6424f1e829e3232aac96921586aa5b4876e34fffead
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: nodejs-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: nodejs-test-d454cf769-n4whd
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "25894912"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0f663224843198b71d0acbd6738008173478ad97f79ed2411ba7a3d6014f69f4
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-cainjector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "19079168"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2118c058c65a24bcf948d3b082c7d24a957ee636d8bfc9a31dec1c700912daf2
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-5dd5756b68-ttp4s
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "54239232"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2188e5dbd44970ada6bb9b4adc1190534cec2034ed4bbbefe39b998b762c8090
+                        stringValue: 6eba76e8e8b34c5b6752f8bddb3e6ec85ee418a9c7ad68e92c9941d73d2db6bb
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5436,61 +7113,19 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "84807680"
+                - asInt: "40960"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 23c653fde53fcb3b3dd7f586ed165f5621f786f1bd68f9ed18caaa132177a05e
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "9072640"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 3c4c69e6395265782987df7e1a9ad2ce992b5fdce80124c6608594c54d069b4a
+                        stringValue: 7318f6ee73f6b12fa94da8dbd1e376a09a53a2555dff9890414dd14b817ebea4
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5517,22 +7152,232 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "63619072"
+                - asInt: "57344"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 450386c43051a8d554ba7b41fb6fd35740fad2ee77f6a5be5f7d7b366934fa37
+                        stringValue: 80ebc82669280f1b7b75fe421dc688767e8e3a8d994c03586774ac60ab0bbcef
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-786c6c9777-phk4x
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "69632"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 87aa0b7b0a21f922d64ae695ebaf92223a716dcbacaa3ab86acf1844350daede
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: dotnet-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: dotnet-test-5479c475fc-z54vg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "323584"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 8e39e2ef0bd7c184c7fd92ffe57859eed2e83b2e623643b241b7a30c5486e2e6
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "69632"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 92f92bf46126ea0711d2d226d0c7e9341a49228e406ea399c973fe620a4568ac
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kindnet-cni
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kindnet-rcfnj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "49152"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 9fc249d17a20e04b5111ffba1b7385e386d1079dbcced79c07b1c23238a0805f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-t987l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "40960"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: a523b442f64ec462b3df12c58bbb5e008c29821d5e51f2081010a0fbc25a72ca
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5562,19 +7407,19 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "27291648"
+                - asInt: "16384"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 47a8c0881856e8eebf6dead289f5605bf7e6e159131148313ff44b43f93792ab
+                        stringValue: ac13e7a1f72ee47bc2dfa61763a7435541d55c4e55b56e6769d9f939747ec3cd
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5592,133 +7437,7 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: cert-manager-controller
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "17018880"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 49285c01fa935e13e79252d57fb188b1c72b317328df453f855fd7307bf6166a
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-5dd5756b68-x8jcx
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "18698240"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 4bd3dfa8576441902eb944836f6752aeb3d5fbd24b17e3984e9f88b205096130
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-proxy-zmds8
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "256647168"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 63c80e0ba2de4a1f83678a6dd53d96b507a07a8a18a45b9819e10498c9d851f0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: java-test
+                        stringValue: nodejs-test
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -5727,22 +7446,232 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: java-test-566495f78-6nhnc
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "10100736"
+                - asInt: "323584"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 9eec542c85daa232c5488c4f587671a6cf01f52ccddf663abd74b8b2f158e962
+                        stringValue: b06077b599f13110494440544cd40c2154f1374cbec3dc347e21c7be4022844e
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "323584"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bcc4f3a6b60298430fc56c2ad850940155bd2890d77d6fa7421281d61047f437
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "323584"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bfabcd9fcca4b4fcca79b128f9baa1d5b21081e2b2a0a1244da303977823b5cd
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "36864"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cf04df7f2aa2fd14983011fda7ee61603a9f366aff018a6193e0c2e7c635bea5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-cainjector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "323584"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cfca01a7f060f4dc3ce9c9c8ce2e61aa6889f8271a56618c301ddee2a6f392c3
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "36864"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dc67528efcf8c0b26e7a5a1c1130c6878b1dfc1f633f598949a8b8c4a5becd55
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5769,22 +7698,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
+                        stringValue: sock-operator-786c6c9777-phk4x
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "16199680"
+                - asInt: "212992"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: cdf2eb0fde3a64bdcb49a31753d8030ee0d3c9d55e27099c582ed524e7fa58e3
+                        stringValue: e478d92439bba6b65361da3ec55c78dd82c464bc912e1a2cc6e17fd7bd2ed29d
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5802,7 +7731,220 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: cert-manager-webhook
+                        stringValue: java-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: java-test-5c4d6479b8-xzsgh
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "24576"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: f03951f790e0a191ae8980950ca870e3cd48881b24d313b1ea71068bc2f25cdb
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: prometheus-annotation-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: container.filesystem.usage
+          - gauge:
+              dataPoints:
+                - asInt: "507342848"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 04a9e15354b63850372c24d01717fb45a584eeeb5df32639f07b753665f0133c
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-apiserver
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-apiserver-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "22716416"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 04b9ef1239f4dd659aa48887c488d69ef2e1eb4ab0c558ad303788fd41c79fab
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: targetallocator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "295055360"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 18f56251ddf0003eaa7a3f9dad5151d8be06cb53fa24bc0abe58fc6b5be798c6
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "28819456"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 1a9416b266db5076bdc7a4a552bbd5382cc9c9f09a00d32274c3324381ff687f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-controller
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -5811,22 +7953,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "21921792"
+                - asInt: "33705984"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: dd4fd2423e56794193a5ccb18b4fd39dbf27ed97eacb1f282e92d108bc0bb2e9
+                        stringValue: 1b1930185f75d7381c08c4aa95a5f3307e9cb4fab444d43972b1c6d8fbf2f7e0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -5856,276 +7998,19 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "8232960"
+                - asInt: "40591360"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f42485d9874a9b0458270281ba2b5c76679bf622b30c92c54b696a5a81b5d7c0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kindnet-cni
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kindnet-wrk68
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-            name: container.memory.usage
-          - name: container_cpu_utilization
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1690"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0200fab216c7ccb291be3d1799f862bd8488cb786b4b1f50abc4e778dc130a3d
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-apiserver
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-apiserver-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 51acb728ea8dc3a01b43334942491036
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "272"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 021327b7039db9dd913ba2beb4625bf3f2d522805decbeb30d3844953d689895
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-znqzs
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 3f2777cd-e7ce-485d-a92c-43c0a2aadee5
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "38"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0a1903dcb4d0fdd4279b401318013e772a755df50a54714195cf5b81132ae688
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "106"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0b7de24593b9e9b9c4dcb6424f1e829e3232aac96921586aa5b4876e34fffead
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: nodejs-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: nodejs-test-d454cf769-n4whd
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 1f680502-7878-451f-8880-2ca25419ce4d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "35"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 0f663224843198b71d0acbd6738008173478ad97f79ed2411ba7a3d6014f69f4
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-cainjector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-cainjector-6cc9b5f678-zm6qg
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c17bb001-2b34-4173-993b-47cc1d285f3d
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "44"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2118c058c65a24bcf948d3b082c7d24a957ee636d8bfc9a31dec1c700912daf2
+                        stringValue: 2d009e1adcdf71017ba9bf6fd7c8619f65828f628731e240f9d6e4bdf8d2ef05
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6152,22 +8037,190 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-ttp4s
+                        stringValue: coredns-5dd5756b68-cjfpv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8a841abc-5346-4344-81d4-8fc298823892
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "410"
+                - asInt: "33460224"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 2188e5dbd44970ada6bb9b4adc1190534cec2034ed4bbbefe39b998b762c8090
+                        stringValue: 2d9b25eac7f522173184bab2706990f23069ec4f5c8eeb7b9bb5b5ba58353cb7
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-proxy
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-proxy-6vc2p
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "15593472"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 43d2186cb60b7090e5c7d77884c1b20760d820388acbdf1290a722017176667f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-webhook
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "10686464"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 4ace844b6d5dd4b77bf14d96fe98860916d7c04d6201a8126c369da1f827dd4d
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "130797568"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 5f96c636d73fd8b023b305c11c9f8639c1fcf9ac86d8026eaa6cdaa246d6daf5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "82173952"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6eba76e8e8b34c5b6752f8bddb3e6ec85ee418a9c7ad68e92c9941d73d2db6bb
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6197,61 +8250,19 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: f98b4cfedb968e3c798bae6ff1faa58d
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "87"
+                - asInt: "12070912"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 23c653fde53fcb3b3dd7f586ed165f5621f786f1bd68f9ed18caaa132177a05e
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: deployment.environment
-                      value:
-                        stringValue: dev
-                    - key: host.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-587576d5842876t
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 73bb8d19-b190-42e9-a77d-c84ef587bd02
-                    - key: os.type
-                      value:
-                        stringValue: linux
-                  timeUnixNano: "1000000"
-                - asInt: "17"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 3c4c69e6395265782987df7e1a9ad2ce992b5fdce80124c6608594c54d069b4a
+                        stringValue: 7318f6ee73f6b12fa94da8dbd1e376a09a53a2555dff9890414dd14b817ebea4
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6278,22 +8289,232 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48-4bmw5
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 6099916d-c417-4145-b1e8-a68a083a4e36
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "592"
+                - asInt: "18907136"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 450386c43051a8d554ba7b41fb6fd35740fad2ee77f6a5be5f7d7b366934fa37
+                        stringValue: 80ebc82669280f1b7b75fe421dc688767e8e3a8d994c03586774ac60ab0bbcef
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-786c6c9777-phk4x
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "149598208"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 87aa0b7b0a21f922d64ae695ebaf92223a716dcbacaa3ab86acf1844350daede
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: dotnet-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: dotnet-test-5479c475fc-z54vg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "10686464"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 8e39e2ef0bd7c184c7fd92ffe57859eed2e83b2e623643b241b7a30c5486e2e6
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "14876672"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 92f92bf46126ea0711d2d226d0c7e9341a49228e406ea399c973fe620a4568ac
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kindnet-cni
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kindnet-rcfnj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "37355520"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 9fc249d17a20e04b5111ffba1b7385e386d1079dbcced79c07b1c23238a0805f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-t987l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "197545984"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: a523b442f64ec462b3df12c58bbb5e008c29821d5e51f2081010a0fbc25a72ca
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6323,19 +8544,19 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 8640ede3763d523342ced9ba7a5fd080
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "59"
+                - asInt: "44867584"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 47a8c0881856e8eebf6dead289f5605bf7e6e159131148313ff44b43f93792ab
+                        stringValue: ac13e7a1f72ee47bc2dfa61763a7435541d55c4e55b56e6769d9f939747ec3cd
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6353,7 +8574,175 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: cert-manager-controller
+                        stringValue: nodejs-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "10682368"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: b06077b599f13110494440544cd40c2154f1374cbec3dc347e21c7be4022844e
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "10686464"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bcc4f3a6b60298430fc56c2ad850940155bd2890d77d6fa7421281d61047f437
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "10682368"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bfabcd9fcca4b4fcca79b128f9baa1d5b21081e2b2a0a1244da303977823b5cd
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "27795456"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cf04df7f2aa2fd14983011fda7ee61603a9f366aff018a6193e0c2e7c635bea5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-cainjector
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -6362,22 +8751,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-5c9d8879fd-zqcdv
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
                     - key: k8s.pod.uid
                       value:
-                        stringValue: dd68fc3a-2f3f-440d-a7e7-618aebbf2090
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "50"
+                - asInt: "10686464"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 49285c01fa935e13e79252d57fb188b1c72b317328df453f855fd7307bf6166a
+                        stringValue: cfca01a7f060f4dc3ce9c9c8ce2e61aa6889f8271a56618c301ddee2a6f392c3
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6395,31 +8784,31 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: coredns
+                        stringValue: pod-w-index-w-ns-exclude
                     - key: k8s.namespace.name
                       value:
-                        stringValue: kube-system
+                        stringValue: ns-w-index
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-5dd5756b68-x8jcx
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 662cb1aa-7d77-4a28-813a-3abe808e9a04
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "40"
+                - asInt: "13787136"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 4bd3dfa8576441902eb944836f6752aeb3d5fbd24b17e3984e9f88b205096130
+                        stringValue: dc67528efcf8c0b26e7a5a1c1130c6878b1dfc1f633f598949a8b8c4a5becd55
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6437,31 +8826,31 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: kube-proxy
+                        stringValue: kube-rbac-proxy
                     - key: k8s.namespace.name
                       value:
-                        stringValue: kube-system
+                        stringValue: default
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kube-proxy-zmds8
+                        stringValue: sock-operator-786c6c9777-phk4x
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3252bcd4-1aa0-4a8d-ad6e-fa3cee960076
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "1142"
+                - asInt: "289685504"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 63c80e0ba2de4a1f83678a6dd53d96b507a07a8a18a45b9819e10498c9d851f0
+                        stringValue: e478d92439bba6b65361da3ec55c78dd82c464bc912e1a2cc6e17fd7bd2ed29d
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6488,10 +8877,99 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: java-test-566495f78-6nhnc
+                        stringValue: java-test-5c4d6479b8-xzsgh
                     - key: k8s.pod.uid
                       value:
-                        stringValue: fbc84ba5-3b1f-4754-b3f3-76e86eace74e
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "171044864"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: f03951f790e0a191ae8980950ca870e3cd48881b24d313b1ea71068bc2f25cdb
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: prometheus-annotation-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+            name: container.memory.usage
+          - name: container_cpu_utilization
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "37490"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 04a9e15354b63850372c24d01717fb45a584eeeb5df32639f07b753665f0133c
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-apiserver
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-apiserver-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 021ea1f4839617eef00a93c39d62616b
                     - key: os.type
                       value:
                         stringValue: linux
@@ -6503,7 +8981,7 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 9eec542c85daa232c5488c4f587671a6cf01f52ccddf663abd74b8b2f158e962
+                        stringValue: 04b9ef1239f4dd659aa48887c488d69ef2e1eb4ab0c558ad303788fd41c79fab
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6521,7 +8999,7 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: kube-rbac-proxy
+                        stringValue: targetallocator
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -6530,22 +9008,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-6cf5597fb6-nkvgb
+                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-b5wr2
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 24d849c7-da2c-4598-a307-9deba65ed5a8
+                        stringValue: 910a536b-e6c5-40da-a35a-d1dd32e9205d
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "22"
+                - asInt: "309"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: cdf2eb0fde3a64bdcb49a31753d8030ee0d3c9d55e27099c582ed524e7fa58e3
+                        stringValue: 18f56251ddf0003eaa7a3f9dad5151d8be06cb53fa24bc0abe58fc6b5be798c6
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6563,7 +9041,49 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: cert-manager-webhook
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-w9hjj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 65b5fa2c-533d-4862-a1f4-31e008b9ef25
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "70"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 1a9416b266db5076bdc7a4a552bbd5382cc9c9f09a00d32274c3324381ff687f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-controller
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -6572,22 +9092,22 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-webhook-7bb7b75848-kbgq5
+                        stringValue: cert-manager-67c98b89c8-tklft
                     - key: k8s.pod.uid
                       value:
-                        stringValue: a21b8615-7e13-46d7-b4e8-8ae1e4a5c79f
+                        stringValue: fc0c659e-8f7a-4dbd-b7a0-d391302b05ae
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "168"
+                - asInt: "1943"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: dd4fd2423e56794193a5ccb18b4fd39dbf27ed97eacb1f282e92d108bc0bb2e9
+                        stringValue: 1b1930185f75d7381c08c4aa95a5f3307e9cb4fab444d43972b1c6d8fbf2f7e0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6617,19 +9137,439 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 90194206b3ac749a8da43c61fd4761ca
+                        stringValue: df1f09f3a1f003b8825519a3341f69fe
                     - key: os.type
                       value:
                         stringValue: linux
                   timeUnixNano: "1000000"
-                - asInt: "20"
+                - asInt: "1192"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f42485d9874a9b0458270281ba2b5c76679bf622b30c92c54b696a5a81b5d7c0
+                        stringValue: 2d009e1adcdf71017ba9bf6fd7c8619f65828f628731e240f9d6e4bdf8d2ef05
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-cjfpv
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: bb3e0f4c-b1dd-4a87-8569-0295e59f0172
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "551"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 2d9b25eac7f522173184bab2706990f23069ec4f5c8eeb7b9bb5b5ba58353cb7
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-proxy
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-proxy-6vc2p
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 065f1562-205d-48d7-b333-756581f19889
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "330"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 43d2186cb60b7090e5c7d77884c1b20760d820388acbdf1290a722017176667f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-webhook
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-webhook-7f9f8648b9-7zfg8
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: bdaedacc-8e17-4dcb-bf50-feb5444aaae9
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "19"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 4ace844b6d5dd4b77bf14d96fe98860916d7c04d6201a8126c369da1f827dd4d
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-index-z2sb5
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: d227ec94-4191-4af2-9d2f-8fa2e6172fab
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "79"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 5f96c636d73fd8b023b305c11c9f8639c1fcf9ac86d8026eaa6cdaa246d6daf5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-86f6f86687fzjzd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 25bf4087-036a-470e-acd5-e865f19a0f22
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "10749"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6eba76e8e8b34c5b6752f8bddb3e6ec85ee418a9c7ad68e92c9941d73d2db6bb
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-controller-manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-controller-manager-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 78e1474ee2ca64de6cd3283ddf989107
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "384"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 7318f6ee73f6b12fa94da8dbd1e376a09a53a2555dff9890414dd14b817ebea4
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: local-path-provisioner
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: local-path-storage
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: local-path-provisioner-6f8956fb48-7tmsz
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: ac368bde-a73b-4922-88d0-9cb4ee96b04d
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "12"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 80ebc82669280f1b7b75fe421dc688767e8e3a8d994c03586774ac60ab0bbcef
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-786c6c9777-phk4x
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "489"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 87aa0b7b0a21f922d64ae695ebaf92223a716dcbacaa3ab86acf1844350daede
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: dotnet-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: dotnet-test-5479c475fc-z54vg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: c9658966-e100-488c-a0b5-ee45b1b6020f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "19"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 8e39e2ef0bd7c184c7fd92ffe57859eed2e83b2e623643b241b7a30c5486e2e6
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-wo-ns-index-z4m9l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3ad6b8b5-fb6a-4ccc-8d73-8b234c8e78b7
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "292"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 92f92bf46126ea0711d2d226d0c7e9341a49228e406ea399c973fe620a4568ac
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -6656,10 +9596,472 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-wrk68
+                        stringValue: kindnet-rcfnj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e72734dd-e62d-4528-b718-d79e757c0900
+                        stringValue: dd4673cc-6cd7-452c-a140-94610772ff50
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "1166"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 9fc249d17a20e04b5111ffba1b7385e386d1079dbcced79c07b1c23238a0805f
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-5dd5756b68-t987l
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 2a107f01-3923-4761-bff8-a52f236e5427
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "12630"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: a523b442f64ec462b3df12c58bbb5e008c29821d5e51f2081010a0fbc25a72ca
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: etcd
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: etcd-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: a652c9e3a037b7be2906ed0ac7fea632
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "96"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: ac13e7a1f72ee47bc2dfa61763a7435541d55c4e55b56e6769d9f939747ec3cd
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: nodejs-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: nodejs-test-56b74df9ff-6r2jz
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9da77355-0eca-4520-98fd-7b6da86678ff
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "20"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: b06077b599f13110494440544cd40c2154f1374cbec3dc347e21c7be4022844e
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-wo-index-w-ns-index-dd9m7
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 74e269c2-efd8-488b-babd-36919dfa4071
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "18"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bcc4f3a6b60298430fc56c2ad850940155bd2890d77d6fa7421281d61047f437
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-wo-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-wo-ns-index-ml4fm
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: cd97d933-6663-403d-ad29-3d1a3d4ed303
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "18"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bfabcd9fcca4b4fcca79b128f9baa1d5b21081e2b2a0a1244da303977823b5cd
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-exclude
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude-2j6nl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 9e49cf9b-e287-4b2b-8c82-e6040ac9a2c8
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "661"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cf04df7f2aa2fd14983011fda7ee61603a9f366aff018a6193e0c2e7c635bea5
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-cainjector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-cainjector-5c5695d979-cqf9t
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 755fd92a-5b0a-4bf1-b80c-af639eec21d4
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "18"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: cfca01a7f060f4dc3ce9c9c8ce2e61aa6889f8271a56618c301ddee2a6f392c3
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: pod-w-index-w-ns-exclude
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: ns-w-index
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: pod-w-exclude-wo-ns-exclude-p6cz4
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: f8b3ab44-45b2-47aa-94ca-028ce75064cd
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "33"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dc67528efcf8c0b26e7a5a1c1130c6878b1dfc1f633f598949a8b8c4a5becd55
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-rbac-proxy
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-786c6c9777-phk4x
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e22ffbc6-3a0e-4fc3-ba9a-c1f5b05a8099
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "1068"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: e478d92439bba6b65361da3ec55c78dd82c464bc912e1a2cc6e17fd7bd2ed29d
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: java-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: java-test-5c4d6479b8-xzsgh
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 481236e3-3e30-4677-b3f2-36536e232d7f
+                    - key: os.type
+                      value:
+                        stringValue: linux
+                  timeUnixNano: "1000000"
+                - asInt: "25"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: f03951f790e0a191ae8980950ca870e3cd48881b24d313b1ea71068bc2f25cdb
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: deployment.environment
+                      value:
+                        stringValue: dev
+                    - key: host.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: prometheus-annotation-test
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: prometheus-annotation-test-cfc77c7b9-ks5mj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 8470da39-482b-47e0-adf3-46e4687b7abe
                     - key: os.type
                       value:
                         stringValue: linux

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -334,7 +334,7 @@ spec:
           # is resolved fall back to previous gopsutil mountinfo path:
           # https://github.com/shirou/gopsutil/issues/1271
           - name: HOST_PROC_MOUNTINFO
-            value: /proc/self/mountinfo
+            value: /hostfs/proc/self/mountinfo
           {{- end }}
           {{- end }}
           {{- with $agent.extraEnvs }}
@@ -370,23 +370,8 @@ spec:
           name: hostfs
           readOnly: true
         {{- else }}
-        - mountPath: /hostfs/dev
-          name: host-dev
-          readOnly: true
-        - mountPath: /hostfs/etc
-          name: host-etc
-          readOnly: true
-        - mountPath: /hostfs/proc
-          name: host-proc
-          readOnly: true
-        - mountPath: /hostfs/run/udev/data
-          name: host-run-udev-data
-          readOnly: true
-        - mountPath: /hostfs/sys
-          name: host-sys
-          readOnly: true
-        - mountPath: /hostfs/var/run/utmp
-          name: host-var-run-utmp
+        - mountPath: "/hostfs"
+          name: hostfs
           readOnly: true
         {{- end }}
         {{- end }}
@@ -534,24 +519,9 @@ spec:
         hostPath:
           path: "C:\\"
       {{- else }}
-      - name: host-dev
+      - name: hostfs
         hostPath:
-          path: /dev
-      - name: host-etc
-        hostPath:
-          path: /etc
-      - name: host-proc
-        hostPath:
-          path: /proc
-      - name: host-run-udev-data
-        hostPath:
-          path: /run/udev/data
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: host-var-run-utmp
-        hostPath:
-          path: /var/run/utmp
+          path: /
       {{- end }}
       {{- end }}
       {{- if or .Values.splunkPlatform.clientCert .Values.splunkPlatform.clientKey .Values.splunkPlatform.caFile }}


### PR DESCRIPTION
**Description:**
Mount `/` under `/hostfs` and change the filesystem scraper to point it at this location to scrape filesystem information. Previously, the daemonset would scrape the container filesystem.
