### PR TITLE
Fix bug where sometimes Instrumentation opentelemetry.io/v1alpha1 can be installed too early

### DIFF
--- a/.chloggen/fix-operator-inst-bug.yaml
+++ b/.chloggen/fix-operator-inst-bug.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where sometimes Instrumentation opentelemetry.io/v1alpha1 can be installed too early
+# One or more tracking issues related to the change
+issues: [1544]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/component: otel-operator
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-weight": "5"
 spec:
   exporter:
     endpoint: http://default-splunk-otel-collector-agent.default.svc.cluster.local:4317

--- a/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: otel-operator
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-weight": "5"
 spec:
   exporter:
     endpoint: {{ include "splunk-otel-collector.operator.instrumentation-exporter-endpoint" . }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- This is a hotfix to address an issue where sometimes the Instrumentation object is installed to early before the operator (and TLS certificate) are ready. This would cause helm install failure in some environments and not others depending on a user's environment setup.
