### PR TITLE
Make it so the default tolerations used to deploy the agent collector account for k8s distribution

### DIFF
--- a/.chloggen/enhance-agent-daemonset-toleration.yaml
+++ b/.chloggen/enhance-agent-daemonset-toleration.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make it so the default tolerations used to deploy the agent collector account for k8s distribution
+# One or more tracking issues related to the change
+issues: [1562]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: OpenShift infra nodes and Azure system nodes will now be monitored by the agent by default

--- a/.chloggen/enhance-agent-daemonset-toleration.yaml
+++ b/.chloggen/enhance-agent-daemonset-toleration.yaml
@@ -9,4 +9,4 @@ issues: [1562]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: OpenShift infra nodes and Azure system nodes will now be monitored by the agent by default
+subtext: OpenShift infra nodes and AKS system nodes will now be monitored by the agent by default

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -44,8 +44,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -44,10 +44,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -42,11 +42,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: kubernetes.io/system-node
           effect: NoSchedule
           operator: Exists

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -41,11 +41,13 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: kubernetes.io/system-node
+          effect: NoSchedule
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
         - key: kubernetes.io/system-node
           effect: NoSchedule
           operator: Exists

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/infra
           effect: NoSchedule
           operator: Exists

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -41,11 +41,13 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/infra
+          effect: NoSchedule
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/infra
           effect: NoSchedule
           operator: Exists

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -44,10 +44,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -42,11 +42,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -44,8 +44,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -44,10 +44,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -42,11 +42,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -44,8 +44,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -42,10 +42,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -42,8 +42,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -40,11 +40,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: windows
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -44,10 +44,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -42,11 +42,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -44,8 +44,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: prepare-fluentd-config
           image: splunk/fluentd-hec:1.3.3

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       initContainers:
         - name: migrate-checkpoint
           image: quay.io/signalfx/splunk-otel-collector:0.113.0

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -41,11 +41,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
-        
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       containers:
       - name: otel-collector
         command:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -43,8 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
       containers:
       - name: otel-collector
         command:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -43,10 +43,10 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
       containers:
       - name: otel-collector
         command:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -80,10 +80,10 @@ spec:
       {{- else }}
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
-          operator: Equal
+          operator: Exists
         {{- if eq .Values.distribution "aks" }}
         - key: kubernetes.io/system-node
           effect: NoSchedule

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -74,9 +74,24 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
       tolerations:
-        {{ toYaml . | nindent 8 }}
+      {{- if and (.Values.tolerations) (ne (len .Values.tolerations) 0) }}
+        {{ toYaml .Values.tolerations | nindent 8 }}
+      {{- else }}
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        {{- if eq .Values.distribution "openshift" }}
+        - key: node-role.kubernetes.io/infra
+          effect: NoSchedule
+          operator: Exists
+        {{- end }}
+        {{- if eq .Values.distribution "aks" }}
+        - key: kubernetes.io/system-node
+          effect: NoSchedule
+          operator: Exists
+        {{- end }}
       {{- end }}
       {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (not .Values.isWindows) (not $agent.skipInitContainers) }}
       initContainers:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -80,8 +80,10 @@ spec:
       {{- else }}
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Equal
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
+          operator: Equal
         {{- if eq .Values.distribution "openshift" }}
         - key: node-role.kubernetes.io/infra
           effect: NoSchedule

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -84,13 +84,13 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
           operator: Equal
-        {{- if eq .Values.distribution "openshift" }}
-        - key: node-role.kubernetes.io/infra
+        {{- if eq .Values.distribution "aks" }}
+        - key: kubernetes.io/system-node
           effect: NoSchedule
           operator: Exists
         {{- end }}
-        {{- if eq .Values.distribution "aks" }}
-        - key: kubernetes.io/system-node
+        {{- if eq .Values.distribution "openshift" }}
+        - key: node-role.kubernetes.io/infra
           effect: NoSchedule
           operator: Exists
         {{- end }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1009,19 +1009,16 @@ secret:
   # Specifies whether secret provided by user should be validated.
   validateSecret: true
 
-# This default tolerations allow the daemonset to be deployed on control-plane
-# nodes, so that we can also collect logs and metrics from those nodes.
-tolerations:
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
-  - key: node-role.kubernetes.io/control-plane
-    effect: NoSchedule
+# The olerations for deploying agent collector daemonset. By default, it targets control-plane, worker,
+# and k8s distribution-specific nodes (infrastructure or system) to ensure logs and metrics collection.
+# If set, the specified tolerations will override the defaults.
+tolerations: []
 
-# Defines which nodes should be selected to deploy the o11y collector daemonset.
+# Defines which nodes should be selected to deploy the agent collector daemonset.
 nodeSelector: {}
 terminationGracePeriodSeconds: 600
 
-# Defines node affinity to restrict deployment of the o11y collector daemonset.
+# Defines node affinity to restrict deployment of the agent collector daemonset.
 affinity: {}
 
 # Defines priorityClassName to assign a priority class to pods.

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1009,8 +1009,8 @@ secret:
   # Specifies whether secret provided by user should be validated.
   validateSecret: true
 
-# The olerations for deploying agent collector daemonset. By default, it targets control-plane, worker,
-# and k8s distribution-specific nodes (infrastructure or system) to ensure logs and metrics collection.
+# The tolerations for deploying the agent collector daemonset. By default, it targets control-plane, worker,
+# and k8s distribution-specific nodes (infrastructure or system) to ensure logs and metrics collection from nodes.
 # If set, the specified tolerations will override the defaults.
 tolerations: []
 


### PR DESCRIPTION
**Description:**  
- Added default tolerations to monitor control-plane, worker, and distribution-specific node pools with the agent collector based on the Kubernetes distribution:
  - OpenShift: infrastructure node pool
  - AKS: system node pool  
- Previously, OpenShift and AKS users needed to configure these tolerations manually. Based on field feedback, this change automates the configuration, simplifying setup and ensuring out-of-the-box support for unique node pools.