### PR TITLE
Update auto-instrumentation-install.md for nginx support notes

### DIFF
--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -401,6 +401,7 @@ provides best effort support with issues related to native OpenTelemetry instrum
 | nodejs                  | OpenTelemetry | Available   | Yes              | Mostly                       | [Link](https://github.com/open-telemetry/opentelemetry-nodejs-instrumentation)       | ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodes        |
 | python                  | OpenTelemetry | Available   | Needs Validation |                              | [Link](https://github.com/open-telemetry/opentelemetry-java-instrumentation)         | ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java         |
 | apache-httpd            | OpenTelemetry | Available   | Needs Validation |                              | [Link](https://github.com/open-telemetry/opentelemetry-apache-httpd-instrumentation) | ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd |
+| nginx                   | OpenTelemetry | Available   | Needs Validation |                              | [Link](https://github.com/open-telemetry/opentelemetry-apache-httpd-instrumentation) | ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd |
 
 ### Documentation Resources
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Add missing entry for nginx support.
- The image used for nginx is the autoinstrumentation-apache-httpd image, you can see it defined upstream [here](https://github.com/open-telemetry/opentelemetry-operator/blob/abbf3607770f0a2029d0f6b12edd90d0bfc60196/versions.txt#L40).