### PR TITLE
Add optional annotations to secrets

### DIFF
--- a/.chloggen/secretannotations.yaml
+++ b/.chloggen/secretannotations.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add optional annotations to secrets
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/secretannotations.yaml
+++ b/.chloggen/secretannotations.yaml
@@ -5,7 +5,7 @@ component: chart
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add optional annotations to secrets
 # One or more tracking issues related to the change
-issues: []
+issues: [1599]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/helm-charts/splunk-otel-collector/templates/secret-etcd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-etcd.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: {{ template "splunk-otel-collector.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.agent.controlPlaneMetrics.etcd.secret.annotations }}
+  annotations:
+    {{- toYaml .Values.agent.controlPlaneMetrics.etcd.secret.annotations | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- with .Values.agent.controlPlaneMetrics.etcd.secret.clientCert }}

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
@@ -10,6 +10,10 @@ metadata:
     chart: {{ template "splunk-otel-collector.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.secret.annotations }}
+  annotations:
+    {{- toYaml .Values.secret.annotations | nindent 4 }}
+  {{- end }}
 type: Opaque
 data:
   {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -425,6 +425,9 @@
                     },
                     "caFile": {
                       "type": "string"
+                    },
+                    "annotations": {
+                      "type": "object"
                     }
                   }
                 },
@@ -1188,6 +1191,9 @@
         },
         "validateSecret": {
           "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
         }
       }
     },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -320,6 +320,8 @@ agent:
         # NOTE: The content of the file itself should be used here, not the file path.
         #       The file will be stored as a secret in kubernetes.
         caFile: ""
+        # Secret annotations
+        annotations: {}
       # Specifies whether the etcd's TLS cert will be verified. If set to false, a CA certificate must be made
       # available as part of the etcd secret to verify the TLS cert with.
       skipVerify: true
@@ -1010,6 +1012,8 @@ secret:
   name: ""
   # Specifies whether secret provided by user should be validated.
   validateSecret: true
+  # Secret annotations
+  annotations: {}
 
 # The tolerations for deploying the agent collector daemonset. By default, it targets control-plane, worker,
 # and k8s distribution-specific nodes (infrastructure or system) to ensure logs and metrics collection from nodes.


### PR DESCRIPTION
**Description:** Add optional annotations to be passed for secrets.

My team uses a mutating webhook to inject secrets on create. We utilize annotations as part of this webhook which this chart does not currently support.

**Testing:** This is an optional value, and tested that no examples show any changes when rendering. I also tested rendering with the below test value file to verify my changes show up correctly. I did not think this change warranted a new example to be created.

```
agent:
  controlPlaneMetrics:
    etcd:
      secret:
        create: true
        annotations:
          testAnnotation: etcdSecret

secret:
  annotations:
    testAnnotation: secret
```

**Documentation:** Updated values schema.

Note:
I went with an if conditional in the templates because I saw it was done this way in the serviceAccount.yaml file:
https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/serviceAccount.yaml#L20-L23

Afterwards I noticed that the service.yaml uses with instead:
https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/service.yaml#L17-L20

I don't know if there is a preference but I can change if requested.