### PR TITLE
Add continuous discovery base config

### DIFF
--- a/.chloggen/support-continuous-discovery.yaml
+++ b/.chloggen/support-continuous-discovery.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add base configuration to support the new continuous discovery mechanism.
+# One or more tracking issues related to the change
+issues: [1455]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The new continuous discovery mechanism is disabled by default. To enable it, set the following values in your configuration:
+  ```yaml
+  agent:
+    discovery:
+      enabled: true
+    featureGates: splunk.continuousDiscovery
+  ```

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -321,6 +325,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -427,6 +432,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 379191976bf8590ad7e28867db39ef860a5b8288f15e5447560acd995bffca92
+        checksum/config: 1bc174d019b1c0db3200781d141bdd85e9956f229ef928020bc12b3290028dee
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -277,6 +281,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -381,6 +386,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 446deacf2fb4a314a607bda26d2da8d80016d1c88faa9d88a868e981119366e7
+        checksum/config: f8b0951fbade08c1605716def0c78e1514810cfe54beef78b899a3e3ce6add6e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -255,6 +260,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f506fde2e1c045a5e06cfa7176b1dd43440e4d8c903a05551405e9e868dd00bb
+        checksum/config: 98e50d7ce98b2f70056a31c79829bf02263eb9d81934c482e32e8bd715400026
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -155,6 +159,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -243,6 +248,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f042b32c7cc95bd6c58332db9048108f22dfa29b3be87a3d909f7247e217685c
+        checksum/config: 365f0d879a8599abd84038331f731b37b7a55c2875d52b87e33770cca289d401
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -305,6 +309,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -418,6 +423,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b5c3e6847ba7993a1c4b7a15de6b0117cb384b7337ed3c4a2fdb6501cb1ccb90
+        checksum/config: 7d3210b22369837962ec7deed92dd19372b0532162e4a127073e6b1f22033468
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -240,6 +245,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5a39391fc66bd7214fec8a5c9a3da45906a1c3452d0486e6f8237a0b39b001a3
+        checksum/config: b506fcb2eda95e2613d376d65e49f1d5539018515b2046dd3cd8b04fc3597c88
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -22,6 +22,10 @@ data:
         endpoint: default-splunk-otel-collector:4317
         tls:
           insecure: true
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: http://default-splunk-otel-collector:6060
@@ -138,6 +142,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -226,6 +231,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - otlp

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a5a0800df4928794d4d1d98c1eb38802a511500837f1dc3b61ba6119c1ed91a2
+        checksum/config: eb7a4cf01962cb23d26c6068d188218df86c4c6d333c14f55b5286a4ffe09fd4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -157,6 +161,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -270,6 +275,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d9741aa91358b9a172f276787e302ced538c6a42ddc05bf2ed68e46a4012193c
+        checksum/config: e666e7b4bc423939ae2ef5242a56a968b6afcbed3132ee3e2447ac682e9b8338
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -240,6 +245,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5a39391fc66bd7214fec8a5c9a3da45906a1c3452d0486e6f8237a0b39b001a3
+        checksum/config: b506fcb2eda95e2613d376d65e49f1d5539018515b2046dd3cd8b04fc3597c88
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -240,6 +245,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5a39391fc66bd7214fec8a5c9a3da45906a1c3452d0486e6f8237a0b39b001a3
+        checksum/config: b506fcb2eda95e2613d376d65e49f1d5539018515b2046dd3cd8b04fc3597c88
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest..signalfx.com/v3/event
       splunk_hec/platform_logs:
         disable_compression: true
         endpoint: CHANGEME
@@ -360,6 +364,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -462,6 +467,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - splunk_hec/platform_metrics

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c4576f6d8e4b20638854bf95c3a3e6510c6da43b88aac0775d4413518ae77b3b
+        checksum/config: f1c290e40534814d552579c9331b6ec1a5af4b5b855814ea976c2a2b37fc50d3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -240,6 +245,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 36b11f38c570e2d3f4c40f6f835b2aef41d13a34c79eae7ba113330e682e30f5
+        checksum/config: f3f28a82477eaa56e5dbaded4c5512addfb4001122405d7bb246152755f8e5e9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -154,6 +158,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -198,6 +203,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3a1042a526a489975d423825dd560533fe8b6131a63abcf2e31fcceff070c029
+        checksum/config: da5240bb4a1de116590d6b7750b99db50ea49a83acb3239b56923cd7bfd248df
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -154,6 +158,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -198,6 +203,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 88eff985222bb77d6f591f66179f90d4365ee40e375d94243487403c9b6c1004
+        checksum/config: 081666735c473888e942865abe359a10b643776414a028dd3bd3eb07a8fc947a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -153,6 +157,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -197,6 +202,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0bb21c02a062397b8e8b8684b7ba371807773935b4b7b1d1c56aba7ef59a7f21
+        checksum/config: 48d4df44a73478c6eb29a0d98595df1b425ef182bf78f7a1f1d6d43837be3581
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -153,6 +157,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -197,6 +202,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a084a243f3af25648300c93a07b105d78fc524f88fbd86f351cc421b2a00f53e
+        checksum/config: cf19671bc340821b61f7a26d38c2d0e752ed01ef987a6bc1ff40c27d3da22701
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -248,6 +253,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9c9adb4262f27887428807b44fd63ea9b8a1aebb7a295f319b935f9e10f05286
+        checksum/config: fcd54d773c0c8cbd13c07b8f65616de222f4722ada6d0c29d860dca190bb8779
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.us0.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.us0.signalfx.com/v2/trace
@@ -275,6 +279,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -380,6 +385,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b1bc869302318df654ba11a6fc823a7737e01a5287331748dada54684ea7d6ef
+        checksum/config: a7f7a6226a55cb21d0126b44642f2cc74d2491aacc439e76f8532d2e4f96d549
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest..signalfx.com/v3/event
       splunk_hec/platform_logs:
         disable_compression: true
         endpoint: CHANGEME
@@ -360,6 +364,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -462,6 +467,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - splunk_hec/platform_metrics

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ab8529b39129c5636211ce36afd97f4d5ee1cc753f6e4d5e832dc5a2c055c506
+        checksum/config: d047c0be996b7ed2d931bc0a6929fa5458f792e8df909bac24ab3122273e2673
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -134,6 +138,7 @@ data:
             endpoint: 0.0.0.0:14250
           thrift_http:
             endpoint: 0.0.0.0:14268
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -172,6 +177,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics/agent:
           exporters:
           - signalfx

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6b2d9be86854ba26c9d2c982601b0ed1d7d4d22f50413930c6be01b36df23a0a
+        checksum/config: 7030312d9a96ab0576b08e120b82d45aaa58d3a480eceee4df7e76fd9b9d9105
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -153,6 +157,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -242,6 +247,15 @@ data:
       - zpages
       - pprof
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 29357f01e67ab10a77046b5f262b226d0f94a80edde40f19c627e311669f8d15
+        checksum/config: 60b5b638bda3f92c7690861ab8ff0a5d0d66206201235ecdf9b9762d5162567f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -170,6 +174,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -273,6 +278,15 @@ data:
           receivers:
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 90ac9f70fa828aea08740003a8d0a2ffcf2f585c67daca42152f8fdf31b1fa56
+        checksum/config: 29b003b2b4c9c798a3bd47095da2bba1a3fa6c5527842dc0d40483551c912494
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -170,6 +174,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -273,6 +278,15 @@ data:
           receivers:
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3a8f21b268d7c4654672aa39b618517cfae5b011aea0135628d09a85c94653bf
+        checksum/config: d29f789b46200a9f4cbaa36533844ede4d14ecfaf7477a8b2d05a4bdb60c3fbc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -275,6 +279,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -379,6 +384,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3473d38f7e81231c0113e71894d5644d31ba52db7da15f55c10f4d98823f3949
+        checksum/config: fd9a96579a0cb2d988fce6919c31619cbeaeb117f26fb803ebb329f2eead05e5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest..signalfx.com/v3/event
       splunk_hec/platform_logs:
         disable_compression: true
         endpoint: CHANGEME
@@ -326,6 +330,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -425,6 +430,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - splunk_hec/platform_metrics

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 037041f2f74ac549eccc8eb1fe1c5d377ffa90aef174e7fcc3e144c39a296a36
+        checksum/config: db3ef9c48654bebf9a61ec8fdf88b9f46dee7a11f10bfdf4ffd9825300b26b56
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -140,6 +144,7 @@ data:
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:8006
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -188,6 +193,15 @@ data:
           receivers:
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics/agent:
           exporters:
           - signalfx

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4eacc47cddcade7859a615d18dabf368c29d11c36399a1293b0f4085fcf77f11
+        checksum/config: 63903c3b8e0d213b419328b8b2a9fc53387c66d50e8a1809aacd2d29332cc51f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -275,6 +279,7 @@ data:
         storage: file_storage
       fluentforward:
         endpoint: 0.0.0.0:8006
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -324,6 +329,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics/agent:
           exporters:
           - signalfx

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1a49c8de023ad5faa8558c8b150aa6ec473f394800921f414e3ea0ef6bbf6dfc
+        checksum/config: 251ec4ac746898fe628418d767380c81f566e11c56b1236d9525fa6e1e360eac
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -268,6 +272,7 @@ data:
         storage: file_storage
       fluentforward:
         endpoint: 0.0.0.0:8006
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -317,6 +322,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         logs/host:
           exporters:
           - splunk_hec/o11y

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 90f1ea9eb63784b50fb9ed5c38d763ba65520db309797d0156a69a1ba58184c1
+        checksum/config: 7fc290a4be8cd3eaf1edda9bf38bc23168cb4976fdae17e4612a9acf716ff11a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest..signalfx.com/v3/event
       splunk_hec/platform_metrics:
         disable_compression: true
         endpoint: CHANGEME
@@ -189,6 +193,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -272,6 +277,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - splunk_hec/platform_metrics

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e05e6330f924850375783532e8f15178f9eb52e4e1c1b70e2a9b68ab99e7fb8a
+        checksum/config: 4d009658324ec9b6b0ad5deed4d4caf92cdc82e339fc8e706e93fac7415fcdab
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -143,6 +147,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -226,6 +231,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: dfdffc9877bb3d65e300abad2ada60ebad048afc7866763f8a90b095bccd70e5
+        checksum/config: 83a8fa86acc6ebd29e383b141b07713ce3cafceeeb0c1b0514e6eeef0f0c7591
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -131,6 +135,7 @@ data:
             endpoint: 0.0.0.0:14250
           thrift_http:
             endpoint: 0.0.0.0:14268
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -169,6 +174,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics/agent:
           exporters:
           - signalfx

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3c0bb4895b0fe7466d2403dfe02d813290d9f45ca43da33a6861614991529c74
+        checksum/config: 1c1f43dcb1d554f4bd183ce3bd27667499970aaf60e1d79643113366c8beefe1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -22,6 +22,10 @@ data:
         endpoint: <custom-gateway-url>:4317
         tls:
           insecure: true
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -156,6 +160,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -247,6 +252,15 @@ data:
         logs:
           exporters:
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - otlp

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ba59307edaf63d4ad64b6d7634365539ca054208f7027d9cd38e7df76307f729
+        checksum/config: 28656fab4288d473f8951a3b80dc978122aec6ad362ff8eea4389fc8bf1e0628
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       signalfx:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
@@ -240,6 +244,7 @@ data:
         storage: file_storage
       fluentforward:
         endpoint: 0.0.0.0:8006
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -289,6 +294,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics/agent:
           exporters:
           - signalfx

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 61c1b10c82fe60d9a4382425d5ccbc9d440e108afd8d91af58f3259a46494c38
+        checksum/config: fc0c8c099fe7833d591932b4774abfd00170650b3bbd9694d16c9cfa7090d554
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest..signalfx.com/v3/event
       splunk_hec/platform_logs:
         disable_compression: true
         endpoint: http://localhost:8088/services/collector
@@ -255,6 +259,7 @@ data:
         storage: file_storage
       fluentforward:
         endpoint: 0.0.0.0:8006
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -304,6 +309,15 @@ data:
           - filelog
           - fluentforward
           - otlp
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
       telemetry:
         metrics:
           address: 0.0.0.0:8889

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 62cfe93758397670c4bb691577b664cbcc00652b0f0b23ae43823bd26e9fc550
+        checksum/config: 24418d96048a886f04181fef7544162f2280847856900d2468319eb4262855ad
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -248,6 +253,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d922ae47fd3be1c5cebb3674dfaa03a945bee2511e9b409123bdf83b57567ec3
+        checksum/config: 1737aacafbcae9815715deb2be88cb84f2ee5ff7175647e819c9acd22e91c960
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -240,6 +245,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5a39391fc66bd7214fec8a5c9a3da45906a1c3452d0486e6f8237a0b39b001a3
+        checksum/config: b506fcb2eda95e2613d376d65e49f1d5539018515b2046dd3cd8b04fc3597c88
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -18,6 +18,10 @@ metadata:
 data:
   relay: |
     exporters:
+      otlphttp/entities:
+        headers:
+          X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
+        logs_endpoint: https://ingest.CHANGEME.signalfx.com/v3/event
       sapm:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         endpoint: https://ingest.CHANGEME.signalfx.com/v2/trace
@@ -152,6 +156,7 @@ data:
         - container
         - pod
         - node
+      nop: null
       otlp:
         protocols:
           grpc:
@@ -248,6 +253,15 @@ data:
       - k8s_observer
       - zpages
       pipelines:
+        logs/entities:
+          exporters:
+          - otlphttp/entities
+          processors:
+          - memory_limiter
+          - batch
+          - resourcedetection
+          receivers:
+          - nop
         metrics:
           exporters:
           - signalfx

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7c85b5abe2e18e2a6232f0e96678a3fe08026f01c2623fb6b17c63f5a1799f78
+        checksum/config: fc22c6f675573e8501d39f35ffd4752e3fd3b2d79d6088a228750af4baaed8c3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true


### PR DESCRIPTION
The new continuous discovery mechanism is disabled by default. To enable it, set the following values in your configuration:
```yaml
agent:
  discovery:
    enabled: true
  featureGates: splunk.continuousDiscovery
```