### PR TITLE
Refactor `make render` to support rendering TLS certificates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       exclude: "^examples|^test"
     - id: check-yaml
       # Can't check source yaml since it has go templates in it.
-      exclude: "^helm-charts"
+      # Can't check operator-webhook.yaml due to redacted TLS certificate information causing yaml format issues.
+      exclude: "^helm-charts|operator-webhook.yaml"
       args: [ --allow-multiple-documents ]
     - id: check-added-large-files

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ dep-update: ## Fetch Helm chart dependency repositories, build the Helm chart wi
 #		make render VALUES="values1.yaml values2.yaml"
 .PHONY: render
 render: dep-update ## Render the Helm chart with the examples as input. Users can also provide value overrides.
-	@examples/render-examples.sh $(VALUES) || exit 1
+	@ci_scripts/render-examples.sh $(VALUES) || exit 1
 
 ##@ Test
 # Tasks related to testing the Helm chart

--- a/tools/splunk_kubernetes_debug_info.sh
+++ b/tools/splunk_kubernetes_debug_info.sh
@@ -56,31 +56,8 @@ write_output() {
     fi
   fi
 
-  # Redact sensitive information
-  output=$(echo "$output" | awk '
-  /BEGIN CERTIFICATE/,/END CERTIFICATE/ {
-      if (/BEGIN CERTIFICATE/) print;
-      else if (/END CERTIFICATE/) print;
-      else print "    [CERTIFICATE REDACTED]";
-      next;
-  }
-  /ca\.crt|client\.crt|client\.key|tls\.crt|tls\.key/ {
-      print "    [SENSITIVE DATA REDACTED]";
-      next;
-  }
-  /[Tt][Oo][Kk][Ee][Nn]/ {
-      print "    [TOKEN REDACTED]";
-      next;
-  }
-  /[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]/ {
-      print "    [PASSWORD REDACTED]";
-      next;
-  }
-  {print}')
-
-  # Write command and output to file
-  echo "# Command: $cmd" > "$file_name"
-  echo "$output" >> "$file_name"
+  # Redact sensitive information from output
+  redact_sensitive_info "$output" "$file_name"
 }
 
 # Function to collect data for a given namespace


### PR DESCRIPTION
Description:
These changes do not affect the customer directly and only make our CI/CD code more flexible in preparation for upcoming changes.
- Refactor `make render` to handle TLS certificate rendering in a way that doesn't break CI/CD checks.
  - For upcoming work, certificates will be generated in the rendered manifest content. Since each make render execution generates unique certificate values, this could cause CI/CD checks to fail.
  - To resolve this, we redacted unique certificate values and updated the linting rules to ignore files containing TLS certificates (e.g., operator-webhook.yaml).
- Moved render-examples.sh to reside under ./ci_scripts/ because it really belongs there at this point.
- Abstracted the TLS redaction logic into a reusable utility function for both the `make render` action and thesplunk_kubernetes_debug_info.sh script to use.