### PR TITLE
update to v0.113.0 and add root_path to hostmetrics receiver

### DIFF
--- a/.chloggen/add-root-path.yaml
+++ b/.chloggen/add-root-path.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes hostmetrics receiver to use the correct mount path of the host's filesystem from inside the container"
+# One or more tracking issues related to the change
+issues: [1547]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
+++ b/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-filter-processor/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-filter-processor/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -304,6 +304,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 935fc1e7c80cf17a292d54be11497c3b08c4a368110b028684628b90fc381fb6
+        checksum/config: f372080340f1c4a43d2ea949e57f3f572222517151cfdb181cadb0fec9c981e0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -118,7 +118,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-filter-processor/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-filter-processor/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-filter-processor/rendered_manifests/service-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/add-filter-processor/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-filter-processor/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -253,6 +253,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f5b6e87e3d60a906c57ccc755f6fa6244b6474a892cf9a3e3251ba5422d5ac88
+        checksum/config: eb5439c4378c87f81c6301f0fffe0cf4a4ac4b2eb4930448b0f80e7404a00e62
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -118,7 +118,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-kafkametrics-receiver/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/service-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/add-kafkametrics-receiver/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 347fc89521ddf0d3ea6abf78f29dc4958f188dae21ac27283aa00e7ffc4b671e
+        checksum/config: 8754015e8d74212dc9065dbc2341f7f9a71538dfeda6ed0e92bb20f81f12d944
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-receiver-creator/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/service-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/add-receiver-creator/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-sampler/rendered_manifests/clusterRole.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-sampler/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -138,6 +138,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: eed68a6489d33118e92296c92c40c48c1ba8eefd09539f55bdf5e15219d104c5
+        checksum/config: 870d629179695f9f97f107d3d8f25580518086a64a93aa2b5915f2050a24c042
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-sampler/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-sampler/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/add-sampler/rendered_manifests/service-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/add-sampler/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-sampler/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/autodetect-istio/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/autodetect-istio/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -288,6 +288,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b15376250d7db832ef0c18489d4320674a2249743033c0385e037df6619f4984
+        checksum/config: 11babc22b246e7f4ad711899f3b4810dacd759b2f2ed9b9e6acb611bd690559c
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:
@@ -49,7 +49,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -119,7 +119,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector
@@ -42,7 +42,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/autodetect-istio/rendered_manifests/secret-splunk.yaml
+++ b/examples/autodetect-istio/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/autodetect-istio/rendered_manifests/service-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/autodetect-istio/rendered_manifests/serviceAccount.yaml
+++ b/examples/autodetect-istio/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-agent-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 22adc750cef6cdc3dddb647c0a553c2e0337aba6b374e26f1d52baa60f5b62f7
+        checksum/config: 5be83086b56656af2fd9fed12e45aae07221bcf48d3368b4f8d5f0bb58b9c730
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-agent-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-agent-only/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-agent-only/rendered_manifests/service-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/collector-agent-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-agent-only/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-all-modes/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-all-modes/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -119,6 +119,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fbc0f81b870a6a3287980ce31c3d4bdb1e2b81a9fc151f718e1c3f11856f8e33
+        checksum/config: e5499dcf6876149aa0da5a0d584e92208b1f87f90d41e9f617b362860df16990
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 83c5b1bf4ebfb06bba7d6912e45d2e599ea97dfbb801f647ca2a65288e6fb91e
+        checksum/config: f89f5e8bcad7f11b219c25ba3ea3b5450662392145d7185d53cf24710e4150d3
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-all-modes/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-all-modes/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-all-modes/rendered_manifests/service-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/collector-all-modes/rendered_manifests/service.yaml
+++ b/examples/collector-all-modes/rendered_manifests/service.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.112.1

--- a/examples/collector-all-modes/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-all-modes/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0720e7cbfe34090213f911bb21f5fa7057da4b7e7c8d8da08211166ff4efcb38
+        checksum/config: c9ed91daa196038bd9df714e679f9472c009405ca19d21f51f4d397b8e2066b4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-cluster-receiver-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 83c5b1bf4ebfb06bba7d6912e45d2e599ea97dfbb801f647ca2a65288e6fb91e
+        checksum/config: f89f5e8bcad7f11b219c25ba3ea3b5450662392145d7185d53cf24710e4150d3
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-gateway-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/service.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/service.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.112.1

--- a/examples/collector-gateway-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -140,6 +140,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cebe46c24692fa084d21681707dc4d5bf3f06f40356545bdeaaef80627d07a49
+        checksum/config: 28a7cc161df7a967b46b54f55c2a18ca10dd518e0b2f26a922558860d7ef43f0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/controlplane-histogram-metrics/rendered_manifests/secret-splunk.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/controlplane-histogram-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/crio-logging/rendered_manifests/clusterRole.yaml
+++ b/examples/crio-logging/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/crio-logging/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/crio-logging/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 22adc750cef6cdc3dddb647c0a553c2e0337aba6b374e26f1d52baa60f5b62f7
+        checksum/config: 5be83086b56656af2fd9fed12e45aae07221bcf48d3368b4f8d5f0bb58b9c730
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/crio-logging/rendered_manifests/secret-splunk.yaml
+++ b/examples/crio-logging/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/crio-logging/rendered_manifests/service-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/crio-logging/rendered_manifests/serviceAccount.yaml
+++ b/examples/crio-logging/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/default/rendered_manifests/clusterRole.yaml
+++ b/examples/default/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/default/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/default/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 22adc750cef6cdc3dddb647c0a553c2e0337aba6b374e26f1d52baa60f5b62f7
+        checksum/config: 5be83086b56656af2fd9fed12e45aae07221bcf48d3368b4f8d5f0bb58b9c730
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/default/rendered_manifests/secret-splunk.yaml
+++ b/examples/default/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/default/rendered_manifests/service-agent.yaml
+++ b/examples/default/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/default/rendered_manifests/serviceAccount.yaml
+++ b/examples/default/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -341,6 +341,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fd382486bdd75fd52c7985d54dc4af42786b4d607fad4fb8fbd2605fb1087ae2
+        checksum/config: 23c46f03a14894bfb7e579b88d6e63893ed91617132f45ce932031c5774066d9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -118,7 +118,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bb16f132c4dc4584e2335816e6e456e20e1086c5e4186b6a76e93e413189dcd0
+        checksum/config: 7021d01637cac35b8e5ae0d9491cc4ce1d944c8544debf07d208dbf4c837427c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/disable-persistence-queue-traces/rendered_manifests/secret-splunk.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/service-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/disable-persistence-queue-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/discovery-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/discovery-mode/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/discovery-mode/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/discovery-mode/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 88163212ceb7d59fc0a5df5014420f8f34f3bd9c40f5f953519b35d1b71b98d8
+        checksum/config: 80f514c40b2593e9fdac95acd1719b1bb6cafbe729997689190b64cb58bc83db
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -80,7 +80,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/discovery-mode/rendered_manifests/secret-splunk.yaml
+++ b/examples/discovery-mode/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/discovery-mode/rendered_manifests/service-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/discovery-mode/rendered_manifests/serviceAccount.yaml
+++ b/examples/discovery-mode/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-aks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-aks/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -137,6 +137,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 934dc3d4e3e440dd2c1dc13bc0decf0332d1081d99a10cc714a55b2a03aba3d6
+        checksum/config: 44058e171d3f17fce89419a56b1485723fe7fc2cdfd03afea7bf75db4207a4a1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3e4e54f73fe9d4864f9e8c7142fd5c8003ba9cc88b0a3c8bc444c90dc0580867
+        checksum/config: 1ab5420ea906d1e94ca1874732f764d5e6ec97d7ce2e53a4f51a211cf601d36f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-aks/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-aks/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-aks/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/distribution-aks/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-aks/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 665ad9323cd291ae55401ac783a0ac7d233b8bf4b999d0a3f51382f31cca397d
+        checksum/config: 55b117929be52d3569cde74641e7a76bd1f68bb4b6781b58660369c8c35cf744
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,7 +74,7 @@ spec:
         command:
         - /otelcol
         - --config=/splunk-messages/config.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: a39d4a05ab79272a68cc1731660e863069fec54ad28f642c2ef5e8c6ddf5748e
+        checksum/config: e94e6df7e0345cfe178daa9a5e806f437ce04dcdd8628444b1247efe01625556
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks-fargate/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/service.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/service.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.112.1

--- a/examples/distribution-eks-fargate/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -137,6 +137,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 089d8815f8af7c6cb11aeb95220acee826089967dc4859c178b36fca37265675
+        checksum/config: 260e25f3f69880f05441f3f294e072bd848125fac4bcd4319d94d4361dc59aff
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8e1b95ce41bfce8da2bedc3adbeb1f05f28168431267d88526e3ff6a98a6b859
+        checksum/config: 664eb7502561a77ce494d9e43540a6f09982c31983055ebaa5261cefc630b18c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-eks/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-eks/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/distribution-eks/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-eks/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -136,6 +136,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5ac8099fd7e39312ee4b2cf9dc916b2db3776a1e7e90a846e24c6104d3331c74
+        checksum/config: 3980cbc94e8588f24013391b29a825dbde2a96e1ec388c08269691b9352abbe4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f0daf6a214d1eefcbef8d16d0af94c0cd975f02831d3be52adf9a35f78bc1d70
+        checksum/config: 25261b3bc83ec62a64103360046b308a1a7c551ddddff250efb55d859243c661
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke-autopilot/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/distribution-gke-autopilot/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -136,6 +136,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3f9b865d0873a05855cdf3d47d0961b40d76eee6b7525a54cc5d316e48aac9af
+        checksum/config: b529642c092efdfd13bba3d5f980a24e1b8cdb4c62f02f6d5b997a02d8a0e530
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f0daf6a214d1eefcbef8d16d0af94c0cd975f02831d3be52adf9a35f78bc1d70
+        checksum/config: 25261b3bc83ec62a64103360046b308a1a7c551ddddff250efb55d859243c661
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-gke/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-gke/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/distribution-gke/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-gke/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-openshift/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6db37dcffc4f4691549a2b10131c7bf62356d2ca89f2a37f19e815ba7b9bbb5a
+        checksum/config: 73d1501dc7a38efa3083ec32f0269bfa8e172e82e1a4e9ba8386a51fec946b0e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3030176451570240421e9ef921817af4436fce5a89762faf7e5b6a5c53f7d22c
+        checksum/config: 1e2372122dbd0b1bc74115f94b7acea1ca4ecf0df75bf57b333b7e795da3f51b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-openshift/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-openshift/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
+++ b/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/distribution-openshift/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/distribution-openshift/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-openshift/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -258,6 +258,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0513dc2db73e986140a78e5be14747d9cc874856bed1c6adbaabfbd3a253da17
+        checksum/config: 09e785c472a5b6a4dd50499c3732428fc22171e1b5473a4e01a2abb6715b0b05
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -118,7 +118,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8f917c9ae0e1f9e4368932c5d2b1adc4fd5db5983f60ad0889fa171589237689
+        checksum/config: fdec9507f71910b4b24cff560029b9d546bdef671377ba0607c0f400b31e64b8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-operator
     chart: splunk-otel-collector-0.112.1

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/secret-splunk.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/service-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -341,6 +341,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0048a80660bcb33c1b7e1c324093b0c8d704097bdb7060ef3f0f755a83ef29ee
+        checksum/config: 5937d2cb45e038daaee835b35bc702aaf2659e40c0c14a0fe572913db7244240
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -118,7 +118,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bb16f132c4dc4584e2335816e6e456e20e1086c5e4186b6a76e93e413189dcd0
+        checksum/config: 7021d01637cac35b8e5ae0d9491cc4ce1d944c8544debf07d208dbf4c837427c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-persistence-queue/rendered_manifests/secret-splunk.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/service-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/enable-persistence-queue/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4351efe268156e1a153118e64215a4ce109c8e1a51a52e9d32f000994157eaa5
+        checksum/config: a1c74b18bf03fdc2601bb693e421a1d1c0e2224dce70e41c4f354b22340c4bba
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -75,7 +75,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-trace-sampling/rendered_manifests/secret-splunk.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/service-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/enable-trace-sampling/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -136,6 +136,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f52b83e856b5d016d4df35b36e0efbf741508afc86f241366307e9819753dc02
+        checksum/config: 1e32eac4f667caac8dd1de657404f6a6dace67231ccc0aa5c06f9480aa9a7590
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enabled-pprof-extension/rendered_manifests/secret-splunk.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/service-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/enabled-pprof-extension/rendered_manifests/serviceAccount.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -153,6 +153,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd-json.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 20484b69d1dce50e5bdbba56f3c30a272e7e4a61d432d9b28321e96a20229073
+        checksum/config: 7554abf46ab028d354e49180e87fdd1f9d9d10dcdf51e1a4a56f46e3d904014a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -152,7 +152,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/secret-splunk.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/service-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/clusterRole.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -153,6 +153,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd-json.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cef1d4ef60f452a452175c9a07eed6550865c11c9dfd99ebe14da2d98c4a7de7
+        checksum/config: 53caf13b9c9086e20ee4c90876d945d56702725ef6de9e9ea3789e3d8d1d9b5b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -152,7 +152,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-refresh-interval/rendered_manifests/secret-splunk.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/service-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/fluentd-refresh-interval/rendered_manifests/serviceAccount.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0ee9a92daa50b8f23ddd9444ce2318151dc66b4a83a99ea1c8ce1c6b4a901b42
+        checksum/config: de5d3ae90cbcd19a9c148036091ee5485566c13f8e648a0f00f0e4983faaeb58
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet
@@ -84,7 +84,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector-windows:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector-windows:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           windowsOptions:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -43,7 +43,7 @@ spec:
         - -command
         - .\otelcol.exe
         - --config=C:\\conf\relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector-windows:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector-windows:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/kubernetes-windows-nodes/rendered_manifests/secret-splunk.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/service-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/kubernetes-windows-nodes/rendered_manifests/serviceAccount.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/multi-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/multi-metrics/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/multi-metrics/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/multi-metrics/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -313,6 +313,7 @@ data:
         endpoint: 0.0.0.0:8006
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1c054bebc9e60f59eb89cc7c2cb2261e2e59277bba68133753f4955ba93017fa
+        checksum/config: 78a10474e8b702d1fe8ced8a9a37dd36087a49c264bc332f52c4f0f9ea7d34b6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -102,7 +102,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bb16f132c4dc4584e2335816e6e456e20e1086c5e4186b6a76e93e413189dcd0
+        checksum/config: 7021d01637cac35b8e5ae0d9491cc4ce1d944c8544debf07d208dbf4c837427c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/multi-metrics/rendered_manifests/secret-splunk.yaml
+++ b/examples/multi-metrics/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/multi-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/multi-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/multi-metrics/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd-json.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d19afc973ad069f91673ed3b9cd7fc6ea866953513ac87523a23f9dd5c4a588c
+        checksum/config: c2204762b2fa840ba8405ac9fa3cc2be49d6e03f6778826390d1f7b58d75cb5f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -132,7 +132,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-logs-fluentd/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/only-logs-fluentd/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-otel/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-otel/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-otel/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-otel/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fd4d9f117255ba76571ede785b0f9a717b663e3dc451574e67366cd8cbed89aa
+        checksum/config: ff17ea20b14273362ce74bf9dced8b3934436ec61a0cbf26d1c074744ae7e06b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -98,7 +98,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/only-logs-otel/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-otel/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-otel/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/only-logs-otel/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-otel/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 74c9698c863ea4a1f1384e16efa92e4bd6b7bdee46d403c3c99febd627942ac3
+        checksum/config: 2b714b0fb4c1e58e17a726459df634cd436d2842b5dc8a79baec7d6c6ebf8f7c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -98,7 +98,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -176,6 +176,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0c5a2954300c8247fb83c8d42cf985c0bd4b6ea8b93424e52b88a7523c873156
+        checksum/config: b2fc207376ece257668dd8bb8f627523fb3a7948a8368fe171f92a1caf04cec5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -63,7 +63,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bb16f132c4dc4584e2335816e6e456e20e1086c5e4186b6a76e93e413189dcd0
+        checksum/config: 7021d01637cac35b8e5ae0d9491cc4ce1d944c8544debf07d208dbf4c837427c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics-platform/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/service-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/only-metrics-platform/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -130,6 +130,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 65521dcf0d28a6e65ee3524fc590c7d61c0c6a7e0a4fb47de3b9ae834e7195c8
+        checksum/config: 738a15883e1fad0a5d57991f4f1196c941e5896018edd8ed2c55128f48dffa49
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -63,7 +63,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-metrics/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/only-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-metrics/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-traces/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bdaea9eab54652ae918a5c2bc7e40c70b09eda6502635af418910a9ba60c970c
+        checksum/config: 0e2f07249c84fbe9eaf8fe3b794838e6e9ae02ab4ac9c9ed019e3e21d395d5bc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -75,7 +75,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-traces/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-traces/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/only-traces/rendered_manifests/service-agent.yaml
+++ b/examples/only-traces/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/only-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-traces/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -139,6 +139,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0c18ea30f4c10c9cb343fb0160095b23c6fdd75a0e54693d1b78a7ba17f2f638
+        checksum/config: 9475b075d008d38b3a92668498e5e1dfa2ce216892835734d6e2fe5712c39c9a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2c995e47370119c74d07be652c8d6aa5e57159fc30e776d73ea3317ab84efc9b
+        checksum/config: 4f393cb2364d7740745c241aaf88f9a323cbfeee393491754d561fcfb409c8fb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/secret-splunk.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/service-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/serviceAccount.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/secret-validation/rendered_manifests/clusterRole.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/secret-validation/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1fcd57b72925e962115f0c0200b1c92382e8d73cdf44f29b7c3313d173e2bbaf
+        checksum/config: c05a45154d875a5093b70a10a8e1b1e123f4badaa3370f867bdc9ede2b72bc81
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -98,7 +98,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/secret-validation/rendered_manifests/secret-splunk-validation-hook.yaml
+++ b/examples/secret-validation/rendered_manifests/secret-splunk-validation-hook.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
   annotations:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -20,7 +20,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: validate-secret
-    image: quay.io/signalfx/splunk-otel-collector:0.112.0
+    image: quay.io/signalfx/splunk-otel-collector:0.113.0
     imagePullPolicy: IfNotPresent
     command: ["sh", "-c"]
     args:

--- a/examples/secret-validation/rendered_manifests/service-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/secret-validation/rendered_manifests/serviceAccount.yaml
+++ b/examples/secret-validation/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4c801acffd8e9eaaad16c0eba8bec8d7fe5a8ed3475b5cda6bb8776c36dbc16e
+        checksum/config: d4206a9ee222fe7f09dd4a35e960ccb8367549e54c0fe617f3d416ed81c25f01
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -48,7 +48,7 @@ spec:
           key: node-role.kubernetes.io/control-plane
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.112.0
+          image: quay.io/signalfx/splunk-otel-collector:0.113.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -98,7 +98,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/secret-splunk.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/service-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/serviceAccount.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/target-allocator/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/target-allocator/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/target-allocator/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 687ac4b834408d10adf9a6540222c39cbd7dae4f159325f5d8471922180fea2c
+        checksum/config: 9678253eb639bc96ac92027aa1691339013bc9dcde3fe6c33eca6138d3247524
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/target-allocator/rendered_manifests/secret-splunk.yaml
+++ b/examples/target-allocator/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/target-allocator/rendered_manifests/service-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/target-allocator/rendered_manifests/serviceAccount.yaml
+++ b/examples/target-allocator/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/use-proxy/rendered_manifests/clusterRole.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/use-proxy/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 22adc750cef6cdc3dddb647c0a553c2e0337aba6b374e26f1d52baa60f5b62f7
+        checksum/config: 5be83086b56656af2fd9fed12e45aae07221bcf48d3368b4f8d5f0bb58b9c730
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/use-proxy/rendered_manifests/secret-splunk.yaml
+++ b/examples/use-proxy/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/use-proxy/rendered_manifests/service-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/use-proxy/rendered_manifests/serviceAccount.yaml
+++ b/examples/use-proxy/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/with-target-allocator/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/with-target-allocator/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default
@@ -135,6 +135,7 @@ data:
     receivers:
       hostmetrics:
         collection_interval: 10s
+        root_path: /hostfs
         scrapers:
           cpu: null
           disk: null

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0da7b1f1a2a6e502ae1f1121913c6d3a8d3cf64178e177f999b8b2cf9b8a5af6
+        checksum/config: 9a94044d2fcdf6437ff8c03c72d6c282eee311428639107cf7d1f2391a31c29c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -79,7 +79,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.112.1
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f07298aeeaf0f41911b5af992fc7e6c344a53aa52b68123d0e5f98f9deb51455
+        checksum/config: 0cc99583a1bdb65c971228e819dde6c80d05cfe90de2433c6105794abfd823ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.112.0
+        image: quay.io/signalfx/splunk-otel-collector:0.113.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/with-target-allocator/rendered_manifests/secret-splunk.yaml
+++ b/examples/with-target-allocator/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/with-target-allocator/rendered_manifests/service-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.112.1

--- a/examples/with-target-allocator/rendered_manifests/serviceAccount.yaml
+++ b/examples/with-target-allocator/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/with-target-allocator/rendered_manifests/targetAllocator-clusterRoleBinding.yaml
+++ b/examples/with-target-allocator/rendered_manifests/targetAllocator-clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/with-target-allocator/rendered_manifests/targetAllocator-configmap.yaml
+++ b/examples/with-target-allocator/rendered_manifests/targetAllocator-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/examples/with-target-allocator/rendered_manifests/targetAllocator-serviceAccount.yaml
+++ b/examples/with-target-allocator/rendered_manifests/targetAllocator-serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.112.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.112.0"
+    app.kubernetes.io/version: "0.113.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.112.1
     release: default

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: splunk-otel-collector
 version: 0.112.1
-appVersion: 0.112.0
+appVersion: 0.113.0
 description: Splunk OpenTelemetry Collector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -49,6 +49,9 @@ receivers:
   {{- if (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
   hostmetrics:
     collection_interval: 10s
+    {{- if not .Values.isWindows }}
+    root_path: "/hostfs"
+    {{- end }}
     scrapers:
       cpu:
       disk:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Updates the collector version to 0.113.0 and adds back the `root_path` config in hostmetrics receiver which is needed for the collector to find the host filesystem mount path inside the container.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
