### PR TITLE
[chore] make tests less flaky

### DIFF
--- a/functional_tests/functional_test.go
+++ b/functional_tests/functional_test.go
@@ -834,6 +834,7 @@ func testK8sClusterReceiverMetrics(t *testing.T) {
 		pmetrictest.IgnoreMetricAttributeValue("k8s.deployment.uid", metricNames...),
 		pmetrictest.IgnoreMetricAttributeValue("k8s.pod.uid", metricNames...),
 		pmetrictest.IgnoreMetricAttributeValue("k8s.pod.name", metricNames...),
+		pmetrictest.IgnoreMetricAttributeValue("k8s.node.name", metricNames...),
 		pmetrictest.IgnoreMetricAttributeValue("k8s.replicaset.uid", metricNames...),
 		pmetrictest.IgnoreMetricAttributeValue("k8s.replicaset.name", metricNames...),
 		pmetrictest.IgnoreMetricAttributeValue("k8s.namespace.uid", metricNames...),
@@ -860,7 +861,7 @@ func testK8sClusterReceiverMetrics(t *testing.T) {
 		pmetrictest.IgnoreMetricsOrder(),
 		pmetrictest.IgnoreScopeMetricsOrder(),
 		pmetrictest.IgnoreMetricDataPointsOrder(),
-		pmetrictest.IgnoreSubsequentDataPoints("k8s.container.ready", "k8s.container.restarts"),
+		pmetrictest.IgnoreSubsequentDataPoints("k8s.container.ready", "k8s.container.restarts", "k8s.pod.phase"),
 	)
 	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
 		writeNewExpectedMetricsResult(t, expectedMetricsFile, selectedMetrics)


### PR DESCRIPTION
ignore k8s.node.name when checking cluster metrics
ignore k8s.pod.phase data points as they can have additional points in case a container restarts