### PR TITLE
Extend options for setting security context

### DIFF
--- a/.chloggen/add-container-security-context-option-cluster-receiver.yaml
+++ b/.chloggen/add-container-security-context-option-cluster-receiver.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an option to set the security context for the container.
+# One or more tracking issues related to the change
+issues: [1647]

--- a/.chloggen/add-container-security-context-option-gateway.yaml
+++ b/.chloggen/add-container-security-context-option-gateway.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: gateway
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an option to set the security context for the container.
+# One or more tracking issues related to the change
+issues: [1647]

--- a/.chloggen/deprecate-security-context-option-cluster-receiver.yaml
+++ b/.chloggen/deprecate-security-context-option-cluster-receiver.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the `securityContext` field in favor of the `podSecurityContext`.
+# One or more tracking issues related to the change
+issues: [1647]

--- a/.chloggen/deprecate-security-context-option-gateway.yaml
+++ b/.chloggen/deprecate-security-context-option-gateway.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: gateway
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the `securityContext` field in favor of the `podSecurityContext`.
+# One or more tracking issues related to the change
+issues: [1647]

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -81,3 +81,9 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
   - Status: Instrumentation language maturity varies. See `operator.instrumentation.spec` and documentation for utilized instrumentation details.
   - Splunk Support: We offer full support for Splunk distributions and best-effort support for native OpenTelemetry distributions of auto-instrumentation libraries.
 {{- end }}
+{{- if not (eq (toString .Values.gateway.securityContext) "<nil>") }}
+[WARNING] "gateway.securityContext" parameter is deprecated. Please use "gateway.podSecurityContext" instead.
+{{ end }}
+{{- if not (eq (toString .Values.clusterReceiver.securityContext) "<nil>") }}
+[WARNING] "clusterReceiver.securityContext" parameter is deprecated. Please use "clusterReceiver.podSecurityContext" instead.
+{{ end }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -81,9 +81,10 @@ spec:
         ` }}
         {{- $clusterReceiver.affinity | mustMergeOverwrite (fromYaml $clusterReceiverPodAntiAffinity) | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $clusterReceiver.securityContext }}
+      {{- $podSecurityContext := $clusterReceiver.podSecurityContext | default $clusterReceiver.securityContext }}
+      {{- if $podSecurityContext }}
       securityContext:
-        {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $clusterReceiver.securityContext) | nindent 8 }}
+        {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $podSecurityContext) | nindent 8 }}
       {{- end }}
       {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
       initContainers:
@@ -126,6 +127,10 @@ spec:
         {{- end }}
         {{- if .Values.clusterReceiver.featureGates }}
         - --feature-gates={{ .Values.clusterReceiver.featureGates }}
+        {{- end }}
+        {{- with .Values.clusterReceiver.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -61,9 +61,10 @@ spec:
       affinity:
         {{- toYaml $gateway.affinity | nindent 8 }}
       {{- end }}
-      {{- if $gateway.securityContext }}
+      {{- $podSecurityContext := $gateway.podSecurityContext | default $gateway.securityContext }}
+      {{- if $podSecurityContext }}
       securityContext:
-        {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $gateway.securityContext) | nindent 8 }}
+        {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $podSecurityContext) | nindent 8 }}
       {{- end }}
       containers:
       - name: otel-collector
@@ -79,6 +80,10 @@ spec:
         {{- end }}
         {{- if .Values.gateway.featureGates }}
         - --feature-gates={{ .Values.gateway.featureGates }}
+        {{- end }}
+        {{- with .Values.gateway.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -731,6 +731,13 @@
           "type": "object"
         },
         "securityContext": {
+          "description": "[DEPRECATED] Use podSecurityContext instead.",
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "containerSecurityContext": {
           "type": "object"
         },
         "terminationGracePeriodSeconds": {
@@ -1348,6 +1355,13 @@
           "type": "object"
         },
         "securityContext": {
+          "description": "[DEPRECATED] Use podSecurityContext instead.",
+          "type": "object"
+        },
+        "podSecurityContext": {
+          "type": "object"
+        },
+        "containerSecurityContext": {
           "type": "object"
         },
         "terminationGracePeriodSeconds": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -475,9 +475,12 @@ clusterReceiver:
   affinity: {}
 
   # Pod configurations
-  securityContext: {}
+  podSecurityContext: {}
   terminationGracePeriodSeconds: 600
   priorityClassName: ""
+
+  # Security context applied to the otel-collector container in the cluster receiver deployment.
+  containerSecurityContext: {}
 
   # k8s cluster receiver collector annotations
   annotations: {}
@@ -1138,9 +1141,12 @@ gateway:
   affinity: {}
 
   # Pod configurations
-  securityContext: {}
+  podSecurityContext: {}
   terminationGracePeriodSeconds: 600
   priorityClassName: ""
+
+  # Security context applied to the otel-collector container in the gateway deployment.
+  containerSecurityContext: {}
 
   # OTel collector annotations
   annotations: {}


### PR DESCRIPTION
Add option to set security contexts on:
- container in the clusterRecever deployment
- container in the gateway deployment
- agent pod