### PR TITLE
Update config for setting up internal metrics scraper

### DIFF
--- a/.chloggen/update-service-telemetry-endpoint.yaml
+++ b/.chloggen/update-service-telemetry-endpoint.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent, clusterReceiver, gateway
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update config for scraping internal metrics to use new config interface and loopback address.
+# One or more tracking issues related to the change
+issues: [1573]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "This also drops redundant attributes reported with the internal metrics: `net.host.name` and `server.address`"

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -361,7 +361,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -493,4 +493,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 599ae6240b728a0f8301552303b8efc55a0040caac39ecba1e04d4fe41f879ac
+        checksum/config: e62f6ee4ef1ba1d8771d4056077ed10afe5d3bc6b4052980b2a7cc9f15a2bcdd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -317,7 +317,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -443,4 +443,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f1de5c58c5e1dade0ae34291f7c2052ec977104cd591d80af085e46119c7a4c1
+        checksum/config: e8ae8de67a024a79ab31a0ac261fdb0c85fd63b509681242d93917bfc29b8a76
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           postgresql:
@@ -321,4 +321,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 879c032d48dac95fa58dae345063f3209037b6b8f1f2941bc3799ccfa343cb43
+        checksum/config: 46b8ba55ad9b9c54254be9211b0396df3cd0d3a71dbc20fb3ba8893b6318ad88
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -195,7 +195,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -310,4 +310,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ea59bab11b6951542d0951611791b361ddad62449c19bb69ebb2d43ca14869e3
+        checksum/config: 4a6276e318600d9ea3e76c91b6670f201c626ba375a03af94eac9d8efcf71cdb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -345,7 +345,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           prometheus_simple:
@@ -485,4 +485,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cec7fb80a25b44aac4bbe1a98c3a7dbec489c2cf18f28d68a5f932c0f2879257
+        checksum/config: c22db802040791e7ed72c236060ae18ce39720b23c968d35bd6d8aac1fb07295
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -306,4 +306,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f1c0ed384f3dcb0048464394fbcac49f7ade4ffe0a21cada1479371bced3c829
+        checksum/config: 1d6330c88154a12a7ef72f47ff1fe38ad8ab08eb47f5116a2b16c13f735ade30
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -176,7 +176,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -290,4 +290,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -161,7 +161,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       signalfx:
         access_token_passthrough: true
         endpoint: 0.0.0.0:9943
@@ -216,4 +216,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f4e781a8e2b267c29c9b6a9be81e4fde6b75035af95c1152b9bfad173aeaeb1f
+        checksum/config: aa6f2aba1c3d388e69538aef580c1ab673bd1bbc263a1ecccb99a7cd76c2e25d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: c1ba585335a1664db94d7d2cfe258e3a202873cf1948cb69b70291944faa95da
+        checksum/config: 9a18e1abec41b07245232e29f2462870e5bda91ddb7df7775e434c1d393f5c7f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,7 +133,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -173,4 +173,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b7c6c8b6f15da89afa7eff5ec8989a631bb3004f90d82d3bf6b7f36a94c08813
+        checksum/config: 16eb789f621f6f691683ae1d9872e6221975434b8cafa68b14aa399c3d07f46e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -161,7 +161,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       signalfx:
         access_token_passthrough: true
         endpoint: 0.0.0.0:9943
@@ -216,4 +216,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: c1ba585335a1664db94d7d2cfe258e3a202873cf1948cb69b70291944faa95da
+        checksum/config: 9a18e1abec41b07245232e29f2462870e5bda91ddb7df7775e434c1d393f5c7f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -197,7 +197,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           prometheus/coredns:
@@ -346,4 +346,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b8939e7c87c9ee524461e8c0c56db1eafdcd0c3b5362100ec3e00befe8e0ea13
+        checksum/config: 71ea8369e9e1803325fc72bbcfcf4a28339570a0c421c74677a752722f8a5cb6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -306,4 +306,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f1c0ed384f3dcb0048464394fbcac49f7ade4ffe0a21cada1479371bced3c829
+        checksum/config: 1d6330c88154a12a7ef72f47ff1fe38ad8ab08eb47f5116a2b16c13f735ade30
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -306,4 +306,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f1c0ed384f3dcb0048464394fbcac49f7ade4ffe0a21cada1479371bced3c829
+        checksum/config: 1d6330c88154a12a7ef72f47ff1fe38ad8ab08eb47f5116a2b16c13f735ade30
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -398,7 +398,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -526,4 +526,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -135,7 +135,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -165,4 +165,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fc4611b77f0e7c94d5d2bf90dd4ad3372d81b7681b661cf7f966819529078c3a
+        checksum/config: 8f13ff66652ba33fe2a9aee4c1a2e43517bfe12d57093be5d675ef515f537d78
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2ebe19c84fd799cfbd9504a0957789f9a289d04bc9a1a08712b09ea6a339c81f
+        checksum/config: 31057c8fa63ede3a8e48bce75a40865619cdd244a7cc16ade3471013072fb603
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -306,7 +306,12 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889
   discovery.properties: |
     splunk.discovery:
       extensions:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f4b4fec857ce1b372b6676a63ae2eb21da8f144dad8a15ad6c53f6621a60cc74
+        checksum/config: 231a2f6df986952c3f8bee10614bcf75037622f942563f3efdcbfc5a8e132f0a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -194,7 +194,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers: null
         watch_observers:
@@ -264,4 +264,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -93,7 +93,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -121,4 +121,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e0eb91e3ebf60872be16884972d437296c4fa5891c51f8b89929ebe4a480cfb9
+        checksum/config: b77d2f4051fab7484cd75e4c622c11aabd72af22dbf6f63412ef41d5e312a87f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c090a229396be782ca350ada8b83f622afca01a39a4238279b01b6780eaf7c1f
+        checksum/config: a26a387d06f8d9ff63215cdd2e7762321b8c1e63734b2af49f80874f5bf641f9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -96,7 +96,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           kubeletstats:
@@ -150,4 +150,9 @@ data:
           - receiver_creator
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -163,7 +163,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       signalfx:
         access_token_passthrough: true
         endpoint: 0.0.0.0:9943
@@ -218,4 +218,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d78e0d008e7296fe1c3fa48154a5840e42560b5d8324d3264b164f9c928e3373
+        checksum/config: 93de5553d98ca8c1308763682892e9d8f85066cd76192936be78510a08d5d4f2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 8798c374ad73a8d5d2707ec1e0a459e6257a8b79a6fc389a21a543a534d63d89
+        checksum/config: e3a492daf843c7412ff52604bb5ad1197601fe57b94f27527f030b9671000ecd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -194,7 +194,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers: null
         watch_observers:
@@ -264,4 +264,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -111,7 +111,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -140,4 +140,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 17091fcba0e1a850ef7d5bfcfa88a2b62141191519057e6651d97445365f9d72
+        checksum/config: 2c67fa0a01433844aaf5c723440d30f55c6c90dd05554e96e3a186279a3d603e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b0f51497d57f09b27212e1e240b285b46ce5b0ae425a1e2b38a448342b955d19
+        checksum/config: f9a639dc73306fd666cd53308a3f5b491b20b70f2ff489b230d2f2a47731282a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -193,7 +193,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers: null
         watch_observers:
@@ -263,4 +263,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -120,4 +120,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0a98fced2980a4471c42c3066189d7e86e734bb6e32ae2a309a81ca4ff8315a2
+        checksum/config: e0fa06b0593a64c95a4cfcaf7516fab16808ac2985ac30f02d0549fff6cf6efc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 09f2176d296fde148259746e522d9c8a9879a710249f7d8c0ac2158f86853290
+        checksum/config: c79002621deb1b6a8c3d2fa7eeedb291558c59ad7c05d0e4ad9dd7dfd5e1050a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -193,7 +193,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers: null
         watch_observers:
@@ -263,4 +263,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -120,4 +120,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ce387c3d2af973c37a6864db4703b3cebd5ccb8232eecbd27e5fb3cd5ec6f943
+        checksum/config: 747dcc2cf82c242f5c1e93afbe873cef0230ab630026acbef7afb4a170561fbf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 09f2176d296fde148259746e522d9c8a9879a710249f7d8c0ac2158f86853290
+        checksum/config: c79002621deb1b6a8c3d2fa7eeedb291558c59ad7c05d0e4ad9dd7dfd5e1050a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -314,4 +314,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -120,4 +120,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5db1e75be1fec098f07e913a95ce2deb6a67bf725e5bab9c55a57b29ddb0736c
+        checksum/config: 5604b19093ef3a5f7d732fe88084dac041d662b8db54be49883e68edf05b61a5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fc1948ab34d8173f04fa0f56f5988af51b3ae3867d0a45cf295a220e85c05676
+        checksum/config: f3c1444fc4a52e438505dda39fbaa9efceb923cbc38be5ac2c3b0eb90d2aa38d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -315,7 +315,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -447,4 +447,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 34109b77372d48f73edb4c4de3899c6aa1cb176bc77bd0e018f80de3fc9eb3af
+        checksum/config: fffa19a4586067f00cfbcf33346aeb74293292766d08dbe53c8beb8f447cb4fc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d53af150853be9b03d554d64c43c83776cd5af4c906b7db6652460557dc27549
+        checksum/config: beda1c4d66ee049ca6ac56a57faab5831c4108eb760853740bfe9782ceb235fb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -398,7 +398,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -526,4 +526,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -135,7 +135,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -165,4 +165,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: eb794d87d20e2f392d41357786bb2fd4f02fbf4a08d4eb7624adb5d6dab8a698
+        checksum/config: 7e28ba091fe865d050d7328d4484a25a517e3f7937d660ab8aca68b1f7206d21
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2ebe19c84fd799cfbd9504a0957789f9a289d04bc9a1a08712b09ea6a339c81f
+        checksum/config: 31057c8fa63ede3a8e48bce75a40865619cdd244a7cc16ade3471013072fb603
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -169,7 +169,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       smartagent/signalfx-forwarder:
         listenAddress: 0.0.0.0:9080
         type: signalfx-forwarder
@@ -219,4 +219,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c9751de7681298fa09fa98b0a7f426e9f72c927617625596dc9d7829f73287bd
+        checksum/config: 87ed5affb87edf7ca49ed750ba43eeb6ec9c15f1a30ff507640dbdc10a819d19
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -193,7 +193,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -308,4 +308,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a5da43fbd08549166e7275760e5d27adc72c2e2efeb5bb351ababeee4c7b47bd
+        checksum/config: 533c39b970ca066d32816a89883d8d71a47056cb8fb9e01c7f4a164e3dddc894
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -210,7 +210,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -339,4 +339,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3f644472796749aeb3c07db5213657b444f742b64742a17c99118f83ac73aace
+        checksum/config: 294cef8c6d6f4ab7e9c2c92b02f377e8ede701cc0b7942fde18617b1c615684e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -210,7 +210,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -339,4 +339,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 76db1beace042957316a45982c093060cc753d1648e8c9740e3acb3c0a5adb35
+        checksum/config: cffb91393d44138edc979f79c33175a975444fb3a7ff92240498d76bf23da4e6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -314,7 +314,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -445,4 +445,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c03d3c55abad541d0b1b20f165a4bd6b9d9aae8491486343f089e7b09dec7c8c
+        checksum/config: bf49f549e45d83598b52121660f4cd179d3f97f0f71dab39bf412367b621d242
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -364,7 +364,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -476,4 +476,9 @@ data:
           - prometheus/agent
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -135,7 +135,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -165,4 +165,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 37094177a299edf764ed863b73af93bda4d95f4cfcf1a9b0fa5819d3146f5623
+        checksum/config: 5b4ddaf2cc99de360060d11ef3f956eaf152f249d2aeb62cf477602745b4cea1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2ebe19c84fd799cfbd9504a0957789f9a289d04bc9a1a08712b09ea6a339c81f
+        checksum/config: 31057c8fa63ede3a8e48bce75a40865619cdd244a7cc16ade3471013072fb603
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -173,7 +173,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -218,4 +218,9 @@ data:
           - prometheus/agent
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 85fa1a338deedcff51ed1f26f5d15ba819bf816a046344b0f5a61982eddb9779
+        checksum/config: bdc593fc6bb963542e70636338e108d880db0730ef8e3c356df5925bcebb2af6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -308,7 +308,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - file_storage
@@ -354,4 +354,9 @@ data:
           - prometheus/agent
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 435a66dc5f7ca1ee96a30c06460f439de9caa772085c4ed35edac0353a028c3f
+        checksum/config: 7ae5eac37faee22fb3d54332696ec32e0ee7c02cf20a5a4e7665d26bfbfc5a2c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -301,7 +301,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - file_storage
@@ -357,4 +357,9 @@ data:
           - prometheus/agent
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ad7210c615ee36c07eb8295a088446b0f3775bd3d6cb2bb1209b1d9c2893614c
+        checksum/config: c32110f203c813ed884597ecfa98f6337945e80cf154d1a66dd84232c74d1508
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -227,7 +227,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -323,4 +323,9 @@ data:
           - prometheus/agent
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -135,7 +135,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -165,4 +165,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2554e887b8e5144f559c95b7219aa9d2d83602a6b09cbf89baf6e655023ab553
+        checksum/config: 1d48c12fc0681c6793c2c6e581e5199248d33a81165761431e28cc813cecd5c5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2ebe19c84fd799cfbd9504a0957789f9a289d04bc9a1a08712b09ea6a339c81f
+        checksum/config: 31057c8fa63ede3a8e48bce75a40865619cdd244a7cc16ade3471013072fb603
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -181,7 +181,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -275,4 +275,9 @@ data:
           - prometheus/agent
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7a917dd48f4d1481acdb34cbd1fa111492f8cca4c316768366d2fe261879b6c5
+        checksum/config: 25993deedb3b21f8c07058cba61cb0cf7bde34473b48c7e3d2dca615b5eed460
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -166,7 +166,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       smartagent/signalfx-forwarder:
         listenAddress: 0.0.0.0:9080
         type: signalfx-forwarder
@@ -215,4 +215,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: db301b13e34d9ae14ccdeda3bce410b2dedd0a53cb80f9b6c681cb58b2107943
+        checksum/config: 2c176facdef5a9c1b642a71cc7608bd30d1ff2bd95ee138a8b2ef96a72c385bd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -196,7 +196,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -313,4 +313,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6e294c7fc535bdea5ae02523f67c97a88194d6027535bf292ebf0544e92dfe9d
+        checksum/config: 2b6cf7100cf13fc7b91055f8f32720a6999caf9ece7f6c834d21204ab80c02bd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: ea4abbb36af6031e76cb8af5268707cb8449b3839b957f6206f342e8faa87ba8
+        checksum/config: 54fc5cd7eeb294eed3f035509cb18d352a86accf13563cdc91e49f2d527d523d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -273,7 +273,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - file_storage
@@ -319,4 +319,9 @@ data:
           - prometheus/agent
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 578b1d7d7d7d733110ccefa32e1b4f82691184938ae3f0335ed33d7e43066400
+        checksum/config: 6c57b882104f758c1b708ac9ee4f5e5bd133faeb8594957b7b1baacbf6d37e98
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -288,7 +288,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - file_storage
@@ -323,4 +323,9 @@ data:
           - nop
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 66e1f37d91e78951760215444772f1fa58b96197824da8a437191e12b8a090f4
+        checksum/config: 3a45f718a21ebacf0c0c7d5d892d43e4cf761adc81e7f6eba5a9e2c6b466fb4e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       prometheus/crd:
         config:
           global:
@@ -314,4 +314,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 51bea0dee2704e1e334499d90f57cbef531d2db4141b9bbaf0d759a01d1c0e41
+        checksum/config: 5a020b1268df244ba36936ae8f5f0d3e64c0f804979402c47d071f94b1066d7e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       receiver_creator:
         receivers:
           smartagent/coredns:
@@ -306,4 +306,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f1c0ed384f3dcb0048464394fbcac49f7ade4ffe0a21cada1479371bced3c829
+        checksum/config: 1d6330c88154a12a7ef72f47ff1fe38ad8ab08eb47f5116a2b16c13f735ade30
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -192,7 +192,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
       prometheus/ta:
         config:
           global:
@@ -315,4 +315,9 @@ data:
           - zipkin
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -91,7 +91,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - ${K8S_POD_IP}:8889
+              - localhost:8889
     service:
       extensions:
       - health_check
@@ -119,4 +119,9 @@ data:
           - prometheus/k8s_cluster_receiver
       telemetry:
         metrics:
-          address: 0.0.0.0:8889
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: localhost
+                  port: 8889

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b1a790a3d549bdfed08023dc6d5614673313ece945513a90f6ac1bfebab9dcb9
+        checksum/config: 134b3c49173c0d6dfac367908b7792d171d61a6547407cdb1a37102577920b30
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4b62199b9bbcfb6f7dc9ae4dd0ec6fc45a2a5953d7002ed90e884883b6f0ad4b
+        checksum/config: ff5ed57ffd6eaabc34c61f909a53c3ead6cf13539461c69ae410cc955d467a21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -558,6 +558,5 @@ prometheus/{{ $receiver }}:
         - __name__
       scrape_interval: 10s
       static_configs:
-      - targets:
-        - "${K8S_POD_IP}:8889"
+      - targets: [localhost:8889]
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -847,7 +847,12 @@ exporters:
 service:
   telemetry:
     metrics:
-      address: 0.0.0.0:8889
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: localhost
+                port: 8889
   extensions:
     {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (eq .Values.logsEngine "otel") }}
     - file_storage

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -137,7 +137,12 @@ exporters:
 service:
   telemetry:
     metrics:
-      address: 0.0.0.0:8889
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: localhost
+                port: 8889
   extensions:
     - health_check
     - zpages

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -212,7 +212,12 @@ exporters:
 service:
   telemetry:
     metrics:
-      address: 0.0.0.0:8889
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: localhost
+                port: 8889
   {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
   extensions: [health_check, k8s_observer]
   {{- else }}


### PR DESCRIPTION
Update config for scraping internal metrics to use new config interface and loopback address. This also drops redundant attributes reported with the internal metrics: `net.host.name` and `server.address`.
