### PR TITLE
Scrape FS metrics from one host disk mounted to the root

### DIFF
--- a/.chloggen/do-not-scrape-fs-metrics-from-snap-mount.yaml
+++ b/.chloggen/do-not-scrape-fs-metrics-from-snap-mount.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Scrape FS metrics from one host disk mounted to the root to avoid scraping errors since the collector likely doesn't have access to other mounts.
+# One or more tracking issues related to the change
+issues: [1569]

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -309,10 +309,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 62b12f9782be458e4d851b56b3736779d9fa819b31d602c2690a85e1e2651398
+        checksum/config: 599ae6240b728a0f8301552303b8efc55a0040caac39ecba1e04d4fe41f879ac
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -258,10 +258,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6b91121b6bca3137df4e27936265ce0db0896ac28a41c32b655bd82f566ca63b
+        checksum/config: f1de5c58c5e1dade0ae34291f7c2052ec977104cd591d80af085e46119c7a4c1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 98e82d01663b276d8e9d39d0c067119a5e8faecdac14b95bed092414f1d26e4a
+        checksum/config: 879c032d48dac95fa58dae345063f3209037b6b8f1f2941bc3799ccfa343cb43
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -143,10 +143,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c516877b22714b6549007864d7a67fbb8247f2e9c7b3f3103cb758e734b07fac
+        checksum/config: ea59bab11b6951542d0951611791b361ddad62449c19bb69ebb2d43ca14869e3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -293,10 +293,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6e673abe5511ec2032b2d3ae7db8f3753ed1fde726389c86bfdf44477423e8b6
+        checksum/config: cec7fb80a25b44aac4bbe1a98c3a7dbec489c2cf18f28d68a5f932c0f2879257
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 777574d73f3948712985d93f22b80f7fd878e5b96d08e33ca35a949b7c826943
+        checksum/config: f1c0ed384f3dcb0048464394fbcac49f7ade4ffe0a21cada1479371bced3c829
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -124,10 +124,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 83e5487eaf9d38ed3e7b0e1794194e13e9999148ea9b243cb722b20c2e65f69e
+        checksum/config: f4e781a8e2b267c29c9b6a9be81e4fde6b75035af95c1152b9bfad173aeaeb1f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -145,10 +145,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bd7c6d887d5635760fdfce06ba65107fbebf3ce9b25eb718b654b1f7274d767a
+        checksum/config: b8939e7c87c9ee524461e8c0c56db1eafdcd0c3b5362100ec3e00befe8e0ea13
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 777574d73f3948712985d93f22b80f7fd878e5b96d08e33ca35a949b7c826943
+        checksum/config: f1c0ed384f3dcb0048464394fbcac49f7ade4ffe0a21cada1479371bced3c829
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 777574d73f3948712985d93f22b80f7fd878e5b96d08e33ca35a949b7c826943
+        checksum/config: f1c0ed384f3dcb0048464394fbcac49f7ade4ffe0a21cada1479371bced3c829
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -346,10 +346,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b004ddf898fc1caa94ef51614938704a33563cdd32c01bdb097a597162642cc3
+        checksum/config: fc4611b77f0e7c94d5d2bf90dd4ad3372d81b7681b661cf7f966819529078c3a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6304ccf9319530453afd837d241e5b5af1b36c4de40662d7b5bad40b004a258b
+        checksum/config: f4b4fec857ce1b372b6676a63ae2eb21da8f144dad8a15ad6c53f6621a60cc74
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -142,10 +142,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: dcc20675c31a093e01099e1db64434a6f6cccfa8c8d1949d3b2173673d5221ec
+        checksum/config: e0eb91e3ebf60872be16884972d437296c4fa5891c51f8b89929ebe4a480cfb9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -142,10 +142,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a8fe90475cc286359dd2944b3a3af5b5e2b6f776e987da995f421216e348a41e
+        checksum/config: 17091fcba0e1a850ef7d5bfcfa88a2b62141191519057e6651d97445365f9d72
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -141,10 +141,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c3292448f4b1f0def03cfde9e2772349cb2a533c3a70a412e4cbbf5b1507b787
+        checksum/config: 0a98fced2980a4471c42c3066189d7e86e734bb6e32ae2a309a81ca4ff8315a2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -141,10 +141,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 56cf37f1b1eff2f7a9e128a839efab64ec48afc5ae1116006d670e079f8a71d4
+        checksum/config: ce387c3d2af973c37a6864db4703b3cebd5ccb8232eecbd27e5fb3cd5ec6f943
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8e095feeacd3811fb1b231b8f0d86f4c782ca875aee425d6335535d2572c5bf4
+        checksum/config: 5db1e75be1fec098f07e913a95ce2deb6a67bf725e5bab9c55a57b29ddb0736c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -263,10 +263,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 79059b846a30bbc5b483a786ee108a4112a98f1886fdef97969b9f3687000749
+        checksum/config: 34109b77372d48f73edb4c4de3899c6aa1cb176bc77bd0e018f80de3fc9eb3af
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -346,10 +346,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1a4382f5b77cb685de6686b307d6ea58f3a3c3da04463d088e8080f8f11c1fb1
+        checksum/config: eb794d87d20e2f392d41357786bb2fd4f02fbf4a08d4eb7624adb5d6dab8a698
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -141,10 +141,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: aa6537d1dac202cd66363f17ce3173efe1dad71dfecd6a5b32e48837970dccc5
+        checksum/config: a5da43fbd08549166e7275760e5d27adc72c2e2efeb5bb351ababeee4c7b47bd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -158,10 +158,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7aec05b09489238f40b5db4c375900ed0fbd7a4295df4a732a879b5d166bd6cd
+        checksum/config: 3f644472796749aeb3c07db5213657b444f742b64742a17c99118f83ac73aace
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -158,10 +158,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fa9cd8190ae8522320ba56f2574d27d32e937c4f331edac13af02c307eb9bfda
+        checksum/config: 76db1beace042957316a45982c093060cc753d1648e8c9740e3acb3c0a5adb35
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -262,10 +262,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0f820425d8e3ec1265f78ed76a73995fc647a0a05cfa263b2621674c31302c5e
+        checksum/config: c03d3c55abad541d0b1b20f165a4bd6b9d9aae8491486343f089e7b09dec7c8c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -318,10 +318,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 95a8f2e139ce46d93d5d388a0ac6410b9ac3810940f67c3ff217942f1eb10829
+        checksum/config: 37094177a299edf764ed863b73af93bda4d95f4cfcf1a9b0fa5819d3146f5623
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -181,10 +181,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9143bce1e08ae4a051c797ef2ba503f0101f143b911653d71752d3252c888bb7
+        checksum/config: 2554e887b8e5144f559c95b7219aa9d2d83602a6b09cbf89baf6e655023ab553
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -135,10 +135,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fa508b761cb98ff0bc8b5fbc62e28016b574101048c9b69ec067572278a9a634
+        checksum/config: 7a917dd48f4d1481acdb34cbd1fa111492f8cca4c316768366d2fe261879b6c5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -144,10 +144,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a48a65ca17ab387b3a2358dc33ad091c53309eb0d371955defbf5500dbe1c5af
+        checksum/config: 6e294c7fc535bdea5ae02523f67c97a88194d6027535bf292ebf0544e92dfe9d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: be77a1e4ac17791bcde7128e6b566358a9deb90a24fc8c386ca40f0a5dcda325
+        checksum/config: 51bea0dee2704e1e334499d90f57cbef531d2db4141b9bbaf0d759a01d1c0e41
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 777574d73f3948712985d93f22b80f7fd878e5b96d08e33ca35a949b7c826943
+        checksum/config: f1c0ed384f3dcb0048464394fbcac49f7ade4ffe0a21cada1479371bced3c829
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -140,10 +140,10 @@ data:
           cpu: null
           disk: null
           filesystem:
-            exclude_mount_points:
-              match_type: regexp
+            include_mount_points:
+              match_type: strict
               mount_points:
-              - /var/.*
+              - /
           load: null
           memory: null
           network: null

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 331113a08a530204f0895358fb1c3b56f6caa37bf572a54181bcf12a03e78a62
+        checksum/config: b1a790a3d549bdfed08023dc6d5614673313ece945513a90f6ac1bfebab9dcb9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -56,10 +56,15 @@ receivers:
       cpu:
       disk:
       filesystem:
-        # exclude mount points that are accessible from the collector container
-        exclude_mount_points:
-          match_type: regexp
-          mount_points: [/var/.*]
+        # Collect metrics from the root filesystem only to avoid scraping errors since the collector
+        # doesn't have access to all filesystems on the host by default. To collect metrics from
+        # other devices, ensure that they are mounted to the collector container using
+        # agent.extraVolumeMounts and agent.extraVolumes helm values options and override this list
+        # using agent.config.hostmetrics.filesystem.include_mount_points.mount_points helm value.
+        include_mount_points:
+          match_type: strict
+          mount_points:
+            - "/"
       memory:
       network:
       # System load average metrics https://en.wikipedia.org/wiki/Load_(computing)


### PR DESCRIPTION
to avoid scraping errors since the collector likely doesn't have access to other mounts.