### PR TITLE
[chore] keep hook annotations for crds installed from upstream operator chart

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
@@ -13,6 +13,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     app.kubernetes.io/component: otel-operator
+{{- if .Values.operator.crds.create }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+{{- end }}
 spec:
   exporter:
     endpoint: {{ include "splunk-otel-collector.operator.instrumentation-exporter-endpoint" . }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Keep hook annotations to unblock helm upgrades for existing operator installations using upstream installations. 
In a previous commit we removed these annotations but see upgrades fail. On upgrade helm sees the object exists but it is not part of tracked objects in its release and throws below error
```
Error: UPGRADE FAILED: Unable to continue with update: Instrumentation "sock-splunk-otel-collector" in namespace "default" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "sock"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "default"
```

The alternative is to ask users to add below annotations to instrumentation objects which were created as hook to add them to helm release 
```
meta.helm.sh/release-name
meta.helm.sh/release-namespace
```
OR ask users to delete the instrumentation object created by hook and let upgrade create a new one.


**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
