### PR TITLE
Add optional propagators configuration for trace context propagation

### DIFF
--- a/.chloggen/featureaddoptionalpropagatorsconfig.yaml
+++ b/.chloggen/featureaddoptionalpropagatorsconfig.yaml
@@ -5,7 +5,7 @@ component: "chart"
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Enable support for custom propagators in `spec.propagators` within Instrumentation Configuration."
 # One or more tracking issues related to the change
-issues: ["https://github.com/signalfx/splunk-otel-collector-chart/issues/1663"]
+issues: [1663]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/.chloggen/featureaddoptionalpropagatorsconfig.yaml
+++ b/.chloggen/featureaddoptionalpropagatorsconfig.yaml
@@ -1,0 +1,13 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: "chart"
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enable support for custom propagators in `spec.propagators` within Instrumentation Configuration."
+# One or more tracking issues related to the change
+issues: ["https://github.com/signalfx/splunk-otel-collector-chart/issues/1663"]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+  This change allows users to specify custom propagators in `spec.propagators` when configuring OpenTelemetry Instrumentation.

--- a/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
@@ -21,14 +21,10 @@ metadata:
 spec:
   exporter:
     endpoint: {{ include "splunk-otel-collector.operator.instrumentation-exporter-endpoint" . }}
+  {{- with .Values.instrumentation.propagators }}
   propagators:
-    {{- if .Values.instrumentation.propagators }}
-    {{- toYaml .Values.instrumentation.propagators | nindent 4 }}
-    {{- else }}
-    - tracecontext
-    - baggage
-    - b3
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.instrumentation.sampler }}
   sampler:
     {{- toYaml . | nindent 4 }}

--- a/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
+++ b/helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml
@@ -22,9 +22,13 @@ spec:
   exporter:
     endpoint: {{ include "splunk-otel-collector.operator.instrumentation-exporter-endpoint" . }}
   propagators:
+    {{- if .Values.instrumentation.propagators }}
+    {{- toYaml .Values.instrumentation.propagators | nindent 4 }}
+    {{- else }}
     - tracecontext
     - baggage
     - b3
+    {{- end }}
   {{- with .Values.instrumentation.sampler }}
   sampler:
     {{- toYaml . | nindent 4 }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1500,6 +1500,28 @@
           "type": "string",
           "description": "Optional endpoint parameter for exporting data to a specific target."
         },
+        "propagators":{
+          "type": "array",
+          "description": "Optional propagators parameter for enabling trace context propagation.",
+          "propagators": {
+            "description": "List of allowed propagators for tracing.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "tracecontext",
+                "baggage",
+                "b3",
+                "b3multi",
+                "jaeger",
+                "ottrace",
+                "xray",
+                "ottrace",
+                "none"
+              ]
+          }
+        }
+      },
         "sampler": {
           "type": "object",
           "description": "Optional sampler parameter for enabling trace sampling.",

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1500,28 +1500,23 @@
           "type": "string",
           "description": "Optional endpoint parameter for exporting data to a specific target."
         },
-        "propagators":{
+        "propagators": {
           "type": "array",
           "description": "Optional propagators parameter for enabling trace context propagation.",
-          "propagators": {
-            "description": "List of allowed propagators for tracing.",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "tracecontext",
-                "baggage",
-                "b3",
-                "b3multi",
-                "jaeger",
-                "ottrace",
-                "xray",
-                "ottrace",
-                "none"
-              ]
+          "items": {
+            "type": "string",
+            "enum": [
+              "tracecontext",
+              "baggage",
+              "b3",
+              "b3multi",
+              "jaeger",
+              "ottrace",
+              "xray",
+              "none"
+            ]
           }
-        }
-      },
+        },
         "sampler": {
           "type": "object",
           "description": "Optional sampler parameter for enabling trace sampling.",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1238,7 +1238,16 @@ instrumentation:
   endpoint: ""
   # endpoint: http://$(SPLUNK_OTEL_AGENT):4317
   # endpoint: http://splunk-otel-collector:4317
-
+  # Optional "propagators" parameter for enabling trace context propagation, see: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_propagators
+  propagators: []
+  # "tracecontext": W3C Trace Context
+  # "baggage": W3C Baggage
+  # "b3": B3 Single
+  # "b3multi": B3 Multi
+  # "jaeger": Jaeger
+  # "xray": AWS X-Ray (third party)
+  # "ottrace": OT Trace (third party)
+  # "none": No automatically configured propagator.
   # Optional "sampler" parameter for enabling trace sampling, see: https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_sampler
   sampler: {}
   # type: traceidratio

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1239,7 +1239,10 @@ instrumentation:
   # endpoint: http://$(SPLUNK_OTEL_AGENT):4317
   # endpoint: http://splunk-otel-collector:4317
   # Optional "propagators" parameter for enabling trace context propagation, see: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_propagators
-  propagators: []
+  propagators:
+    - tracecontext
+    - baggage
+    - b3
   # "tracecontext": W3C Trace Context
   # "baggage": W3C Baggage
   # "b3": B3 Single


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This pull request introduces changes to the Helm chart for the Splunk OpenTelemetry Collector, primarily focusing on adding support for configurable propagators in the instrumentation configuration. The most important changes include updates to the templates, values schema, and values file.

Support for configurable propagators:

* `helm-charts/splunk-otel-collector/templates/operator/instrumentation.yaml`: Added conditional logic to include custom propagators if specified in the values file.
* `helm-charts/splunk-otel-collector/values.schema.json`: Added a new `propagators` parameter to the schema, allowing users to specify an array of allowed propagators for tracing.
* `helm-charts/splunk-otel-collector/values.yaml`: Introduced the `propagators` parameter in the instrumentation section, providing options for various trace context propagation methods.
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to Splunk idea:** 

https://github.com/signalfx/splunk-otel-collector-chart/issues/1663

**Testing:** <Describe what testing was performed and which tests were added.>

* Existing behavior

```bash:bash
❯ helm template my-release helm-charts/splunk-otel-collector/ > test.yaml
# Source: splunk-otel-collector/templates/operator/instrumentation.yaml
apiVersion: opentelemetry.io/v1alpha1
kind: Instrumentation
metadata:
  name: my-release-splunk-otel-collector
  namespace: default
  labels:
    app.kubernetes.io/name: splunk-otel-collector
    helm.sh/chart: splunk-otel-collector-0.118.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/version: "0.118.0"
    app: splunk-otel-collector
    component: otel-operator
    chart: splunk-otel-collector-0.118.0
    release: my-release
    heritage: Helm
    app.kubernetes.io/component: otel-operator
spec:
  exporter:
    endpoint: http://my-release-splunk-otel-collector-agent.default.svc.cluster.local:4317
  propagators:
    - tracecontext
    - baggage
    - b3
```

* Customized propagators

```bash:bash
❯ helm template my-release helm-charts/splunk-otel-collector/ > test.yaml
# Source: splunk-otel-collector/templates/operator/instrumentation.yaml
apiVersion: opentelemetry.io/v1alpha1
kind: Instrumentation
metadata:
  name: my-release-splunk-otel-collector
  namespace: default
  labels:
    app.kubernetes.io/name: splunk-otel-collector
    helm.sh/chart: splunk-otel-collector-0.118.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/version: "0.118.0"
    app: splunk-otel-collector
    component: otel-operator
    chart: splunk-otel-collector-0.118.0
    release: my-release
    heritage: Helm
    app.kubernetes.io/component: otel-operator
spec:
  exporter:
    endpoint: http://my-release-splunk-otel-collector-agent.default.svc.cluster.local:4317
  propagators:
    - b3
```

* Invalid propagators

```bash:bash
❯ helm template my-release helm-charts/splunk-otel-collector/ > test.yaml
Error: values don't meet the specifications of the schema(s) in the following chart(s):
splunk-otel-collector:
- instrumentation.propagators.0: instrumentation.propagators.0 must be one of the following: "tracecontext", "baggage", "b3", "b3multi", "jaeger", "ottrace", "xray", "none"
```

* make render

```bash:bash
❯ make render
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "open-telemetry" chart repository
...Successfully got an update from the "jetstack" chart repository
Update Complete. ⎈Happy Helming!⎈
collector-agent-only-values.yaml SUCCESS
collector-gateway-only-values.yaml SUCCESS
only-logs-with-extra-file-logs-values.yaml SUCCESS
secret-validation-values.yaml SUCCESS
splunk-enterprise-index-routing-values.yaml SUCCESS
discovery-mode-values.yaml SUCCESS
collector-cluster-receiver-only-values.yaml SUCCESS
only-logs-otel-values.yaml SUCCESS
enable-trace-sampling-values.yaml SUCCESS
only-traces-values.yaml SUCCESS
kubernetes-windows-nodes-values.yaml SUCCESS
add-filter-processor-values.yaml SUCCESS
add-sampler-values.yaml SUCCESS
enable-persistence-queue-values.yaml SUCCESS
autodetect-istio-values.yaml SUCCESS
use-proxy-values.yaml SUCCESS
distribution-aks-values.yaml SUCCESS
add-receiver-creator-values.yaml SUCCESS
route-data-through-gateway-deployed-separately-values.yaml SUCCESS
only-metrics-platform-values.yaml SUCCESS
crio-logging-values.yaml SUCCESS
target-allocator-values.yaml SUCCESS
distribution-eks-values.yaml SUCCESS
kafkametrics-receiver-values.yaml SUCCESS
only-logs-fluentd-values.yaml SUCCESS
enabled-pprof-extension-values.yaml SUCCESS
default-values.yaml SUCCESS
enable-multi-metrics-values.yaml SUCCESS
only-metrics-values.yaml SUCCESS
disable-persistence-queue-traces-values.yaml SUCCESS
values.yaml SUCCESS
distribution-openshift-values.yaml SUCCESS
distribution-gke-autopilot-values.yaml SUCCESS
distribution-gke-values.yaml SUCCESS
distribution-eks-fargate-values.yaml SUCCESS
fluentd-refresh-interval-values.yaml SUCCESS
fluentd-multiline-logs-java-stack-traces-values.yaml SUCCESS
collector-all-modes-values.yaml SUCCESS
values.yaml SUCCESS
enable-operator-and-auto-instrumentation-values.yaml SUCCESS
Examples were rendered successfully
```

**Documentation:** <Describe the documentation added.>
