### PR TITLE
Update the chart - collector agent can use a K8s service by default

### DIFF
--- a/.chloggen/agent-service-enabled.yaml
+++ b/.chloggen/agent-service-enabled.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: 'agent'
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The agent is now deployed with a Kubernetes service for receiving telemetry data by default
+# One or more tracking issues related to the change
+issues: [1485]

--- a/examples/add-filter-processor/rendered_manifests/service-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/add-kafkametrics-receiver/rendered_manifests/service-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/add-receiver-creator/rendered_manifests/service-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/add-sampler/rendered_manifests/service-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/autodetect-istio/rendered_manifests/service-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/collector-agent-only/rendered_manifests/service-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/collector-all-modes/rendered_manifests/service-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/controlplane-histogram-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/crio-logging/rendered_manifests/service-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/default/rendered_manifests/service-agent.yaml
+++ b/examples/default/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/disable-persistence-queue-traces/rendered_manifests/service-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/discovery-mode/rendered_manifests/service-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/distribution-aks/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/distribution-eks/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/distribution-gke-autopilot/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/distribution-gke/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/distribution-openshift/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
@@ -19,17 +19,12 @@ metadata:
     app.kubernetes.io/component: otel-operator
 spec:
   exporter:
-    endpoint: http://$(SPLUNK_OTEL_AGENT):4317
+    endpoint: http://default-splunk-otel-collector-agent.default.svc.cluster.local:4317
   propagators:
     - tracecontext
     - baggage
     - b3
   env:
-    - name: SPLUNK_OTEL_AGENT
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.hostIP
   apacheHttpd:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd:1.0.4
     env:
@@ -42,15 +37,10 @@ spec:
         value: "Splunk.OpenTelemetry.AutoInstrumentation.Plugin,Splunk.OpenTelemetry.AutoInstrumentation"
       - name: OTEL_RESOURCE_ATTRIBUTES
         value: splunk.zc.method=splunk-otel-dotnet:v1.7.0
-      - name: SPLUNK_OTEL_AGENT
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: status.hostIP
       # dotnet auto-instrumentation uses http/proto by default, so data must be sent to 4318 instead of 4317.
       # See: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(SPLUNK_OTEL_AGENT):4318
+        value: http://default-splunk-otel-collector-agent.default.svc.cluster.local:4318
   go:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-go:v0.10.1-alpha
     env:
@@ -61,15 +51,10 @@ spec:
     env:
       - name: OTEL_RESOURCE_ATTRIBUTES
         value: splunk.zc.method=splunk-otel-java:v2.8.1
-      - name: SPLUNK_OTEL_AGENT
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: status.hostIP
       # java auto-instrumentation uses http/proto by default, so data must be sent to 4318 instead of 4317.
       # See: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(SPLUNK_OTEL_AGENT):4318
+        value: http://default-splunk-otel-collector-agent.default.svc.cluster.local:4318
   nginx:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd:1.0.4
     env:
@@ -85,12 +70,7 @@ spec:
     env:
       - name: OTEL_RESOURCE_ATTRIBUTES
         value: splunk.zc.method=autoinstrumentation-python:0.44b0
-      - name: SPLUNK_OTEL_AGENT
-        valueFrom:
-          fieldRef:
-            apiVersion: v1
-            fieldPath: status.hostIP
       # python auto-instrumentation uses http/proto by default, so data must be sent to 4318 instead of 4317.
       # See: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://$(SPLUNK_OTEL_AGENT):4318
+        value: http://default-splunk-otel-collector-agent.default.svc.cluster.local:4318

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/service-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/enable-persistence-queue/rendered_manifests/service-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/enable-trace-sampling/rendered_manifests/service-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/service-agent.yaml
@@ -1,0 +1,51 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/enabled-pprof-extension/rendered_manifests/service-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/service-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/fluentd-refresh-interval/rendered_manifests/service-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/kubernetes-windows-nodes/rendered_manifests/service-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/service-agent.yaml
@@ -1,0 +1,59 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/multi-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/service-agent.yaml
@@ -1,0 +1,43 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/only-logs-fluentd/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/service-agent.yaml
@@ -1,0 +1,39 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/only-logs-otel/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/service-agent.yaml
@@ -1,0 +1,39 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/service-agent.yaml
@@ -1,0 +1,39 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/only-metrics-platform/rendered_manifests/service-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/service-agent.yaml
@@ -1,0 +1,39 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/only-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/service-agent.yaml
@@ -1,0 +1,39 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/only-traces/rendered_manifests/service-agent.yaml
+++ b/examples/only-traces/rendered_manifests/service-agent.yaml
@@ -1,0 +1,51 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/service-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/secret-validation/rendered_manifests/service-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/service-agent.yaml
@@ -1,0 +1,39 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/service-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/service-agent.yaml
@@ -1,0 +1,39 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/target-allocator/rendered_manifests/service-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/use-proxy/rendered_manifests/service-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/with-target-allocator/rendered_manifests/service-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/service-agent.yaml
@@ -1,0 +1,55 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.110.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.110.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.110.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-grpc
+    port: 14250
+    targetPort: jaeger-grpc
+    protocol: TCP
+  - name: jaeger-thrift
+    port: 14268
+    targetPort: jaeger-thrift
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: sfx-forwarder
+    port: 9080
+    targetPort: sfx-forwarder
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  - name: zipkin
+    port: 9411
+    targetPort: zipkin
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -404,7 +404,7 @@ agent:
   service:
     # create a service for the agents with a local internalTrafficPolicy
     # so that agent pods can be discovered via dns etc
-    enabled: false
+    enabled: true
 
   # hostNetwork schedules the pod with the host's network namespace.
   # Disabling this value will affect monitoring of some control plane

--- a/test/unittests/operator_customized_test.yaml
+++ b/test/unittests/operator_customized_test.yaml
@@ -10,7 +10,7 @@ tests:
           count: 1
       - equal:
           path: spec.exporter.endpoint
-          value: http://RELEASE-NAME-splunk-otel-collector:4317
+          value: http://RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4317
       - contains:
           path: spec.env
           content:
@@ -25,7 +25,7 @@ tests:
           path: spec.nodejs.env
           content:
             name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: "http://$(NODEJS_OTEL_AGENT):4318"
+            value: "http://RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4318"
       - contains:
           path: spec.nodejs.env
           content:

--- a/test/unittests/operator_customized_test.yaml
+++ b/test/unittests/operator_customized_test.yaml
@@ -25,7 +25,7 @@ tests:
           path: spec.nodejs.env
           content:
             name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: "http://RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4318"
+            value: "http://SOME-OTHER-RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4318"
       - contains:
           path: spec.nodejs.env
           content:

--- a/test/unittests/operator_default_test.yaml
+++ b/test/unittests/operator_default_test.yaml
@@ -10,7 +10,7 @@ tests:
           count: 1
       - equal:
           path: spec.exporter.endpoint
-          value: http://$(SPLUNK_OTEL_AGENT):4317
+          value: http://RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4317
       - contains:
           path: spec.propagators
           content: tracecontext
@@ -21,14 +21,6 @@ tests:
           path: spec.propagators
           content: b3
       - contains:
-          path: spec.env
-          content:
-            name: SPLUNK_OTEL_AGENT
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
-      - contains:
           path: spec.dotnet.env
           content:
             name: OTEL_DOTNET_AUTO_PLUGINS
@@ -37,17 +29,9 @@ tests:
           path: spec.dotnet.env
           content:
             name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(SPLUNK_OTEL_AGENT):4318
-      - contains:
-          path: spec.env
-          content:
-            name: SPLUNK_OTEL_AGENT
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
+            value: http://RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4318
       - contains:
           path: spec.java.env
           content:
             name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(SPLUNK_OTEL_AGENT):4318
+            value: http://RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4318

--- a/test/unittests/values/operator_customized.yaml
+++ b/test/unittests/values/operator_customized.yaml
@@ -20,7 +20,7 @@ instrumentation:
   nodejs:
     env:
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4318
+      value: http://SOME-OTHER-RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4318
     - name: SPLUNK_PROFILER_ENABLED
       value: "false"
     - name: SPLUNK_PROFILER_MEMORY_ENABLED

--- a/test/unittests/values/operator_customized.yaml
+++ b/test/unittests/values/operator_customized.yaml
@@ -20,7 +20,7 @@ instrumentation:
   nodejs:
     env:
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://$(NODEJS_OTEL_AGENT):4318
+      value: http://RELEASE-NAME-splunk-otel-collector-agent.NAMESPACE.svc.cluster.local:4318
     - name: SPLUNK_PROFILER_ENABLED
       value: "false"
     - name: SPLUNK_PROFILER_MEMORY_ENABLED


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR updates the default values.yaml to enable the agent service by default, allowing customers using Kubernetes to send data via a Kubernetes service instead of relying on host ports. This change addresses customer requests for better security and alignment with modern Kubernetes practices, while still maintaining the use of the host network for now.

Changes:
- Default Change: agent.service.enabled is now set to true to enable the agent service by default.
- The agent will continue to use the host network as before, ensuring compatibility while we plan future efforts to migrate away from the host network (not in scope for this PR).