### PR TITLE
[chore] Add optional label to ignore functional tests

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -46,7 +46,7 @@ jobs:
           - configuration_switching
           - istio
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -108,7 +108,7 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -147,7 +147,7 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout main if in a PR
@@ -212,7 +212,7 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout old release
@@ -266,7 +266,7 @@ jobs:
       KUBE_TEST_ENV: gke/autopilot
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -304,7 +304,7 @@ jobs:
       KUBE_TEST_ENV: gke/autopilot
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout main if in a PR
@@ -363,7 +363,7 @@ jobs:
       KUBE_TEST_ENV: aks
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -402,7 +402,7 @@ jobs:
       KUBE_TEST_ENV: gce
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -46,6 +46,7 @@ jobs:
           - configuration_switching
           - istio
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -107,6 +108,7 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -145,6 +147,7 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout main if in a PR
@@ -209,6 +212,7 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout old release
@@ -262,6 +266,7 @@ jobs:
       KUBE_TEST_ENV: gke/autopilot
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -299,6 +304,7 @@ jobs:
       KUBE_TEST_ENV: gke/autopilot
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout main if in a PR
@@ -357,6 +363,7 @@ jobs:
       KUBE_TEST_ENV: aks
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -395,6 +402,7 @@ jobs:
       KUBE_TEST_ENV: gce
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Add optional PR label to ignore functional test results. This allows us to check in known breaking changes that will cause functional tests to fail, useful for Helm chart version upgrade tests.