### PR TITLE
Add preserveLeadingWhitespaces and preserveTrailingWhitespaces variables under logsCollection.containers in values.yaml

### DIFF
--- a/.chloggen/fixwhitespaceconfigfilelog.yaml
+++ b/.chloggen/fixwhitespaceconfigfilelog.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add possibility to modify preserve_leading_whitespaces and preserve_trailing_whitespaces variables of filelog receiver through values.yaml"
+# One or more tracking issues related to the change
+issues: [1571]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -296,6 +296,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 62b12f9782be458e4d851b56b3736779d9fa819b31d602c2690a85e1e2651398
+        checksum/config: 8d6900c97e5d3bf0d8ce00c6eeff9904ae3461c86e118da887e7ae395dc4ffd2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -245,6 +245,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6b91121b6bca3137df4e27936265ce0db0896ac28a41c32b655bd82f566ca63b
+        checksum/config: bfda1e2d0b74799cbe5d5c4204a48ac332b6d769f1f5ec7ea7bf1be1d4cae1f3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -280,6 +280,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6e673abe5511ec2032b2d3ae7db8f3753ed1fde726389c86bfdf44477423e8b6
+        checksum/config: dc397cdaad1302bdc95b593fbced87ef2099d8ed95589ce5eeb208fdfbfd0b11
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -333,6 +333,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b004ddf898fc1caa94ef51614938704a33563cdd32c01bdb097a597162642cc3
+        checksum/config: 8c731d1e8c617fc408a84c62d32516c4ce5afa75070402be343e7ca2019d3c5c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -250,6 +250,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 79059b846a30bbc5b483a786ee108a4112a98f1886fdef97969b9f3687000749
+        checksum/config: cd4dad6ea2ba0557ee4ad2d802f049e7457b40cf8364ac1d30c588d66908a7ec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -333,6 +333,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1a4382f5b77cb685de6686b307d6ea58f3a3c3da04463d088e8080f8f11c1fb1
+        checksum/config: 87e78a8fd3cf5ade5cbfde1213ec59553056eaf5a11ecf2e36bd23e06ce82a2d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -250,6 +250,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0f820425d8e3ec1265f78ed76a73995fc647a0a05cfa263b2621674c31302c5e
+        checksum/config: 28183ba1e70bbfd80cb9e68c71d6b253121ca16422a28215b15f974436864f14
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -305,6 +305,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 95a8f2e139ce46d93d5d388a0ac6410b9ac3810940f67c3ff217942f1eb10829
+        checksum/config: 935a514186a4b1d36e343f0047f5ee5dba0378a51ab1f02a92fab34b1fd16897
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -275,6 +275,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 435a66dc5f7ca1ee96a30c06460f439de9caa772085c4ed35edac0353a028c3f
+        checksum/config: 5574a7553ab2a44605cf3f8c6832f1e93d1d54682c63428f18706e52496b133a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -240,6 +240,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ad7210c615ee36c07eb8295a088446b0f3775bd3d6cb2bb1209b1d9c2893614c
+        checksum/config: 06ea25889a8127c43bd0cf609b4cf2958cb28b9b1935ada6e8d385f1d6b44db1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -240,6 +240,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 578b1d7d7d7d733110ccefa32e1b4f82691184938ae3f0335ed33d7e43066400
+        checksum/config: b6a7f3a860dbab9fb74c9b0e634b8255e0b705b4ce17936424396746bfc338ab
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -255,6 +255,8 @@ data:
         - field: attributes.time
           type: remove
         poll_interval: 200ms
+        preserve_leading_whitespaces: false
+        preserve_trailing_whitespaces: false
         retry_on_failure:
           enabled: true
         start_at: beginning

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 66e1f37d91e78951760215444772f1fa58b96197824da8a437191e12b8a090f4
+        checksum/config: d8c30fb1d47d21e9bac15a312f9da62d0189b9b0fbc05c597a45054b853a03ac
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -423,6 +423,8 @@ receivers:
       {{- range $_, $excludePath := .Values.logsCollection.containers.excludePaths }}
       - {{ $excludePath }}
       {{- end }}
+    preserve_leading_whitespaces: {{ .Values.logsCollection.containers.preserveLeadingWhitespaces | default false }}
+    preserve_trailing_whitespaces: {{ .Values.logsCollection.containers.preserveTrailingWhitespaces | default false }}
     start_at: beginning
     include_file_path: true
     include_file_name: false

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -833,6 +833,12 @@
             },
             "maxRecombineLogSize": {
               "type": "integer"
+            },
+            "preserveLeadingWhitespaces":{
+              "type": "boolean"
+            },
+            "preserveTrailingWhitespaces": {
+              "type": "boolean"
             }
           }
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -621,6 +621,11 @@ logsCollection:
     # Set to 0 to remove any size limit.
     maxRecombineLogSize: 1048576
 
+    # Whether to preserve leading whitespaces in logs.
+    preserveLeadingWhitespaces: false
+    # Whether to preserve trailing whitespaces in logs.
+    preserveTrailingWhitespaces: false
+
 # Configuration for collecting journald logs using otel collector
   journald:
     enabled: false


### PR DESCRIPTION
**Description:**  Allow users to control whether filelog receiver should remove leading and trailing whitespaces from their logs. We noticed a case when one log message is spread across several logs and then joined using [recombine operator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/docs/operators/recombine.md), the default behaviour of filelog receiver (removing leading and trailing whitespaces) resulted in malformed combined log. 

**Testing:** Manual testing

**Documentation:** 
