### PR TITLE
[chore] Update Ubuntu 20.04 runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   functional-test:
     name: K8s ${{ matrix.kubernetes_version }} ${{ matrix.container_runtime }}, Splunk ${{ matrix.splunk_version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
20.04 runners are now deprecated and will be fully unsupported as of April 1. This updates from ubuntu-20.04 to ubuntu-24.04

https://github.com/actions/runner-images/issues/11101