### PR TITLE
OTL-3190 Additional fixes for operator install order issues using Helm hooks

### DIFF
--- a/.chloggen/fix-operator-install-operations.yaml
+++ b/.chloggen/fix-operator-install-operations.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: operator
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Additional fixes for issues where sometimes certificates and Instrumentation opentelemetry.io/v1alpha1 are installed too early
+# One or more tracking issues related to the change
+issues: [1559]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/certmanager.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/certmanager.yaml
@@ -5,7 +5,7 @@ kind: Certificate
 metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "1"
+    helm.sh/hook-weight: "3"
   labels:
     helm.sh/chart: operator-0.71.2
     app.kubernetes.io/name: operator
@@ -34,7 +34,7 @@ kind: Issuer
 metadata:
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "1"
+    helm.sh/hook-weight: "2"
   labels:
     helm.sh/chart: operator-0.71.2
     app.kubernetes.io/name: operator

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/job-operator-startupapicheck.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/job-operator-startupapicheck.yaml
@@ -25,7 +25,8 @@ spec:
     spec:
       containers:
         - name: startupapicheck
-          image: "busybox:latest"
+
+          image: registry.access.redhat.com/ubi9/ubi
           env:
             - name: MANAGER_METRICS_SERVICE_CLUSTERIP
               value: "default-splunk-otel-collector-operator"

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/job-operator-startupapicheck.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/job-operator-startupapicheck.yaml
@@ -1,0 +1,50 @@
+---
+# Source: splunk-otel-collector/templates/operator/job-operator-startupapicheck.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:  default-splunk-otel-collector-operator-startupapicheck
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.113.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.113.0"
+    app: splunk-otel-collector
+    component: otel-operator
+    chart: splunk-otel-collector-0.113.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-operator
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "4"
+spec:
+  template:
+    spec:
+      containers:
+        - name: startupapicheck
+          image: "busybox:latest"
+          env:
+            - name: MANAGER_METRICS_SERVICE_CLUSTERIP
+              value: "default-splunk-otel-collector-operator"
+            - name: MANAGER_METRICS_SERVICE_PORT
+              value: "8443"
+          command:
+            - sh
+            - -c
+            - |
+              i=0
+              while [ $i -lt 300 ]; do
+                if wget -qO- "$MANAGER_METRICS_SERVICE_CLUSTERIP:$MANAGER_METRICS_SERVICE_PORT" 2>&1 | grep -qv "HTTP/1.0 400 Bad Request"; then
+                  echo "Operator service is available."
+                  exit 0
+                fi
+                echo "Waiting for operator service to become available... (attempt $i)"
+                i=$((i + 1))
+                sleep 1
+              done
+              echo "Timeout reached. Operator service did not become available."
+              exit 1
+      restartPolicy: Never

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/job-operator-webhook-startupapicheck.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/job-operator-webhook-startupapicheck.yaml
@@ -1,0 +1,50 @@
+---
+# Source: splunk-otel-collector/templates/operator/job-operator-webhook-startupapicheck.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: default-splunk-otel-collector-operator-webhook-startupapicheck
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.113.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.113.0"
+    app: splunk-otel-collector
+    component: otel-operator
+    chart: splunk-otel-collector-0.113.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-operator
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "4"
+spec:
+  template:
+    spec:
+      containers:
+        - name: wget
+          image: "busybox:latest"
+          env:
+            - name: WEBHOOK_SERVICE_CLUSTERIP
+              value: "default-splunk-otel-collector-operator-webhook"
+            - name: WEBHOOK_SERVICE_PORT
+              value: "443"
+          command:
+            - sh
+            - -c
+            - |
+              i=0
+              while [ $i -lt 300 ]; do
+                if wget -qO- "$WEBHOOK_SERVICE_CLUSTERIP:$WEBHOOK_SERVICE_PORT" 2>&1 | grep -qv "HTTP/1.0 400 Bad Request"; then
+                  echo "Operator webhook service is available."
+                  exit 0
+                fi
+                echo "Waiting for webhook service to become available... (attempt $i)"
+                i=$((i + 1))
+                sleep 1
+              done
+              echo "Timeout reached. Operator webhook service did not become available."
+              exit 1
+      restartPolicy: Never

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/job-operator-webhook-startupapicheck.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/job-operator-webhook-startupapicheck.yaml
@@ -24,8 +24,9 @@ spec:
   template:
     spec:
       containers:
-        - name: wget
-          image: "busybox:latest"
+        - name: startupapicheck
+
+          image: registry.access.redhat.com/ubi9/ubi
           env:
             - name: WEBHOOK_SERVICE_CLUSTERIP
               value: "default-splunk-otel-collector-operator-webhook"

--- a/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
@@ -1,4 +1,11 @@
 {{/*
+Create the job image name.
+*/}}
+{{/*{{- define "splunk-otel-collector.image.job" -}}*/}}
+{{/*{{- printf "%s:%s" .Values.instrumentation.job.repository .Values.instrumentation.job.tag | trimSuffix ":" -}}*/}}
+{{/*{{- end -}}*/}}
+
+{{/*
 Helper to ensure the correct usage of the Splunk OpenTelemetry Collector Operator.
 - Checks for a valid endpoint for exporting telemetry data.
 - Validates that the operator is configured correctly according to user input and default settings.

--- a/helm-charts/splunk-otel-collector/templates/operator/job-operator-startupapicheck.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/job-operator-startupapicheck.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.operator.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name:  {{ template "splunk-otel-collector.fullname" . }}-operator-startupapicheck
+  namespace: {{ template "splunk-otel-collector.namespace" . }}
+  labels:
+    {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
+    app: {{ template "splunk-otel-collector.name" . }}
+    component: otel-operator
+    chart: {{ template "splunk-otel-collector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: otel-operator
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "4"
+spec:
+  template:
+    spec:
+      containers:
+        - name: startupapicheck
+          image: "busybox:latest"
+          env:
+            - name: MANAGER_METRICS_SERVICE_CLUSTERIP
+              value: "{{ template "splunk-otel-collector.fullname" . }}-operator"
+            - name: MANAGER_METRICS_SERVICE_PORT
+              value: "8443"
+          command:
+            - sh
+            - -c
+            - |
+              i=0
+              while [ $i -lt 300 ]; do
+                if wget -qO- "$MANAGER_METRICS_SERVICE_CLUSTERIP:$MANAGER_METRICS_SERVICE_PORT" 2>&1 | grep -qv "HTTP/1.0 400 Bad Request"; then
+                  echo "Operator service is available."
+                  exit 0
+                fi
+                echo "Waiting for operator service to become available... (attempt $i)"
+                i=$((i + 1))
+                sleep 1
+              done
+              echo "Timeout reached. Operator service did not become available."
+              exit 1
+      restartPolicy: Never
+{{- end }}

--- a/helm-charts/splunk-otel-collector/templates/operator/job-operator-startupapicheck.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/job-operator-startupapicheck.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
         - name: startupapicheck
-          image: "busybox:latest"
+{{/*          image: {{ template "splunk-otel-collector.image.job" . }}*/}}
+          image: registry.access.redhat.com/ubi9/ubi
           env:
             - name: MANAGER_METRICS_SERVICE_CLUSTERIP
               value: "{{ template "splunk-otel-collector.fullname" . }}-operator"

--- a/helm-charts/splunk-otel-collector/templates/operator/job-operator-webhook-startupapicheck.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/job-operator-webhook-startupapicheck.yaml
@@ -19,8 +19,9 @@ spec:
   template:
     spec:
       containers:
-        - name: wget
-          image: "busybox:latest"
+        - name: startupapicheck
+{{/*          image: {{ template "splunk-otel-collector.image.job" . }}*/}}
+          image: registry.access.redhat.com/ubi9/ubi
           env:
             - name: WEBHOOK_SERVICE_CLUSTERIP
               value: "{{ template "splunk-otel-collector.fullname" . }}-operator-webhook"

--- a/helm-charts/splunk-otel-collector/templates/operator/job-operator-webhook-startupapicheck.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/job-operator-webhook-startupapicheck.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.operator.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "splunk-otel-collector.fullname" . }}-operator-webhook-startupapicheck
+  namespace: {{ template "splunk-otel-collector.namespace" . }}
+  labels:
+    {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
+    app: {{ template "splunk-otel-collector.name" . }}
+    component: otel-operator
+    chart: {{ template "splunk-otel-collector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: otel-operator
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "4"
+spec:
+  template:
+    spec:
+      containers:
+        - name: wget
+          image: "busybox:latest"
+          env:
+            - name: WEBHOOK_SERVICE_CLUSTERIP
+              value: "{{ template "splunk-otel-collector.fullname" . }}-operator-webhook"
+            - name: WEBHOOK_SERVICE_PORT
+              value: "443"
+          command:
+            - sh
+            - -c
+            - |
+              i=0
+              while [ $i -lt 300 ]; do
+                if wget -qO- "$WEBHOOK_SERVICE_CLUSTERIP:$WEBHOOK_SERVICE_PORT" 2>&1 | grep -qv "HTTP/1.0 400 Bad Request"; then
+                  echo "Operator webhook service is available."
+                  exit 0
+                fi
+                echo "Waiting for webhook service to become available... (attempt $i)"
+                i=$((i + 1))
+                sleep 1
+              done
+              echo "Timeout reached. Operator webhook service did not become available."
+              exit 1
+      restartPolicy: Never
+{{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1681,6 +1681,18 @@
             }
           },
           "required": ["repository", "tag"]
+        },
+        "job": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1168,13 +1168,14 @@ operator:
   enabled: false
   admissionWebhooks:
     certManager:
-      # Annotate the certificate and issuer to ensure they are created after the cert-manager CRDs have been installed.
-      certificateAnnotations:
-        "helm.sh/hook": post-install,post-upgrade
-        "helm.sh/hook-weight": "1"
+      # Annotate the issuer and certificate to ensure they are created after the cert-manager CRDs
+      # have been installed and cert-manager is ready.
       issuerAnnotations:
         "helm.sh/hook": post-install,post-upgrade
-        "helm.sh/hook-weight": "1"
+        "helm.sh/hook-weight": "2"
+      certificateAnnotations:
+        "helm.sh/hook": post-install,post-upgrade
+        "helm.sh/hook-weight": "3"
   # Collector deployment via the operator is not supported at this time.
   # The collector image repository is specified here to meet operator subchart constraints.
   manager:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -973,7 +973,6 @@ image:
     # The policy that specifies when the user wants the Universal Base images to be pulled
     pullPolicy: IfNotPresent
 
-
 ################################################################################
 # Extra system configuration
 ################################################################################
@@ -1262,6 +1261,10 @@ instrumentation:
     #   - name: NGINX_ENV_VAR
     #     value: nginx_value
   # Auto-instrumentation Libraries (End)
+  # Jobs related to installing, uninstalling, or managing Instrumentation.
+#  job:
+#    repository: registry.access.redhat.com/ubi9/ubi
+#    tag: latest
 
 # The cert-manager is a CNCF application deployed as a subchart and used for supporting operators that require TLS certificates.
 # Full list of Helm value configurations: https://artifacthub.io/packages/helm/cert-manager/cert-manager?modal=values


### PR DESCRIPTION
**Description**  
Helm install failures occur in rare cases due to deployment order issues:  
- **Instrumentation Object:** May fail because the Operator and its webhook are not ready.  
- **Cert-Manager Certificate:** May fail because Cert-Manager is not yet initialized.  

**Proposed Solution**  
Add Helm hooks to enforce readiness checks and ensure resources are deployed in the correct order. Cert-Manager and Operator readiness will be validated before Instrumentation deployment. We will use appropriate Hook weight values to ensure each related operation is completed sequentially.

**Installation Order**  
1. **Default Installation Phase:** Deploy Cert-Manager, Operator, and Operator CRDs.  
2. **Cert-Manager Readiness Check:** Post-install hook (weight 1) verifies Cert-Manager is operational.  
3. **Install Issuer:** Post-install hook (weight 2) deploys the Cert-Manager Issuer.  
4. **Install Certificate:** Post-install hook (weight 3) deploys the Cert-Manager Certificate.  
5. **Operator Readiness Checks:** Post-install hooks (weight 4) validate the Operator and related webhook are ready.  
6. **Install Instrumentation:** Post-install hook (weight 5) deploys Instrumentation resources.  

**Benefits**  
- Ensures dependencies are deployed in the correct order.  
- Mitigates Helm installation errors reported from the field.  

**Cons**  
- Using Helm hooks like this and this much is an anti-pattern for Helm.

**Callouts**  
- **Future Refactoring:** We may refactor Cert-Manager usage and CRD installation in the near future, potentially eliminating the need for post-install hooks. While this PR provides an effective interim solution, it may be short-lived within this project.  

**Testing**  
- Verified with local and lab Kubernetes clusters. 

**Related Alernative solution:** https://github.com/signalfx/splunk-otel-collector-chart/pull/1561
