### PR TITLE
Added new dimension to internal metrics to identify mode

### DIFF
--- a/.chloggen/add_collector_mode.yaml
+++ b/.chloggen/add_collector_mode.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent, clusterReceiver, gateway
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new dimension to internal metrics to identify collector mode
+# One or more tracking issues related to the change
+issues: [1634]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/add_collector_mode.yaml
+++ b/.chloggen/add_collector_mode.yaml
@@ -3,7 +3,7 @@ change_type: enhancement
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: agent, clusterReceiver, gateway
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add new dimension to internal metrics to identify collector mode
+note: Add new dimension `otelcol.service.mode` to internal metrics to identify collector mode
 # One or more tracking issues related to the change
 issues: [1634]
 # (Optional) One or more lines of additional information to render under the primary note.

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -176,6 +176,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -474,6 +479,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c231dafe36c0682673dddd6c85709ccee470181c3126470b2e645cd7ba56507c
+        checksum/config: fcb21155261f59bb9d209e0d4f5c0748d04cff784753bff6a92183f22b14d58a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -125,6 +125,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -424,6 +429,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 44f909abad1637b2e78068afc4ab38b2fd530cce14f57ee66f13f5e565ab30ee
+        checksum/config: ad95b3c2831a47c954119c1715845cc9ed49dc506bddc27026fd350360bdd969
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -302,6 +307,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 836fcc21881bde4060a0d9edff09d7809cee53e63e6a1168001c531a47680516
+        checksum/config: 07098b77606a130fe8b3c0619fc513eb0e700265d1abf11c5571479d7274c0ef
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -120,6 +120,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -290,6 +295,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 087b234e31830ae8352ceafdb062671206dac92eb3490ff008cd6a734536c1d9
+        checksum/config: 0d926858899a7d27ca9c752f9db3f257c8e93ba953d32c0303bd382d2f78f30c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -143,6 +143,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -466,6 +471,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c83c91c483abdf4d4f0f76b0c2dfcc2c900966e258fde53ab368e7e427eb05d4
+        checksum/config: 25545be88b6636d4e92888850b2dfcdc95bc2201cf8e45c80f22ad6edcde385f
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -287,6 +292,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 447bfd0ac5cea8708f6ca3c5904fb629da253463ed465d5badaf167ce00c793c
+        checksum/config: 99ecbdd7c6f9b7bb4a206b6c1d9c4c6b8a1f9ee74ff85d1089ac0630c29c6c98
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -110,6 +110,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resourcedetection:
         detectors:
         - env
@@ -271,6 +276,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -113,6 +113,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: gateway
       resource/logs:
         attributes:
         - action: upsert
@@ -199,6 +204,7 @@ data:
           - batch
           - resource/add_collector_k8s
           - resourcedetection
+          - resource/add_mode
           - resource/add_cluster_name
           receivers:
           - prometheus/collector

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: de8047430e8f2e001b69b753b999b7951a25263a5baf0a5f3ff9e37bf37c89a9
+        checksum/config: a706a132d720349f41bc3d416e174b095bf73ae1887d3ee9e2aef24c3095055f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 603c26affc8fc81a7fa1a503b440032dd83d7034c26ca38bb571d03d271ab030
+        checksum/config: c8ecff561f039e2c31584d7697745b66d879b1b534c9ea1916947859cd3bfdcb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -169,6 +174,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 24b1822554040a1882c9653c96ba6677fe8f1d8424d32c9394192cbd368f4f04
+        checksum/config: 7be42f3eddf64aef08347a41c51ef834f1762f0cc53fe99b5144bf17a85bfae6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -113,6 +113,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: gateway
       resource/logs:
         attributes:
         - action: upsert
@@ -199,6 +204,7 @@ data:
           - batch
           - resource/add_collector_k8s
           - resourcedetection
+          - resource/add_mode
           - resource/add_cluster_name
           receivers:
           - prometheus/collector

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 603c26affc8fc81a7fa1a503b440032dd83d7034c26ca38bb571d03d271ab030
+        checksum/config: c8ecff561f039e2c31584d7697745b66d879b1b534c9ea1916947859cd3bfdcb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -122,6 +122,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -316,6 +321,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         metrics/histograms:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f2d83a712c5399a2a914133ea36aa0c08d48658216cf811fdeefe1a0fa0f1a44
+        checksum/config: eb0f162dadffe14f3fc7aa992db30dccc6a885e330a57f6ef8f8cb83f515bdd3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -287,6 +292,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 447bfd0ac5cea8708f6ca3c5904fb629da253463ed465d5badaf167ce00c793c
+        checksum/config: 99ecbdd7c6f9b7bb4a206b6c1d9c4c6b8a1f9ee74ff85d1089ac0630c29c6c98
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -287,6 +292,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 447bfd0ac5cea8708f6ca3c5904fb629da253463ed465d5badaf167ce00c793c
+        checksum/config: 99ecbdd7c6f9b7bb4a206b6c1d9c4c6b8a1f9ee74ff85d1089ac0630c29c6c98
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -213,6 +213,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -508,6 +513,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           - k8sattributes/metrics
           receivers:
           - prometheus/agent

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -101,6 +101,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -160,6 +165,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           - k8sattributes/metrics
           receivers:
           - prometheus/k8s_cluster_receiver

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f405847530e0f6f78292d2d0d2ccafb7994ebfd7f8fca47cc3bda0c14beef5e6
+        checksum/config: 3b426a38b9fb50746a9102e14c5de53925d1b88e7e675f42d41428c4e31465db
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0f97cb08ed174dc00cfac1b7bdbd68818d2c46eb4bdef8feeed61772fb88e113
+        checksum/config: e8a59deb66daa3379180665060336cf25774d4934c639e6df25541ed62a72ed1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -287,6 +292,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c82d1a63efffa811553be74e0368db4e400c455ca1078832b8fe7fa5da7e311f
+        checksum/config: c305c90946c8d9beec835f976d37f13a5b8f3604c67216d83ed4f63ed1fbe1ad
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -245,6 +250,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -117,6 +122,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 73532e9a7e14a4cda235d622fabe5c3e2ef7e4c96091838c800c698fa775eb47
+        checksum/config: c7f2b28d3498ee69347c006ef6c3f9e92ff76adc29f9367c3410d4e403b69caf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0f76d8756a4f018722b342310ddd7efa8e25350161aec3a0e77956f1b290ac2d
+        checksum/config: cf54cfbee24bc853b70dec6b256fb22a2116f1ecad9fd70ff9683ca80d1a86bc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -58,6 +58,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -137,6 +142,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
         metrics/eks:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -113,6 +113,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: gateway
       resource/logs:
         attributes:
         - action: upsert
@@ -201,6 +206,7 @@ data:
           - batch
           - resource/add_collector_k8s
           - resourcedetection
+          - resource/add_mode
           - resource/add_cluster_name
           receivers:
           - prometheus/collector

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2c3c68225ef4cb5b0b6c16c9a4926c6c2d4c84aec313efc1720bc85059f2808f
+        checksum/config: eac93ba89623fd4b61f1c4ffcd247451ae99112a5e76655375282cddc1d3fe1d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: ac036db8dcdf313f442dd307b00192c93e4fa51b369b7aab7b87c6d964fd6eab
+        checksum/config: 628e34b118f38041929a2e00a0cbd52d72535d6497f871a3ab34a166b8ee60d6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -245,6 +250,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -136,6 +141,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f69ec6a01d0a5d5523b2ed984c1e73a0be57f55cf07888c49b1755429bdd4feb
+        checksum/config: d365f9c9cee2d54d34b0a42b27063410ad796199d9199fb59738da424f227b82
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3de0122c104743ed10d41dda29124ec077085f593815530c2f5c7f5e9d24b8a5
+        checksum/config: 778cde672dc6156dd78c3943da798c0e31c2ce0f7253693b383c1c9858936502
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -244,6 +249,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -116,6 +121,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 998bff0efa9d35587bf93096e4e15e7ec99bd75c86231a5071d49078170465a7
+        checksum/config: a5fd93f81b38314f5b7c5d57a1c5d06c6cc2f6a39daa46e4448327e50482d4b5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fa06f319b00c5605f94b82414a240b1121c7ecf48053032f6f9cd7224da63d62
+        checksum/config: e88a0264cf867a7ee973f0fbbd0fdea8b6476ff4ea4f75449f11b492528db672
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -244,6 +249,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -116,6 +121,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fd6d0ef4a5ed3ef6601b87078674e3df0d36dd43fa916ea12ad45874db3d736e
+        checksum/config: fd614fd91223e4f85b0e980ae1de55024e3b2bc44fc6713d0566854971ce51be
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fa06f319b00c5605f94b82414a240b1121c7ecf48053032f6f9cd7224da63d62
+        checksum/config: e88a0264cf867a7ee973f0fbbd0fdea8b6476ff4ea4f75449f11b492528db672
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -295,6 +300,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -116,6 +121,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 42711f07e660fddb8643a087d4fc7c3dde3ba2a9de31aa34d4e64e45436ba8bc
+        checksum/config: ab3321ad8d58c40c5fe45a8934a22ae12cc58e66f59ea2a93e16a23fef906b35
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: ba173444776c07df18b1123fc423e1b1d74bc01f6e952060deb20928c01a6a21
+        checksum/config: 80b648a9c4f99cf246acdf97b96f56d71f2a3ff7d36be675d1fafeb850a5a765
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -130,6 +130,11 @@ data:
         - action: insert
           key: deployment.environment
           value: CHANGEME
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -427,6 +432,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2d438e3fc8b11077fd8775eb68c59c6442d5fd9eb970291e6f6cc9f61a2147d8
+        checksum/config: 355af349de7c2300e218e35a605d6922ec98ed7bbbafd02492576617dc1f355b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 531d87525b6e86afbe26e3997f6f5d5be1bd2092ef0a8461b61773f4ee2b63dc
+        checksum/config: e4c27f7313b77fef1719c0b29bfb2192b16234a84ed86bb8f6ef525208abfb8f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -213,6 +213,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -508,6 +513,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           - k8sattributes/metrics
           receivers:
           - prometheus/agent

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -101,6 +101,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -160,6 +165,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           - k8sattributes/metrics
           receivers:
           - prometheus/k8s_cluster_receiver

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6da916d7046486fc24445af58468734f39a4a42c8511dc1e6cac0ccab2345b05
+        checksum/config: 6e0ce773bf136641bdd6ac1b0796c084b7879f4db6403d3889c14b6dec021fd1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0f97cb08ed174dc00cfac1b7bdbd68818d2c46eb4bdef8feeed61772fb88e113
+        checksum/config: e8a59deb66daa3379180665060336cf25774d4934c639e6df25541ed62a72ed1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -120,6 +120,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -200,6 +205,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 73dfa3eae5ecaa8039503c5cc5a4e0ffbcba9096297e1dd943174caa6aa120e1
+        checksum/config: 815281679e36bb91e6e35700005e7f69eaaac77f11b63886a59f87346ad258c0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -118,6 +118,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -289,6 +294,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c134a259e70002c6bd86738f539a757ae9da0e21338578fcede35255f6bd320e
+        checksum/config: e1791230f57d181f3f63a84da36b3f3093222ffc563a801e3886d111ae729d9e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -133,6 +133,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -320,6 +325,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 075fdc34f9b9ea2842645046a91ccd2184fa571b11499e06eaff2bc3d057f9fb
+        checksum/config: 17f0b1162e95b8357b72a8393bb7439f892867a9e777e86fa64a5d43364c1f58
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -133,6 +133,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -320,6 +325,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3e45c5848667b88e7ca0cbe72c6c38a9d88237319e8e2509b0e0bb76d62f13b0
+        checksum/config: bf725066e76995326b6fd14e6b3ff61cd12f59ea039a2ac0d68066e124ac380e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -130,6 +130,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -426,6 +431,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 314af281f1fdde03cb4b060333d324d87691568ca02a15aa61a4eb29100c0f70
+        checksum/config: 96ca6619c58c520ed5002de3fb575a35d3e84f6fbf81565bc62162b8ba122ba0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -185,6 +185,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -471,6 +476,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           - k8sattributes/metrics
           receivers:
           - prometheus/agent

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -101,6 +101,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -160,6 +165,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           - k8sattributes/metrics
           receivers:
           - prometheus/k8s_cluster_receiver

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3d92d665b60422f70b08b7986d6dcdbec1fcbd6912e08da2dc866d52133ccaf7
+        checksum/config: 22e6c9c8b5938aea4783c1bccb93a8423995fb5ccc999075735b9e0af92d9c8a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0f97cb08ed174dc00cfac1b7bdbd68818d2c46eb4bdef8feeed61772fb88e113
+        checksum/config: e8a59deb66daa3379180665060336cf25774d4934c639e6df25541ed62a72ed1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -128,6 +128,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -214,6 +219,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
       telemetry:

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5a5aaa591aacbf784246a8b678c9f219e4e5b120bce6029eec46fbce352a5f3f
+        checksum/config: c630268a19754a553000b1d486afd10d3af4dd347780dfaf28aeb98725ae80ee
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -120,6 +120,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -350,6 +355,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
       telemetry:

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3e64fa6fb1ebb1e874b5fe3e353ae0015e4fde0803f61187113bde7f3b21fce6
+        checksum/config: 34cf1b10d9c812fb3fc0d1f4dc42e01405e779ac1d03f551148621f07e973f21
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -120,6 +120,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -353,6 +358,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
       telemetry:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 972f722855c6ee1ef659bbd49afe6ea62d5c4532fa5b963db857b0b961bc2417
+        checksum/config: 902d4fc791fd722432bbe9f1cf7dc890834ce8d83135179dcc2f09c4feb422ff
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -158,6 +158,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -318,6 +323,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           - k8sattributes/metrics
           receivers:
           - prometheus/agent

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -101,6 +101,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -160,6 +165,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           - k8sattributes/metrics
           receivers:
           - prometheus/k8s_cluster_receiver

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c29f45f3afaffe91c153f1ba6f2ca393eeb2f38c2d135e3410bc807f4630bdd6
+        checksum/config: 1ffdca8b66802862eb4e522d592863d0f0bfdbc5f886debbe981c325e2d72075
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0f97cb08ed174dc00cfac1b7bdbd68818d2c46eb4bdef8feeed61772fb88e113
+        checksum/config: e8a59deb66daa3379180665060336cf25774d4934c639e6df25541ed62a72ed1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -112,6 +112,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -271,6 +276,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
       telemetry:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: dc719eb0c79f42650d121a967f4e01a5bef72c19425f54de24a432b7aadf914c
+        checksum/config: a42602b53735e7e793281bac30627c9621a9b5e34e6d8930ca5a3b0d71842848
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -197,6 +202,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: af5e86d0fd2b41df5cf98b6b10a96ab376c9a286fe0f5838e80e54630fa9da24
+        checksum/config: 9beefa89e4e4f6ea6e0e1ee2fc42ebf2317c210f855a929b465041438338af8d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -121,6 +121,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -294,6 +299,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0cedb093b03e0072ff7e2703e86fc6e69bee6b49ef0302bd18e12c9d3a56ff20
+        checksum/config: 640dd8c283a3ed2af17f8b52a3e2141806110f4cae0863940e80fe410b37a861
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 410388b23c303a7bd00d3d5a20ddbaef5766bc3171a6196fc144652f67d83710
+        checksum/config: d44764a978e3f66cbadad9e346bee3dab9031498dbea3510e4c7d8238a86b37c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -120,6 +120,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -315,6 +320,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
       telemetry:

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8b58accde8175711c32f1576a5fa5197c97c74ded22f699cab3c727c0cd7c488
+        checksum/config: dfe8163a085fbb9c0213f40671509dd2882597eff7e011733cbf0f2b248e0319
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -132,6 +132,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ea1f8b83ecaa816e93de1da897ee316e73acf3e936feeb35eeec8e94cc341787
+        checksum/config: ee1b4bdf6dd5455e66cb48ae845b95c3988435bcba677bf1b7911e37e21c2c4e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -295,6 +300,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b4938892f85224086757d23bd61688ee20292e4ce983dfaae5905fc22fd26d5
+        checksum/config: 7e870158060c318504de94b612206365f279f852c62b1abf159af31907123c9c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -287,6 +292,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 447bfd0ac5cea8708f6ca3c5904fb629da253463ed465d5badaf167ce00c793c
+        checksum/config: 99ecbdd7c6f9b7bb4a206b6c1d9c4c6b8a1f9ee74ff85d1089ac0630c29c6c98
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -117,6 +117,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: agent
       resource/logs:
         attributes:
         - action: upsert
@@ -296,6 +301,7 @@ data:
           - resource/add_agent_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/agent
         traces:

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -55,6 +55,11 @@ data:
         - action: insert
           key: k8s.namespace.name
           value: ${K8S_NAMESPACE}
+      resource/add_mode:
+        attributes:
+        - action: insert
+          key: otelcol.service.mode
+          value: clusterReceiver
       resource/k8s_cluster:
         attributes:
         - action: insert
@@ -115,6 +120,7 @@ data:
           - resource/add_collector_k8s
           - resourcedetection
           - resource
+          - resource/add_mode
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ef9cb53a3319729cf505e919461124d056f6e6fd314d862f73ace82702e1eb2a
+        checksum/config: 874987a599e670e5fac244dbd030008c7477e75a4804de5ad5873a263c39dc00
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 255712b444c57ed04dd3499a8655f166a80985e294e08e7237b6b500ef76b0b3
+        checksum/config: 5080b8509ea7b5474b08c17da8a05009a8fdf466709c300f7fd4826f0111037e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -746,6 +746,13 @@ processors:
         value: "{{ .Values.environment }}"
   {{- end }}
 
+  # The following processor is used to add "otelcol.service.mode" attribute to the internal metrics
+  resource/add_mode:
+    attributes:
+      - action: insert
+        value: "agent"
+        key: otelcol.service.mode
+
   {{- if .Values.isWindows }}
   metricstransform:
     transforms:
@@ -1050,6 +1057,7 @@ service:
         - resource/add_agent_k8s
         - resourcedetection
         - resource
+        - resource/add_mode
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -95,6 +95,13 @@ processors:
         key: deployment.environment
   {{- end }}
 
+  # The following processor is used to add "otelcol.service.mode" attribute to the internal metrics
+  resource/add_mode:
+    attributes:
+      - action: insert
+        value: "gateway"
+        key: otelcol.service.mode
+
 exporters:
   {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
   signalfx:
@@ -257,6 +264,7 @@ service:
         - batch
         - resource/add_collector_k8s
         - resourcedetection
+        - resource/add_mode
         {{- if .Values.clusterName }}
         - resource/add_cluster_name
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -174,7 +174,6 @@ processors:
         value: "clusterReceiver"
         key: otelcol.service.mode
 
-
   resource/k8s_cluster:
     attributes:
       # XXX: Added so that Smart Agent metrics and OTel metrics don't map to the same MTS identity

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -167,6 +167,14 @@ processors:
         value: "{{ .Values.environment }}"
   {{- end }}
 
+  # The following processor is used to add "otelcol.service.mode" attribute to the internal metrics
+  resource/add_mode:
+    attributes:
+      - action: insert
+        value: "clusterReceiver"
+        key: otelcol.service.mode
+
+
   resource/k8s_cluster:
     attributes:
       # XXX: Added so that Smart Agent metrics and OTel metrics don't map to the same MTS identity
@@ -278,6 +286,7 @@ service:
         - resource/add_collector_k8s
         - resourcedetection
         - resource
+        - resource/add_mode
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
         {{- end }}


### PR DESCRIPTION
**Description:**

To easily filter between agent and gateway deployments of the collector in dashboards a proposed new dimension `otelcol.service.mode` to be added to the internal metrics pipeline.

**Testing:** 
Deployed the chart to a cluster with the gateway enabled. Validated on the OOTB otel collector dashboard I can filter on `otelcol.service.mode` with both a value for `agent` and `gateway`
Deployed the chart to a cluster with the gateway disabled. Validated on the OOTB otel collector dashboard I can filter on `otelcol.service.mode` with only a value for  `agent`

This feature is already merged into the splunk otel-collector: https://github.com/signalfx/splunk-otel-collector/pull/5701