### PR TITLE
SWAT-8663 gateway - add signalfx exporter to traces pipeline to enable correlation

### DIFF
--- a/.chloggen/gw-apm-correlation.yaml
+++ b/.chloggen/gw-apm-correlation.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: gateway
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add signalfx exporter to the gateway traces pipeline to enable APM correlation
+# One or more tracking issues related to the change
+issues: [1607]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -205,6 +205,7 @@ data:
         traces:
           exporters:
           - otlphttp
+          - signalfx
           processors:
           - memory_limiter
           - k8sattributes

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9a18e1abec41b07245232e29f2462870e5bda91ddb7df7775e434c1d393f5c7f
+        checksum/config: a4f6cdac19856ea507be247f9656711d130956dc6e895c1a8c16512745ff68b5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -205,6 +205,7 @@ data:
         traces:
           exporters:
           - otlphttp
+          - signalfx
           processors:
           - memory_limiter
           - k8sattributes

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9a18e1abec41b07245232e29f2462870e5bda91ddb7df7775e434c1d393f5c7f
+        checksum/config: a4f6cdac19856ea507be247f9656711d130956dc6e895c1a8c16512745ff68b5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -207,6 +207,7 @@ data:
         traces:
           exporters:
           - otlphttp
+          - signalfx
           processors:
           - memory_limiter
           - k8sattributes

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: e3a492daf843c7412ff52604bb5ad1197601fe57b94f27527f030b9671000ecd
+        checksum/config: 40e24931c5e5d4fc49d32dc1e9bc073fcedd41116956babf3fdc8b4f0846881a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -176,6 +176,7 @@ service:
       exporters:
         {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
         - otlphttp
+        - signalfx
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformTracesEnabled" .) "true") }}
         - splunk_hec/platform_traces


### PR DESCRIPTION
**Description:** <Describe what has changed.>
In an Agent -> GW configuration, the traces correlations happen in 2 different places
1) `host.name` correlation occurs at the agent/collector running on the same host as the instrumented app. (no issue here)
2) k8s metadata enrichment ex: `k8s.pod.uid` occurs at the GW (k8sattributes processor on the agent is configured with passthrough set to true) . However, the GW traces pipelines is not configured with the signalfx exporter, ie: no correlation will be attempted . 

This PR simply adds the signalfx exporter to the traces pipeline to enable correlation at the GW level.

