### PR TITLE
[chore] improve ci_scripts/base_util.sh debug functionality

### DIFF
--- a/ci_scripts/base_util.sh
+++ b/ci_scripts/base_util.sh
@@ -86,10 +86,17 @@ debug() {
         local var_name="$1"
         local var_value="${!var_name}"  # Indirect reference to get the value
         if [[ -f "$var_value" ]]; then
+            # Prints out the supplied file path and the content of the file
             echo "[DEBUG] $var_name: Content of file $var_value:"
             cat "$var_value"
         else
-            echo "[DEBUG] $var_name: $var_value"
+          if [[ -z "$var_value" ]]; then
+              # Prints out the supplied string's value
+              echo "[DEBUG] $var_name"
+          else
+              # Prints out the supplied variable name and value
+              echo "[DEBUG] $var_name: $var_value"
+          fi
         fi
     fi
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Improved debug info handling for ci scripts in this project. Now, `debug "some string value"` and `debug $SOME_VAR` are treated differently for better readability of debug logs when the strings vs environment variables are used for debugging.






