### PR TITLE
Refactoring after #1481 - removing not needed env variables

### DIFF
--- a/.chloggen/refactoring-removing-not-needed-environmental-variables.yaml
+++ b/.chloggen/refactoring-removing-not-needed-environmental-variables.yaml
@@ -1,0 +1,13 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: clusterReceiver refactor by removing unnecessary environmental variables after introducing the k8sAttributesProcessor to clusterReceiver, and improve the configuration for the metrics k8sAttributesProcessor
+
+# One or more tracking issues related to the change
+issues: [1540]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -134,6 +134,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e881b03d9e52b770bdae0905a06a9bf05d0b90f0baf735dd66309b9623849eae
+        checksum/config: be86b91b6614fb14865078de55ab855fecdecd837c8e100f3173c3c89baccff9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -83,6 +83,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9d7bc9b2dc86c6f1fbfda895a9cdecc2142aa77419fc568cfe3ce27947143bdb
+        checksum/config: a0f82342f1e60a1db6a90ed1d6d04330d24289f196dd42f5cd1dbd07ff354821
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4906709b9d935ca9acf53fb68b3d73dcf1e30f8e0f8c593d3f3f57de8e371454
+        checksum/config: 473ce326ca062fb96cde78297e2da0d067d53cae300ca52937b7d29513b83c79
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a2aff2e7ab61b5023a94d3890060d9179dd4b54075b87d287a61a45dce05ec54
+        checksum/config: 71d7b6414c337ca870b9e33a2c0e23e258f420d882afc16512cd6200559cc48c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -101,6 +101,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 78f50f8dc786d855d30fa3c86deb33d1d3d045f9457a983bd6843566a55f0d39
+        checksum/config: d9c869c658c16c14d9b52411af1efab8d257149dbdb7d89aac63fbbaa330e902
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector
@@ -51,23 +51,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5eb71401eb3a1d4c94103254afa7361a1bbaedd05ef9374123e822239e593b35
+        checksum/config: 578374eba11ab610de9ec3fe0f17a3674f3b42a3de1d08d3762c995476b60bef
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -67,6 +67,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -73,6 +73,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c3c3646f943ab0e09a502968b0230e74cd7e1f251f53861a4bf5432241107771
+        checksum/config: f0b6f2ab36ef8b5efbfa97c69e0b6bbab98e7f2ee21c51203a3186b4aaa196dc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2e2ed1bab47a74d37928c5441caae457dd8ead382e4265821197c4ee81c082cc
+        checksum/config: f8238761600b9f1d3f79b6451b55598caebe7bc2e6855b5f01b078cddfb7defb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,6 +43,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag
@@ -69,15 +70,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -46,27 +46,6 @@ spec:
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB
             value: "500"
-          - name: K8S_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 65b9dd0b49618c3448ff225468b06eb130558231a5d1a87c62b080875bf80da4
+        checksum/config: 3afb6ca213c512e260c8d7101d0329214f933227177b674aea4c0a473e459c04
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -46,6 +46,10 @@ spec:
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB
             value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -73,6 +73,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2e2ed1bab47a74d37928c5441caae457dd8ead382e4265821197c4ee81c082cc
+        checksum/config: f8238761600b9f1d3f79b6451b55598caebe7bc2e6855b5f01b078cddfb7defb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -80,6 +80,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 23aa422db1d2bd758e4e63599dec7e319f67ea1630352bbb88369a97e5841423
+        checksum/config: c08e3f8ab94a0516b2a21cee946d071d5192a5e05d7738c18c5e76eaf21a3977
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5eb71401eb3a1d4c94103254afa7361a1bbaedd05ef9374123e822239e593b35
+        checksum/config: 578374eba11ab610de9ec3fe0f17a3674f3b42a3de1d08d3762c995476b60bef
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5eb71401eb3a1d4c94103254afa7361a1bbaedd05ef9374123e822239e593b35
+        checksum/config: 578374eba11ab610de9ec3fe0f17a3674f3b42a3de1d08d3762c995476b60bef
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -142,6 +142,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag
@@ -173,7 +174,11 @@ data:
           - from: pod
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
-          metadata: []
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -58,7 +58,11 @@ data:
           - from: pod
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
-          metadata: []
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:
@@ -92,15 +96,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 910964220545ba83d7c5681f8c06779655893f943b28b32e167fcdfd02e2ee3c
+        checksum/config: 2f944b57426e7f36680303e2f7a0cb50ea21d2e24f14b0780bf2e2b9c89f0485
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc4a0f1c2390351f7216a170b12488d1537ec4584cf63480a7d0b8dd2f6f0fbe
+        checksum/config: 83037075d1eaec412211763637f4a6218a78c2226920ece38fad004403976310
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_PLATFORM_HEC_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1f9d5ca120b16438e2bd9d7f711dea2d9be5d31a049608f26bff5bfe8ed8d599
+        checksum/config: b7b7419a4e74a0928f98ee20dc8008123d64424421e89d1c067bc42009b9f267
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 76e569260306d33459de8d8d45884fac5719d63ada65dffa86625f3239fe5f31
+        checksum/config: 812665523b05df51dd2671d8ef4207b9e8a6374c8d6ad44b0f375146057d625d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1c0dff9a01988246e217285106fc86b0901a8a4439701a07f0bbf9e0e5d31439
+        checksum/config: 272b4bdaa2ca4dcceb62897b89625804bac2291e69648bf0012d0ff05aa21e0e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -49,15 +49,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -73,6 +73,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56147c527f0631d92437c53590e226c6b6ee0a6531a203777cfc037e535c2177
+        checksum/config: 46ad1f13b9edbafdfa17142de0ecf5a94a46b824b1d3ae2548c4537fcda67284
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -83,23 +83,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: a4e8460e21b72eab321d81cab09134fb0747498bcd0858d57bb1b3b77cf057e2
+        checksum/config: 914d28bca75772870b7d8819904a1ec5d17152ff0df67dc6c24af10f85c982ba
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9c24898293930e63c86ad8cda5b587621474fbcc675374fb66a6f6f925ebd95c
+        checksum/config: 8aed08f8f9de8f1f1e3f1e9a3d0d67ef448659c75c0bbdb5bd9632c40bb78069
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 15aa65e71fe6ffb23929a7ea2796a3a5872c0bcb07375cab2bf0bf22c9ba1bc3
+        checksum/config: 58b13cdab92d2fe7acd617d26703efc3f7ad640f41182efb5df6608b09a63aa9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 93c7680d2bc7cf29accc6587d3f39adcbc3126bdfd02b125d538cc87022bb9ab
+        checksum/config: 41baced79b5377ebf1ccb2b54ee496716a6b578e044ab13b320f5af058e3e7c0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 458e5b5e644093c37be8fe9994456eff9205e68e430a32596b17971992a1adf5
+        checksum/config: ef4c345ef9a57f8be27f156b74d8e652d68dc051a90c140ad9b6b02289d615d7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d63fef8284d7f4d9e9a1e47650d63e212087e827fb37c7d8c6558dc97bd739ba
+        checksum/config: 7fc802325021be14694e3e5ac27abc00fb409c80cec69f9c1c642d808bad5c55
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 458e5b5e644093c37be8fe9994456eff9205e68e430a32596b17971992a1adf5
+        checksum/config: ef4c345ef9a57f8be27f156b74d8e652d68dc051a90c140ad9b6b02289d615d7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 277f3d7f5676ba28a8354b153b8911497f5ba8b922f4317b0228cec0d4063ae0
+        checksum/config: 4a0637e091767ea7d5bccd2e2eb4f629e70b8c8ec36969402d1ba3d98b5b2e7c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: db4a97ee9dc1412d0a2d9768d7e719863ff4f2f76ad544f6164b1c7ad3c9ca0e
+        checksum/config: 3c0cec097eec579aba888821b36b1e4d481b586d63c329c12a9ee3fd5a06ed35
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -83,6 +83,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: abcac6d611b5d772f7560f99ba18a94d6c065d607707b684cba5ca5d58e799d8
+        checksum/config: 5f5bd74270c1b24da7975bbd263851552b356b5e456636dd5c6c100df6db41b0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3036fe3ee485f6d7db493ef6623d06bb2662cb7cd582c14974b0bd067b4d300b
+        checksum/config: ee2d3d7934fb306ca55cf75ad208f6a0bb02f9d7c58d48413e96c17a17e2200e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -142,6 +142,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag
@@ -173,7 +174,11 @@ data:
           - from: pod
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
-          metadata: []
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -58,7 +58,11 @@ data:
           - from: pod
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
-          metadata: []
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:
@@ -92,15 +96,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1c1ee6f0547bf3378a6461791baa5e18048748974cdbc9515662f6a09b4a63a0
+        checksum/config: 6b3ca2cd70e93730a7a1cf9dee1fe73729c60f3134c01f6012617f62673912fa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc4a0f1c2390351f7216a170b12488d1537ec4584cf63480a7d0b8dd2f6f0fbe
+        checksum/config: 83037075d1eaec412211763637f4a6218a78c2226920ece38fad004403976310
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_PLATFORM_HEC_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 605b79d5be864f35c5176985141d1508de8c323a0cf1078dfc04eb1775acae7d
+        checksum/config: 7f5d7c13119279c16ce6f698ad3dbf6da030734bd4b833ce4c764572eb67d6bb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -76,6 +76,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8f05cb52638cb7af67c888b0ba83386cc4928dc476e7f39d15635bcc05d92c2a
+        checksum/config: 36c486669a73cf04e7d041d6a2900b8c48adb1758f3d65b9afea85dc0b293120
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -91,6 +91,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0f2bd9b8d0051928f92ddcd40e4badd8edf6c2e8c9e10a2723481176bff268ca
+        checksum/config: efb13d7292b5aac0bfcbf1ddce32948014f3a5bcda69283556bb6bfb445d15d4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -91,6 +91,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2cff4dfd4c2135d98298167b438f78d7ae2b9911d35b3611d96251f8df0c6b29
+        checksum/config: e13a17a665940b04118dea6188e79ec7c692db4cf95e3cb11ec9827a0ca29101
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -83,6 +83,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: db7f8592f13ad4dc17302781e9430a0d4c13dcebe4430c1a26a8c478765f5496
+        checksum/config: 79eb4647736b9d1de3bffe5936172ff61c81dc90ad77a6fef902cb2b175a173f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -52,23 +52,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -114,6 +114,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag
@@ -145,7 +146,11 @@ data:
           - from: pod
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
-          metadata: []
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -58,7 +58,11 @@ data:
           - from: pod
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
-          metadata: []
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:
@@ -92,15 +96,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 88b937ca61dcba36afcf02b059f05b28d568ed4ee237653722313c3e6f52b940
+        checksum/config: c4ea0f794b7c67015a8671d193cef80f3767432cbae87a0b71ee499ab2a12f09
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc4a0f1c2390351f7216a170b12488d1537ec4584cf63480a7d0b8dd2f6f0fbe
+        checksum/config: 83037075d1eaec412211763637f4a6218a78c2226920ece38fad004403976310
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_PLATFORM_HEC_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -86,6 +86,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: af5b388db451839c79ea5a7cf0c1802da356137818ddf96caeecfdf118968a61
+        checksum/config: 1ef290b6a15cb80548f1eb34bddc8746d846bc0349c4d32f113bf61ac71669ca
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -78,6 +78,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 38bd67a2d2e789695c3d6eec7ac93f489c0b24bb85aff7aa94cf54e0ebd8fd08
+        checksum/config: 77c5dd75dc5bd9217c43db11dad8802394158859d72b38bff36946e86f44011f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -78,6 +78,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a9f4d7674f21d009b7de7d51d2afaf740996f4ba7b438761273d67597b64dafc
+        checksum/config: 1b068db2df63abe9a02b02c7796cb2665e1eec5cb2de5f4a280fa0c5b074fdd3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -87,6 +87,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag
@@ -118,7 +119,11 @@ data:
           - from: pod
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
-          metadata: []
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -58,7 +58,11 @@ data:
           - from: pod
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
-          metadata: []
+          metadata:
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
         filter:
           node_from_env_var: K8S_NODE_NAME
         pod_association:
@@ -92,15 +96,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7d85bbe4bf372577b9da3d11ca84157b697b9d281afc5bc23efac3d965f85db8
+        checksum/config: 052b0ba2f62bf386bfce2b2e5637b9f9d5c300534a48d878f8d12afd4b6f2b28
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc4a0f1c2390351f7216a170b12488d1537ec4584cf63480a7d0b8dd2f6f0fbe
+        checksum/config: 83037075d1eaec412211763637f4a6218a78c2226920ece38fad004403976310
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_PLATFORM_HEC_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -70,6 +70,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e80b3b8ffe35188a7fd25c9b8d214db621ee8f5ae2968c9b0704b3aff535a2e2
+        checksum/config: 1c3f527cad6bee5c7a98e5e0ff678aa0b8ffe0220d8c3a47897d7cdce09ca178
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 73ae2ec4b01a52f0b2d1d009a3de3065eae3af9a8f32b04ec617bcb8b68ec9a4
+        checksum/config: 1949d305827841759e72c062fc5a9e8ae60df6d5586667acc4b260cc6c0acb5a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -79,6 +79,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6166ecb8708d5dea5940836a6d99a02194b5eebd319a354adcdacd25237bcba4
+        checksum/config: f674333211f3b8cc1486fdcfefaf3c527c08f14a50437e503122b3b9bf87db1f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2d30104c1725bfc46d21422a78e2ebf2739ebca5499b79cf5b57362c722add65
+        checksum/config: a931c9a0934e1c42a84984c6431779121c6ef1373f1b6879d69243dcd0c85574
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -78,6 +78,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b3f1f12b71f67ff6f5925a78164f653a4fd71701765d682f002bd5a6fb729d4
+        checksum/config: 13c5ee6bff56428f604c1938cfc2da8c3932e7b126d56d9ef1f2cf425941e807
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -90,6 +90,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 337b62ab6e26e59337eb748710c0020c704126443416cef3db07f902f26ea6b5
+        checksum/config: 31faba299d53a6d9dc13e35d884a21e5ff8d2d9dc7b9471dac0ee6923bf5efa9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 40d2922b85afbb24c334a3d1a7b547e82c3d17029f07d5a772f6e8751a9b8a57
+        checksum/config: 05b9d0d19212263728d7ec93142e7ea11c8e326860f490f7c7fc1cf2817a7dc4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5eb71401eb3a1d4c94103254afa7361a1bbaedd05ef9374123e822239e593b35
+        checksum/config: 578374eba11ab610de9ec3fe0f17a3674f3b42a3de1d08d3762c995476b60bef
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,7 @@ data:
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
+          - k8s.pod.ip
           - container.id
           - container.image.name
           - container.image.tag

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -46,15 +46,6 @@ data:
         - action: insert
           key: k8s.node.name
           value: ${K8S_NODE_NAME}
-        - action: insert
-          key: k8s.pod.name
-          value: ${K8S_POD_NAME}
-        - action: insert
-          key: k8s.pod.uid
-          value: ${K8S_POD_UID}
-        - action: insert
-          key: k8s.namespace.name
-          value: ${K8S_NAMESPACE}
       resource/add_mode:
         attributes:
         - action: insert

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6422bd347912cec6c9da2acf721602d737528c85e75e171b1455fa8a739b6ab3
+        checksum/config: 584aad3dd532bcd8dface7ca76e6460c191251e482f5ec5c3c14f7bd6d854aea
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: ab4d49962c0d97151ddf075a55415a06495912f386c1a20355f795c16157d0be
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -50,23 +50,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:

--- a/functional_tests/testdata/expected_kind_values/expected_cluster_receiver.yaml
+++ b/functional_tests/testdata/expected_kind_values/expected_cluster_receiver.yaml
@@ -6027,12 +6027,21 @@ resourceMetrics:
                     - key: k8s.cluster.name
                       value:
                         stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.node.uid
                       value:
-                        stringValue: e879976d-29c7-441f-926a-e4d94e6e3795
+                        stringValue: 30cea3fc-191d-4891-ad80-7aea7a5bfef2
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: dotnet-test-6f6d54979f-lfcqx
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 85bd538b-5c34-4c4a-80e5-7c3a9c29340a
                     - key: metric_source
                       value:
                         stringValue: kubernetes

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -184,6 +184,7 @@ k8sattributes:
       - k8s.node.name
       - k8s.pod.name
       - k8s.pod.uid
+      - k8s.pod.ip
       - container.id
       - container.image.name
       - container.image.tag
@@ -226,6 +227,7 @@ k8sattributes/clusterReceiver:
       - k8s.node.name
       - k8s.pod.name
       - k8s.pod.uid
+      - k8s.pod.ip
       - container.id
       - container.image.name
       - container.image.tag
@@ -263,7 +265,11 @@ k8sattributes/metrics:
     - sources:
       - from: connection
   extract:
-    metadata: []
+    metadata:
+      - k8s.namespace.name
+      - k8s.node.name
+      - k8s.pod.name
+      - k8s.pod.uid
     annotations:
       - key: splunk.com/sourcetype
         from: pod

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -131,15 +131,6 @@ processors:
       - action: insert
         key: k8s.node.name
         value: "${K8S_NODE_NAME}"
-      - action: insert
-        key: k8s.pod.name
-        value: "${K8S_POD_NAME}"
-      - action: insert
-        key: k8s.pod.uid
-        value: "${K8S_POD_UID}"
-      - action: insert
-        key: k8s.namespace.name
-        value: "${K8S_NAMESPACE}"
 
   resource:
     attributes:

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -136,23 +136,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: K8S_POD_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.podIP
-          - name: K8S_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: K8S_POD_UID
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.uid
-          - name: K8S_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
           {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
           - name: SPLUNK_OBSERVABILITY_ACCESS_TOKEN
             valueFrom:


### PR DESCRIPTION
**Description:** 
Cleanup and refactor work to prevent code duplication related to setting Kubernetes attributes by using k8sAttributesProcessor for cluster receiver introduced by [PR](https://github.com/signalfx/splunk-otel-collector-chart/pull/1481)

Once following two PRs will be merged we can merge this one:
 - [Contrib repo PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35528)
 - [Chart repo PR](https://github.com/signalfx/splunk-otel-collector-chart/pull/1481)
 
 We need also decide what to do with `resource/add_collector_k8s`: [link](https://github.com/signalfx/splunk-otel-collector-chart/blob/7ea0cab65fd0825b61e162e405ae11bedcf06890/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl#L121)
as this is using env variables which we want to remove, but the functionality of adding additional parameters is covered by `k8sattributes/metrics`, so probably it is safe to remove `resource/add_collector_k8s` from configuration