### PR TITLE
Option change the default internal traffic policy for the agent service

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/service-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service-agent.yaml
@@ -40,6 +40,6 @@ spec:
     app: {{ template "splunk-otel-collector.name" . }}
     component: otel-collector-agent
     release: {{ .Release.Name }}
-  internalTrafficPolicy: Local
+  internalTrafficPolicy: {{ default "Local" .Values.agent.service.internalTrafficPolicy }}
 {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -605,7 +605,11 @@
               "type": "boolean"
             },
             "internalTrafficPolicy": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                  "Local",
+                  "Cluster"
+              ]
             }
           }
         },

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -603,6 +603,9 @@
           "properties": {
             "enabled": {
               "type": "boolean"
+            },
+            "internalTrafficPolicy": {
+              "type": "string"
             }
           }
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -408,6 +408,9 @@ agent:
     # so that agent pods can be discovered via dns etc
     enabled: true
 
+    # (optional) Override the default service internal traffic policy
+    internalTrafficPolicy: "Local"
+
   # hostNetwork schedules the pod with the host's network namespace.
   # Disabling this value will affect monitoring of some control plane
   # components. Enabling the agent service is recommended (see above).

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -408,7 +408,8 @@ agent:
     # so that agent pods can be discovered via dns etc
     enabled: true
 
-    # (optional) Override the default service internal traffic policy
+    # (optional) Override the default service internal traffic policy,
+    # valid values are "Local" and "Cluster".
     internalTrafficPolicy: "Local"
 
   # hostNetwork schedules the pod with the host's network namespace.


### PR DESCRIPTION
**Description:** 

During our Helm deployments in EKS it came up that the hard coded `internalTrafficPolicy: Local` causes a communication issues with the service returning 404 error which was fixed by manually changing this to `Cluster`. This PR adds the option to override the value of the `internalTrafficPolicy` in the chart.
