### PR TITLE
[chore] Bump splunk from 9.3.0 to 9.4.0

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -25,7 +25,7 @@ jobs:
           - "containerd"
           - "cri-o"
         splunk_version:
-          - 9.3.0
+          - 9.4.0
           - 8.2.9
     env:
       CI_SPLUNK_PORT: 8089


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- This dependency is only used in testing