### PR TITLE
[chore] Update collector image to 0.119.0

### DIFF
--- a/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
+++ b/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-filter-processor/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-filter-processor/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -505,3 +505,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -352,11 +352,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3be2a07bb2411698c0f94876311afe9c3c1d9d299ec67cde10009e7987e68226
+        checksum/config: 160108908dd6f92bcd20dcf457377c50b72f0a0e8bc6486f3d30b56e75fce7b2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 160108908dd6f92bcd20dcf457377c50b72f0a0e8bc6486f3d30b56e75fce7b2
+        checksum/config: 54db1407564ca4bbf5d1aa1d61bb65491bd213c9d8381ebedf7df56f96737178
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e881b03d9e52b770bdae0905a06a9bf05d0b90f0baf735dd66309b9623849eae
+        checksum/config: 3be2a07bb2411698c0f94876311afe9c3c1d9d299ec67cde10009e7987e68226
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -125,7 +125,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-filter-processor/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-filter-processor/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-filter-processor/rendered_manifests/service-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/add-filter-processor/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-filter-processor/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -308,11 +308,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -455,3 +455,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b832237dd020920ce877fac81a13b3f3511b8bc9bc5735d1c1337a60b8a34b1e
+        checksum/config: a4f935b0f96b241fc076e2ca1067a308af8094d320d2cfb0fd9ffb2935f8cbec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9d7bc9b2dc86c6f1fbfda895a9cdecc2142aa77419fc568cfe3ce27947143bdb
+        checksum/config: 830ac0e98c2e0ec804426dfc769b8de358ec07a076139dd761854c01f15bcf7d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -125,7 +125,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 830ac0e98c2e0ec804426dfc769b8de358ec07a076139dd761854c01f15bcf7d
+        checksum/config: b832237dd020920ce877fac81a13b3f3511b8bc9bc5735d1c1337a60b8a34b1e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-kafkametrics-receiver/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-kafkametrics-receiver/rendered_manifests/service-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/add-kafkametrics-receiver/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -333,3 +333,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4906709b9d935ca9acf53fb68b3d73dcf1e30f8e0f8c593d3f3f57de8e371454
+        checksum/config: fb1750cabeab3914272086e9379dbd6c1007d2523c770608efa78b713a387c17
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fb1750cabeab3914272086e9379dbd6c1007d2523c770608efa78b713a387c17
+        checksum/config: 42510674788262357449084d43748c56c7c3d239f36c2e09b538873a0f8b14df
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 42510674788262357449084d43748c56c7c3d239f36c2e09b538873a0f8b14df
+        checksum/config: a7363d07f6199a325a0d1c7cb0d177b799e5eee2c5a88b6b14f159e8c281e344
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-receiver-creator/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-receiver-creator/rendered_manifests/service-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/add-receiver-creator/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-sampler/rendered_manifests/clusterRole.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-sampler/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -186,11 +186,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -322,3 +322,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: eeb3ddae0a37c832bb7c2c55e0ee1f82e75aeb05a7eb93a54437173781fbf417
+        checksum/config: b0dbfae1721e0e58bac4198e1f993cc82a267e7ff8767ff1660a0f936031bb90
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 244a351f27bd08d69b4842d7b3a4664a39ce300d3471170d9b9c5e79b94b753c
+        checksum/config: eeb3ddae0a37c832bb7c2c55e0ee1f82e75aeb05a7eb93a54437173781fbf417
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a2aff2e7ab61b5023a94d3890060d9179dd4b54075b87d287a61a45dce05ec54
+        checksum/config: 244a351f27bd08d69b4842d7b3a4664a39ce300d3471170d9b9c5e79b94b753c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/add-sampler/rendered_manifests/secret-splunk.yaml
+++ b/examples/add-sampler/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/add-sampler/rendered_manifests/service-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/add-sampler/rendered_manifests/serviceAccount.yaml
+++ b/examples/add-sampler/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/autodetect-istio/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/autodetect-istio/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -497,3 +497,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -336,11 +336,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1ca403871a46b270c0db977dcf4a71b88deb307dd8a458ce46ce74be56af6ddd
+        checksum/config: f942b0c6f7579a514f7b152a7a004a6ea2d749679d55b945a87af3434fbedec8
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 78f50f8dc786d855d30fa3c86deb33d1d3d045f9457a983bd6843566a55f0d39
+        checksum/config: 1ca403871a46b270c0db977dcf4a71b88deb307dd8a458ce46ce74be56af6ddd
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:
@@ -56,7 +56,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -126,7 +126,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f942b0c6f7579a514f7b152a7a004a6ea2d749679d55b945a87af3434fbedec8
+        checksum/config: 337519922f986cb91fc21d6331c2ad89ce3b539f1b04bf929739d3c3f894cc74
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector
@@ -42,7 +42,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/autodetect-istio/rendered_manifests/secret-splunk.yaml
+++ b/examples/autodetect-istio/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/autodetect-istio/rendered_manifests/service-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/autodetect-istio/rendered_manifests/serviceAccount.yaml
+++ b/examples/autodetect-istio/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-agent-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -318,3 +318,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5eb71401eb3a1d4c94103254afa7361a1bbaedd05ef9374123e822239e593b35
+        checksum/config: e3bfbfa9de704e67d35c45e2ddcc65bf2cc0a06aac435fe570ece898bc96bacf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3752c67248b5e11391e1a8de2aa741d2990bfc1445d952131030976e3a87ad24
+        checksum/config: 8bbe8f7b9532522201698c0426760b708a1ad608560eec39b501c4b48f6eab18
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e3bfbfa9de704e67d35c45e2ddcc65bf2cc0a06aac435fe570ece898bc96bacf
+        checksum/config: 3752c67248b5e11391e1a8de2aa741d2990bfc1445d952131030976e3a87ad24
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-agent-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-agent-only/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-agent-only/rendered_manifests/service-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/collector-agent-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-agent-only/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-all-modes/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-all-modes/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -302,3 +302,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -167,11 +167,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -229,3 +229,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -152,11 +152,7 @@ data:
           - job_name: otel-collector
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c3c3646f943ab0e09a502968b0230e74cd7e1f251f53861a4bf5432241107771
+        checksum/config: 83a1bf8e0d0aeb315c4e90944995239a2972459405c176c06ad35ca513ed11c8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 83a1bf8e0d0aeb315c4e90944995239a2972459405c176c06ad35ca513ed11c8
+        checksum/config: 76bf974100c169cab53c5bbb31c0863e43fadec7405cca8d27962b7ef395b1e4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 76bf974100c169cab53c5bbb31c0863e43fadec7405cca8d27962b7ef395b1e4
+        checksum/config: a62a9e0d95fed550005c63bf8d3b64615d5d96bc741252e926a56973d37c42d6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9609c86818da346f149502af201c15f63c115be92d95a6978fa0e9c29daae1bc
+        checksum/config: 955506cc82b2523739f96aa63de8d1ad9aace977dd3acbabe56b572eb81a8083
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2e2ed1bab47a74d37928c5441caae457dd8ead382e4265821197c4ee81c082cc
+        checksum/config: 19cd1514c64ab91b7245b48440679d989451e2ac4313413591e7791e00f55aa7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 19cd1514c64ab91b7245b48440679d989451e2ac4313413591e7791e00f55aa7
+        checksum/config: 9609c86818da346f149502af201c15f63c115be92d95a6978fa0e9c29daae1bc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-all-modes/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-all-modes/rendered_manifests/service-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/collector-all-modes/rendered_manifests/service.yaml
+++ b/examples/collector-all-modes/rendered_manifests/service.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.118.0

--- a/examples/collector-all-modes/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-all-modes/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -185,3 +185,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -124,11 +124,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 40dc38d6f82bbdd83bbc0e7cf9d62e992f15b7a2d403fd5b64d5ea8aec00e023
+        checksum/config: a9e1979e431670b7ac4e39c5cdba1d967d1cbdb5fa5e2058c0d689731f962199
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 65b9dd0b49618c3448ff225468b06eb130558231a5d1a87c62b080875bf80da4
+        checksum/config: 4dcb5615d142bc66b2d5be9f00981f58618ef36d00d255ba735665f1edfbf922
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4dcb5615d142bc66b2d5be9f00981f58618ef36d00d255ba735665f1edfbf922
+        checksum/config: 40dc38d6f82bbdd83bbc0e7cf9d62e992f15b7a2d403fd5b64d5ea8aec00e023
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-cluster-receiver-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -229,3 +229,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -152,11 +152,7 @@ data:
           - job_name: otel-collector
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9609c86818da346f149502af201c15f63c115be92d95a6978fa0e9c29daae1bc
+        checksum/config: 955506cc82b2523739f96aa63de8d1ad9aace977dd3acbabe56b572eb81a8083
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 2e2ed1bab47a74d37928c5441caae457dd8ead382e4265821197c4ee81c082cc
+        checksum/config: 19cd1514c64ab91b7245b48440679d989451e2ac4313413591e7791e00f55aa7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 19cd1514c64ab91b7245b48440679d989451e2ac4313413591e7791e00f55aa7
+        checksum/config: 9609c86818da346f149502af201c15f63c115be92d95a6978fa0e9c29daae1bc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/secret-splunk.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/collector-gateway-only/rendered_manifests/service.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/service.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.118.0

--- a/examples/collector-gateway-only/rendered_manifests/serviceAccount.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -358,3 +358,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -188,11 +188,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 23aa422db1d2bd758e4e63599dec7e319f67ea1630352bbb88369a97e5841423
+        checksum/config: c5aef578c23e91a4625944656d312b01cf355e9ba40886441e2e457f39cf5e96
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c5aef578c23e91a4625944656d312b01cf355e9ba40886441e2e457f39cf5e96
+        checksum/config: 898522bb08d9654c1f6651b899ab755e2571b7a7db9a8b98f1ee8088c378d1c1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 898522bb08d9654c1f6651b899ab755e2571b7a7db9a8b98f1ee8088c378d1c1
+        checksum/config: 0e256de2e1dd7b17df9758802f3c4a00509a7b531270fb642384694e3d079b98
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/controlplane-histogram-metrics/rendered_manifests/secret-splunk.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/controlplane-histogram-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/controlplane-histogram-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/crio-logging/rendered_manifests/clusterRole.yaml
+++ b/examples/crio-logging/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/crio-logging/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/crio-logging/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -318,3 +318,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5eb71401eb3a1d4c94103254afa7361a1bbaedd05ef9374123e822239e593b35
+        checksum/config: e3bfbfa9de704e67d35c45e2ddcc65bf2cc0a06aac435fe570ece898bc96bacf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3752c67248b5e11391e1a8de2aa741d2990bfc1445d952131030976e3a87ad24
+        checksum/config: 8bbe8f7b9532522201698c0426760b708a1ad608560eec39b501c4b48f6eab18
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e3bfbfa9de704e67d35c45e2ddcc65bf2cc0a06aac435fe570ece898bc96bacf
+        checksum/config: 3752c67248b5e11391e1a8de2aa741d2990bfc1445d952131030976e3a87ad24
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/crio-logging/rendered_manifests/secret-splunk.yaml
+++ b/examples/crio-logging/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/crio-logging/rendered_manifests/service-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/crio-logging/rendered_manifests/serviceAccount.yaml
+++ b/examples/crio-logging/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/default/rendered_manifests/clusterRole.yaml
+++ b/examples/default/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/default/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/default/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -318,3 +318,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5eb71401eb3a1d4c94103254afa7361a1bbaedd05ef9374123e822239e593b35
+        checksum/config: e3bfbfa9de704e67d35c45e2ddcc65bf2cc0a06aac435fe570ece898bc96bacf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3752c67248b5e11391e1a8de2aa741d2990bfc1445d952131030976e3a87ad24
+        checksum/config: 8bbe8f7b9532522201698c0426760b708a1ad608560eec39b501c4b48f6eab18
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e3bfbfa9de704e67d35c45e2ddcc65bf2cc0a06aac435fe570ece898bc96bacf
+        checksum/config: 3752c67248b5e11391e1a8de2aa741d2990bfc1445d952131030976e3a87ad24
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/default/rendered_manifests/secret-splunk.yaml
+++ b/examples/default/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/default/rendered_manifests/service-agent.yaml
+++ b/examples/default/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/default/rendered_manifests/serviceAccount.yaml
+++ b/examples/default/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -538,3 +538,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -389,11 +389,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -126,11 +126,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -177,3 +177,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ceb5d680c4fadc647358bc5995cded59a38cf9ec071f968d54e786d90bf76460
+        checksum/config: f4ffbb032038ad98c94327f190ee4764163f658a93b632ed408bcb1f3376cabf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 910964220545ba83d7c5681f8c06779655893f943b28b32e167fcdfd02e2ee3c
+        checksum/config: db29ff5a8c401883e5fc79fa9407ce9d1ee9dc52d5942ebdef411cc111f1a09a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -125,7 +125,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: db29ff5a8c401883e5fc79fa9407ce9d1ee9dc52d5942ebdef411cc111f1a09a
+        checksum/config: ceb5d680c4fadc647358bc5995cded59a38cf9ec071f968d54e786d90bf76460
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 62cef7e39915ab7e2e0cbc16a5a858565022f980bdd9f1000200da5b4b7e7b2b
+        checksum/config: d529fea5e625426b1904abf754ba7423e298551ad19546ddc5e154fc4e4fa1e6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc4a0f1c2390351f7216a170b12488d1537ec4584cf63480a7d0b8dd2f6f0fbe
+        checksum/config: 62cef7e39915ab7e2e0cbc16a5a858565022f980bdd9f1000200da5b4b7e7b2b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d529fea5e625426b1904abf754ba7423e298551ad19546ddc5e154fc4e4fa1e6
+        checksum/config: e33bfc582d5659771518c4063ea8f37bd3e378c7ce1f172ee304b3b8d21cf95d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/secret-splunk.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/disable-persistence-queue-traces/rendered_manifests/service-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/disable-persistence-queue-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/discovery-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/discovery-mode/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/discovery-mode/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/discovery-mode/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -318,6 +318,9 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true
   discovery.properties: |
     splunk.discovery:
       extensions:

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ab95abe46fa8ecfbbb8a2e1a1b01261117d91e8533a49710ba0de225ee0f62ed
+        checksum/config: 968a434e8b0e9ebdc10e22ec8e4c17bfa6a5e30df7388f16741156d83e3f7488
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1f9d5ca120b16438e2bd9d7f711dea2d9be5d31a049608f26bff5bfe8ed8d599
+        checksum/config: ab95abe46fa8ecfbbb8a2e1a1b01261117d91e8533a49710ba0de225ee0f62ed
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -87,7 +87,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 968a434e8b0e9ebdc10e22ec8e4c17bfa6a5e30df7388f16741156d83e3f7488
+        checksum/config: 3436942314e342d90a4f7d878c4494b6dd8298f54f6f4307cb05692c02c0f268
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/secret-splunk.yaml
+++ b/examples/discovery-mode/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/discovery-mode/rendered_manifests/service-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/discovery-mode/rendered_manifests/serviceAccount.yaml
+++ b/examples/discovery-mode/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-aks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-aks/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -276,3 +276,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -185,11 +185,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,3 +133,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -84,11 +84,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2768ef86dd3445bca097c169c0a2d8f6ca3c648cdc13dd7dc2c70abe5f916093
+        checksum/config: 536dc7ede57e23672aabc3f6c80b62bed6607308fe08333bbae99b1dbd3e1305
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 536dc7ede57e23672aabc3f6c80b62bed6607308fe08333bbae99b1dbd3e1305
+        checksum/config: a85aa5c5f1ef777f998c5133729e1e35acedc8db4626b36fa7c04bb41e8b6d7c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 76e569260306d33459de8d8d45884fac5719d63ada65dffa86625f3239fe5f31
+        checksum/config: 2768ef86dd3445bca097c169c0a2d8f6ca3c648cdc13dd7dc2c70abe5f916093
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3cf7d95bc93d3ea571b93b4d003d64af3e5bb13af5d36c3f57b26b8b1c191a0a
+        checksum/config: 24da87fc5b73f6050a77e3cb6f51e9a6ad57f212f68213b5934ff8d79a91126b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1c0dff9a01988246e217285106fc86b0901a8a4439701a07f0bbf9e0e5d31439
+        checksum/config: 8ed29b7890d30ab47459a2bcc13880ddbb194616a53458bffe55a4c5fc59efd8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8ed29b7890d30ab47459a2bcc13880ddbb194616a53458bffe55a4c5fc59efd8
+        checksum/config: 3cf7d95bc93d3ea571b93b4d003d64af3e5bb13af5d36c3f57b26b8b1c191a0a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-aks/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-aks/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/distribution-aks/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-aks/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -87,11 +87,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -162,3 +162,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -231,3 +231,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -154,11 +154,7 @@ data:
           - job_name: otel-collector
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 6a7e49904187cc85928a39896621c394d2d3cbd365e79234af0d6539f6f1a0bb
+        checksum/config: d5547521237fe6a7191f916fda1fd8d7705a72fdc34ce8eb883669897bf710f9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 6e8c1f044823969e19f722bfc37a3f8e189ced6332f3472de5326f2470ce13a0
+        checksum/config: 6a7e49904187cc85928a39896621c394d2d3cbd365e79234af0d6539f6f1a0bb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56147c527f0631d92437c53590e226c6b6ee0a6531a203777cfc037e535c2177
+        checksum/config: 6e8c1f044823969e19f722bfc37a3f8e189ced6332f3472de5326f2470ce13a0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,7 +74,7 @@ spec:
         command:
         - /otelcol
         - --config=/splunk-messages/config.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: a4e8460e21b72eab321d81cab09134fb0747498bcd0858d57bb1b3b77cf057e2
+        checksum/config: 881443db9b531dcb542b94302857bec6d2af6974b3623761b8204a870f78cdba
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 9bbdc87a466d9db5c2c4e5c11c9510af887ea4bb75759c46bb296ab66262bb6a
+        checksum/config: 882113ec3a588153c65aa9749a19a5e7ccea86ed8e585d1d9bd2a2229ad5d2f9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 881443db9b531dcb542b94302857bec6d2af6974b3623761b8204a870f78cdba
+        checksum/config: 9bbdc87a466d9db5c2c4e5c11c9510af887ea4bb75759c46bb296ab66262bb6a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks-fargate/rendered_manifests/service.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/service.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector
     chart: splunk-otel-collector-0.118.0

--- a/examples/distribution-eks-fargate/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -276,3 +276,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -185,11 +185,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -102,11 +102,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -152,3 +152,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 274a09c8b5974e008a46ebb491406b5ea688b577b2d3df9b396b3714b62fc40a
+        checksum/config: 070ec510e8e8345239a282de880bf8731e03e06fae00da90fa0d2722bd2fc069
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9c24898293930e63c86ad8cda5b587621474fbcc675374fb66a6f6f925ebd95c
+        checksum/config: 274a09c8b5974e008a46ebb491406b5ea688b577b2d3df9b396b3714b62fc40a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 070ec510e8e8345239a282de880bf8731e03e06fae00da90fa0d2722bd2fc069
+        checksum/config: 91bff57b714f4d53d19d7f6c50172cc761d477086bcb292ca03f87b9b0c27427
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 15aa65e71fe6ffb23929a7ea2796a3a5872c0bcb07375cab2bf0bf22c9ba1bc3
+        checksum/config: acf2916bb94e60ccebab08fb7b4261b898bdd8350dc36b4495ec20c8ffb295f3
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: cf24389573beb80db95a298ce06bf783840c6aa32f19b2d9fd7378a8bcbcb923
+        checksum/config: 2725c802bf21aa43f1db63b2e4f20e5c2ac704afa2e6ba63d41370d7d5cfb60c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: acf2916bb94e60ccebab08fb7b4261b898bdd8350dc36b4495ec20c8ffb295f3
+        checksum/config: cf24389573beb80db95a298ce06bf783840c6aa32f19b2d9fd7378a8bcbcb923
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-eks/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-eks/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/distribution-eks/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-eks/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -184,11 +184,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -275,3 +275,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -132,3 +132,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -83,11 +83,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 50f77f0a7489847f1d783bc8be163a979242d9bc22f92e863ba51b2dbbefd004
+        checksum/config: e89c6906fce15646b048d0966adad91e80ba4c14d32db76e133b286bfc98e92e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 93c7680d2bc7cf29accc6587d3f39adcbc3126bdfd02b125d538cc87022bb9ab
+        checksum/config: 50f77f0a7489847f1d783bc8be163a979242d9bc22f92e863ba51b2dbbefd004
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e89c6906fce15646b048d0966adad91e80ba4c14d32db76e133b286bfc98e92e
+        checksum/config: 01ec9ec10f4152df81484fb7badde3111c34876094e79cb2d8d4fd6632f4bd48
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 514d12bc718761e1fca4e10805dfa4551a296e451d067eb6e4af514e4d8f5437
+        checksum/config: 95d95497d20d8e029408aec3081b6e5185b102d8a82a66b16c4e0db462a2973b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: abf5c1bf93b441ef41686386c98b62886b40f47682c4ba3ddef7d044db64afd7
+        checksum/config: 514d12bc718761e1fca4e10805dfa4551a296e451d067eb6e4af514e4d8f5437
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 458e5b5e644093c37be8fe9994456eff9205e68e430a32596b17971992a1adf5
+        checksum/config: abf5c1bf93b441ef41686386c98b62886b40f47682c4ba3ddef7d044db64afd7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke-autopilot/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke-autopilot/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/distribution-gke-autopilot/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -184,11 +184,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -275,3 +275,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -132,3 +132,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -83,11 +83,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0bd146e2e7a0c61afd1fe363d9bf3b3180e6bb41d7d472bc4193f01d358e426d
+        checksum/config: 450b0c9e8f1c7976360af2c49839ee93e04304b61bbcf9af3dcd8ae835d2b4d1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d63fef8284d7f4d9e9a1e47650d63e212087e827fb37c7d8c6558dc97bd739ba
+        checksum/config: 0bd146e2e7a0c61afd1fe363d9bf3b3180e6bb41d7d472bc4193f01d358e426d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 450b0c9e8f1c7976360af2c49839ee93e04304b61bbcf9af3dcd8ae835d2b4d1
+        checksum/config: 37f8caff2abc330d788225383b246ee66bba4904a0eb9e4d053687b772930dbe
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 514d12bc718761e1fca4e10805dfa4551a296e451d067eb6e4af514e4d8f5437
+        checksum/config: 95d95497d20d8e029408aec3081b6e5185b102d8a82a66b16c4e0db462a2973b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: abf5c1bf93b441ef41686386c98b62886b40f47682c4ba3ddef7d044db64afd7
+        checksum/config: 514d12bc718761e1fca4e10805dfa4551a296e451d067eb6e4af514e4d8f5437
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 458e5b5e644093c37be8fe9994456eff9205e68e430a32596b17971992a1adf5
+        checksum/config: abf5c1bf93b441ef41686386c98b62886b40f47682c4ba3ddef7d044db64afd7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-gke/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-gke/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-gke/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/distribution-gke/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-gke/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-openshift/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -326,3 +326,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -132,3 +132,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -83,11 +83,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 990956b5490546e02f9215ac733a660b395e83c305bd80925b8eaaa87ce0490c
+        checksum/config: 3c080cb7b1445dfb617ed415dc6624f679e12a94830c3641f8f3fe8d7ac792dd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3c080cb7b1445dfb617ed415dc6624f679e12a94830c3641f8f3fe8d7ac792dd
+        checksum/config: 1575adc9bb53f81387306f3737d866bf1001dbfa63fc8f5c2bfecef0a042cc3d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 277f3d7f5676ba28a8354b153b8911497f5ba8b922f4317b0228cec0d4063ae0
+        checksum/config: 990956b5490546e02f9215ac733a660b395e83c305bd80925b8eaaa87ce0490c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 44ceaf7e9789178621356c530500bbb6a3c3f4e4d61635faea2f3fe1fa14e642
+        checksum/config: d27892816d0b62a9a44257366931cc610495d1844d301efcb83fecbce5ea108d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d27892816d0b62a9a44257366931cc610495d1844d301efcb83fecbce5ea108d
+        checksum/config: 5a20e51d9fdf8af930158fc4b07e7012dc20e60726c1b4ddcda4ca00b6f25b76
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: db4a97ee9dc1412d0a2d9768d7e719863ff4f2f76ad544f6164b1c7ad3c9ca0e
+        checksum/config: 44ceaf7e9789178621356c530500bbb6a3c3f4e4d61635faea2f3fe1fa14e642
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/distribution-openshift/rendered_manifests/secret-splunk.yaml
+++ b/examples/distribution-openshift/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
+++ b/examples/distribution-openshift/rendered_manifests/securityContextConstraints.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/distribution-openshift/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/distribution-openshift/rendered_manifests/serviceAccount.yaml
+++ b/examples/distribution-openshift/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -459,3 +459,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -306,11 +306,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: abcac6d611b5d772f7560f99ba18a94d6c065d607707b684cba5ca5d58e799d8
+        checksum/config: 506b95b9e4d325a029c93e43f05ac7e795886201ef07fcc8589fa722cc9e382a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -125,7 +125,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 506b95b9e4d325a029c93e43f05ac7e795886201ef07fcc8589fa722cc9e382a
+        checksum/config: 90ddb5c8013d219fc19bcab0ef63e53c0ec57559dce693b6801d23306c6e1c9a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 90ddb5c8013d219fc19bcab0ef63e53c0ec57559dce693b6801d23306c6e1c9a
+        checksum/config: a0fc79abd5f824cd26622c6006dc68b6fbd1747363c5cfd60e00b4a1bfaf44b9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 85f9702117b61d4f5c205ae1796947d81606affaa91725688d0e68f9c928bb13
+        checksum/config: f850dd56a382a8e3f058a5990db236dd656fe853aa5d9a41184a761e97dfadb6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3036fe3ee485f6d7db493ef6623d06bb2662cb7cd582c14974b0bd067b4d300b
+        checksum/config: 85f9702117b61d4f5c205ae1796947d81606affaa91725688d0e68f9c928bb13
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f850dd56a382a8e3f058a5990db236dd656fe853aa5d9a41184a761e97dfadb6
+        checksum/config: 0fa6769b4840257819d12e5e8637442587ba3e56eb1f850b1bfa083cb305906d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-operator
     chart: splunk-otel-collector-0.118.0

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/secret-splunk.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/service-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -538,3 +538,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -389,11 +389,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -126,11 +126,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -177,3 +177,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1c1ee6f0547bf3378a6461791baa5e18048748974cdbc9515662f6a09b4a63a0
+        checksum/config: fbd5e916cae0633ad31fdf66fa6624af55dd556aab634e6eedaa6a75544691e5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -125,7 +125,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fbd5e916cae0633ad31fdf66fa6624af55dd556aab634e6eedaa6a75544691e5
+        checksum/config: 287d794af31dbb5915c97ac46323d7db60d95ef0c1c970354b0d24ee1d19e257
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 287d794af31dbb5915c97ac46323d7db60d95ef0c1c970354b0d24ee1d19e257
+        checksum/config: 62bf87773486ebb55aa97d60d6a3a2bdaf8b4b22630398328e34254704e4152b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 62cef7e39915ab7e2e0cbc16a5a858565022f980bdd9f1000200da5b4b7e7b2b
+        checksum/config: d529fea5e625426b1904abf754ba7423e298551ad19546ddc5e154fc4e4fa1e6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc4a0f1c2390351f7216a170b12488d1537ec4584cf63480a7d0b8dd2f6f0fbe
+        checksum/config: 62cef7e39915ab7e2e0cbc16a5a858565022f980bdd9f1000200da5b4b7e7b2b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d529fea5e625426b1904abf754ba7423e298551ad19546ddc5e154fc4e4fa1e6
+        checksum/config: e33bfc582d5659771518c4063ea8f37bd3e378c7ce1f172ee304b3b8d21cf95d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/secret-splunk.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-persistence-queue/rendered_manifests/service-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/enable-persistence-queue/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -231,3 +231,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -160,11 +160,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 26f576c90f28c62cd1df6e74b53155346dc00618725bd13e79baf88e2f2dd54a
+        checksum/config: c10c64ad8b8e21cd178bfb902e1e90bc9254c9b6bb12c1ba802c5cea450d7898
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 605b79d5be864f35c5176985141d1508de8c323a0cf1078dfc04eb1775acae7d
+        checksum/config: 26f576c90f28c62cd1df6e74b53155346dc00618725bd13e79baf88e2f2dd54a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -82,7 +82,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c10c64ad8b8e21cd178bfb902e1e90bc9254c9b6bb12c1ba802c5cea450d7898
+        checksum/config: 08eaf0c730e3ab3cbd96a03884b1eff29f1b562e35a7a571f697b4ce3c76c7a8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/secret-splunk.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enable-trace-sampling/rendered_manifests/service-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/enable-trace-sampling/rendered_manifests/serviceAccount.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -184,11 +184,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -320,3 +320,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d986a293b3074d41254c543aa05dc30f09424a2a9ddd2bee81b3f02cf4050030
+        checksum/config: 6c017f70f07beac6bc3a06e64dd6ed9688edceba388942fe380428f2cc8dc0d3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 292ce857c67d0d7b2e2d4efe1effec797351de3741f0e866b4307d25bc750db0
+        checksum/config: d986a293b3074d41254c543aa05dc30f09424a2a9ddd2bee81b3f02cf4050030
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8f05cb52638cb7af67c888b0ba83386cc4928dc476e7f39d15635bcc05d92c2a
+        checksum/config: 292ce857c67d0d7b2e2d4efe1effec797351de3741f0e866b4307d25bc750db0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/enabled-pprof-extension/rendered_manifests/secret-splunk.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/enabled-pprof-extension/rendered_manifests/service-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/enabled-pprof-extension/rendered_manifests/serviceAccount.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -201,11 +201,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -351,3 +351,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd-json.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-fluentd.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 574300b5e89206a99ddd007b61b85a0ddbf0fa373981617b7056894630ea6da2
+        checksum/config: 551376260283bda11d3c34f893402ca802da5caf613ddb8d6e118bd243cc19fe
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0f2bd9b8d0051928f92ddcd40e4badd8edf6c2e8c9e10a2723481176bff268ca
+        checksum/config: c5145392c83a5a096f86ea8b92fbde5931516489a54aa1918300482a65d0c1f5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -159,7 +159,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c5145392c83a5a096f86ea8b92fbde5931516489a54aa1918300482a65d0c1f5
+        checksum/config: 574300b5e89206a99ddd007b61b85a0ddbf0fa373981617b7056894630ea6da2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/secret-splunk.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/service-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/clusterRole.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -201,11 +201,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -351,3 +351,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd-json.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-fluentd.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d309d388e6063261b0a68a3cb4e9c632853482163d421946669d94bc8936694c
+        checksum/config: 85eb0a390cb19b52bdac43126e9568708c49829ceadf2eb177f9ce97c8703590
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2cff4dfd4c2135d98298167b438f78d7ae2b9911d35b3611d96251f8df0c6b29
+        checksum/config: d309d388e6063261b0a68a3cb4e9c632853482163d421946669d94bc8936694c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -159,7 +159,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 85eb0a390cb19b52bdac43126e9568708c49829ceadf2eb177f9ce97c8703590
+        checksum/config: 3325aa24b4f11d07fb1ee0a39a85484a1ff7a0183ec0229f7feb33e75e7d6e47
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/fluentd-refresh-interval/rendered_manifests/secret-splunk.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/fluentd-refresh-interval/rendered_manifests/service-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/fluentd-refresh-interval/rendered_manifests/serviceAccount.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -305,11 +305,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -457,3 +457,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c4da1db0b360ce48ae16e792dc5f05a4462f413ad94fcaa441bac37b6ee0a941
+        checksum/config: 0e921ecf4c8694ee6af790ef93ddabffc20142e9fddef77a80e4e4886d4b43e6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0e921ecf4c8694ee6af790ef93ddabffc20142e9fddef77a80e4e4886d4b43e6
+        checksum/config: 90804beecc3138487071d39a8acc6cb156244c0ee01e9f6e4e321d913a2bbb2a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: db7f8592f13ad4dc17302781e9430a0d4c13dcebe4430c1a26a8c478765f5496
+        checksum/config: c4da1db0b360ce48ae16e792dc5f05a4462f413ad94fcaa441bac37b6ee0a941
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet
@@ -91,7 +91,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector-windows:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector-windows:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           windowsOptions:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -43,7 +43,7 @@ spec:
         - -command
         - .\otelcol.exe
         - --config=C:\\conf\relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector-windows:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector-windows:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/secret-splunk.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/kubernetes-windows-nodes/rendered_manifests/service-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/kubernetes-windows-nodes/rendered_manifests/serviceAccount.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/multi-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/multi-metrics/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/multi-metrics/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/multi-metrics/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -355,11 +355,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -488,3 +488,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -126,11 +126,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -177,3 +177,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ffe803f3feded17647f95968e52b3795975c99d06542a9450ee81722f3f37304
+        checksum/config: 55af00156f935751c55baaa9691be6d63e61d21fe5e61597df229d0b9bcce416
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 71374d4c9b07f0b5ffaf79d2e9e2407b5ba787af5e6763c991d9e3463a2b15f9
+        checksum/config: ffe803f3feded17647f95968e52b3795975c99d06542a9450ee81722f3f37304
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 88b937ca61dcba36afcf02b059f05b28d568ed4ee237653722313c3e6f52b940
+        checksum/config: 71374d4c9b07f0b5ffaf79d2e9e2407b5ba787af5e6763c991d9e3463a2b15f9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -109,7 +109,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 62cef7e39915ab7e2e0cbc16a5a858565022f980bdd9f1000200da5b4b7e7b2b
+        checksum/config: d529fea5e625426b1904abf754ba7423e298551ad19546ddc5e154fc4e4fa1e6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc4a0f1c2390351f7216a170b12488d1537ec4584cf63480a7d0b8dd2f6f0fbe
+        checksum/config: 62cef7e39915ab7e2e0cbc16a5a858565022f980bdd9f1000200da5b4b7e7b2b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d529fea5e625426b1904abf754ba7423e298551ad19546ddc5e154fc4e4fa1e6
+        checksum/config: e33bfc582d5659771518c4063ea8f37bd3e378c7ce1f172ee304b3b8d21cf95d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/secret-splunk.yaml
+++ b/examples/multi-metrics/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/multi-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/multi-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/multi-metrics/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -230,3 +230,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -164,11 +164,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd-json.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd-json.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-fluentd.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c29a2512deb20f03f9ff2c2429972d7ed0c3227bf07b5d962551d0913fb0656e
+        checksum/config: 43705606f0f4394ac797aca03b4f15b625e03ef2e2d356ad814d062480cb955a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: af5b388db451839c79ea5a7cf0c1802da356137818ddf96caeecfdf118968a61
+        checksum/config: c29a2512deb20f03f9ff2c2429972d7ed0c3227bf07b5d962551d0913fb0656e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -139,7 +139,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 43705606f0f4394ac797aca03b4f15b625e03ef2e2d356ad814d062480cb955a
+        checksum/config: b037c9bb6ca04926181d8b2d77f638aa62d54681d614bddfd087870cbf381d20
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-fluentd/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-fluentd/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/only-logs-fluentd/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-otel/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-otel/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-otel/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-otel/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -366,3 +366,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -299,11 +299,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 33c51fa3a0d51c323f2e6355a284d6aa69124689c5e332e1c8beb739f82233ea
+        checksum/config: 88235c76c8d4b5f0c1c025ce9bba496beb0871bbd98edd1ed3d897dd9d4cb497
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 38bd67a2d2e789695c3d6eec7ac93f489c0b24bb85aff7aa94cf54e0ebd8fd08
+        checksum/config: d2cec0c4efa01a249c6da2bb239c01a333d5364f110dfa0e8a9b37b583ca2454
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -105,7 +105,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d2cec0c4efa01a249c6da2bb239c01a333d5364f110dfa0e8a9b37b583ca2454
+        checksum/config: 33c51fa3a0d51c323f2e6355a284d6aa69124689c5e332e1c8beb739f82233ea
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-otel/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-otel/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/only-logs-otel/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-otel/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -292,11 +292,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -369,3 +369,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a9f4d7674f21d009b7de7d51d2afaf740996f4ba7b438761273d67597b64dafc
+        checksum/config: 78303cb12ed90e72c44e10be455e571b09e489bdfafb320da250054b6288f206
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -105,7 +105,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 78303cb12ed90e72c44e10be455e571b09e489bdfafb320da250054b6288f206
+        checksum/config: a2207324566225cdd6fb572f8204212e4b4e1b73d2e1df96e0e485c929b2d7d8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a2207324566225cdd6fb572f8204212e4b4e1b73d2e1df96e0e485c929b2d7d8
+        checksum/config: aec915a30547233b593d8c48f6090f2ee017d714fa97a602c05af9db82f905fd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/service-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -335,3 +335,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -218,11 +218,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -126,11 +126,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -177,3 +177,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 73f482d8681e535883e0320d8a2800c0ee9950b24a5396456b2ee47d8582bccc
+        checksum/config: 3ab25c519a042d7ee08f13be1e3bf178a6638429c6af7ec4ed118b57171acc68
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3ab25c519a042d7ee08f13be1e3bf178a6638429c6af7ec4ed118b57171acc68
+        checksum/config: 8da38b1c97209a3cbde27deee1c1bb4722617348f007fe18634edfeb4c0dab69
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7d85bbe4bf372577b9da3d11ca84157b697b9d281afc5bc23efac3d965f85db8
+        checksum/config: 73f482d8681e535883e0320d8a2800c0ee9950b24a5396456b2ee47d8582bccc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -70,7 +70,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 62cef7e39915ab7e2e0cbc16a5a858565022f980bdd9f1000200da5b4b7e7b2b
+        checksum/config: d529fea5e625426b1904abf754ba7423e298551ad19546ddc5e154fc4e4fa1e6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc4a0f1c2390351f7216a170b12488d1537ec4584cf63480a7d0b8dd2f6f0fbe
+        checksum/config: 62cef7e39915ab7e2e0cbc16a5a858565022f980bdd9f1000200da5b4b7e7b2b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d529fea5e625426b1904abf754ba7423e298551ad19546ddc5e154fc4e4fa1e6
+        checksum/config: e33bfc582d5659771518c4063ea8f37bd3e378c7ce1f172ee304b3b8d21cf95d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics-platform/rendered_manifests/service-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/only-metrics-platform/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -287,3 +287,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -172,11 +172,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e3d52e9406e4eb3817415a8d28989d5c79129d218052438a7b1148d59167f3e1
+        checksum/config: 973bbcf1345f632e6bc5f0631f172e0a8e57db5b134e38f7a5e8939284a34752
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 973bbcf1345f632e6bc5f0631f172e0a8e57db5b134e38f7a5e8939284a34752
+        checksum/config: 3627150b9bbcd4667a47e1c64ede968f29c98c716b6269999ebbb09ee920e37e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e80b3b8ffe35188a7fd25c9b8d214db621ee8f5ae2968c9b0704b3aff535a2e2
+        checksum/config: e3d52e9406e4eb3817415a8d28989d5c79129d218052438a7b1148d59167f3e1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -70,7 +70,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-metrics/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-metrics/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/only-metrics/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-metrics/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-traces/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -227,3 +227,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -157,11 +157,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 45fe6d4e0d737e783fd925ac68a3c278875637158123bcaf3b5c7d4c3b19454b
+        checksum/config: 719f4e043d94bb6ce4e60328d28d13c38326ea5224783875ac417de03868afea
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1c87fe2b05bce868c8e2476d551f321ecb5bf4be6679834222063b2a22aa52f1
+        checksum/config: 45fe6d4e0d737e783fd925ac68a3c278875637158123bcaf3b5c7d4c3b19454b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 73ae2ec4b01a52f0b2d1d009a3de3065eae3af9a8f32b04ec617bcb8b68ec9a4
+        checksum/config: 1c87fe2b05bce868c8e2476d551f321ecb5bf4be6679834222063b2a22aa52f1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -82,7 +82,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/only-traces/rendered_manifests/secret-splunk.yaml
+++ b/examples/only-traces/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/only-traces/rendered_manifests/service-agent.yaml
+++ b/examples/only-traces/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/only-traces/rendered_manifests/serviceAccount.yaml
+++ b/examples/only-traces/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -187,11 +187,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -325,3 +325,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5c108485a11e54964ef966b101f9667eb561b021ec432aac8bd4d82c6c1280e2
+        checksum/config: 9b20567ac5c9e6777143f3b170eadd55927de8d3cdc24c604435906d275a50c7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 62e4637f4f7b75053cafad27d331287d2c98943b1ffd6270f15161c667a45236
+        checksum/config: 5c108485a11e54964ef966b101f9667eb561b021ec432aac8bd4d82c6c1280e2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6166ecb8708d5dea5940836a6d99a02194b5eebd319a354adcdacd25237bcba4
+        checksum/config: 62e4637f4f7b75053cafad27d331287d2c98943b1ffd6270f15161c667a45236
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2d30104c1725bfc46d21422a78e2ebf2739ebca5499b79cf5b57362c722add65
+        checksum/config: 4dbd6da72865c6b0dc79d928a75f37025bb715a867abbe735161c7f2deffa93b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4dbd6da72865c6b0dc79d928a75f37025bb715a867abbe735161c7f2deffa93b
+        checksum/config: 2d5a866de11498bd7a8545c0ec28a3b8a389a1b91a96af5ccf60ce5986c90333
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2d5a866de11498bd7a8545c0ec28a3b8a389a1b91a96af5ccf60ce5986c90333
+        checksum/config: 80ec5a8462ae498443c59562679040d99fc9abbd5f4cfde791357c3b4a839f86
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/secret-splunk.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/service-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/serviceAccount.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/secret-validation/rendered_manifests/clusterRole.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/secret-validation/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -331,3 +331,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -264,11 +264,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6089f83b6aa14724dcc0adaf3e02b68d228316db97a5730d40074ebd797e4950
+        checksum/config: f9ca3f5951a1db5c1c5a16a6d119ef09f2b367b4a498f266cf808199c117fc55
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f1f70978e121320d7537be88c56c0b2581b4d194b97cc1189fcea8e60ac279b2
+        checksum/config: 6089f83b6aa14724dcc0adaf3e02b68d228316db97a5730d40074ebd797e4950
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b3f1f12b71f67ff6f5925a78164f653a4fd71701765d682f002bd5a6fb729d4
+        checksum/config: f1f70978e121320d7537be88c56c0b2581b4d194b97cc1189fcea8e60ac279b2
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -105,7 +105,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/secret-validation/rendered_manifests/secret-splunk-validation-hook.yaml
+++ b/examples/secret-validation/rendered_manifests/secret-splunk-validation-hook.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
   annotations:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/examples/secret-validation/rendered_manifests/service-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/secret-validation/rendered_manifests/serviceAccount.yaml
+++ b/examples/secret-validation/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -334,3 +334,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -279,11 +279,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: eb64046b16823f2ea92e7bbb4e72be3f38b225f715914b24b3143b9f8b68a23c
+        checksum/config: 8feace46ae7f20dcc8b8dad9eaaf575b86579a7673bbaa02f80828e4c18deafa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5554d4e4cf47bfde76b41ac6782ecf89b189ddd6da4a118427fbb9afcf32c050
+        checksum/config: eb64046b16823f2ea92e7bbb4e72be3f38b225f715914b24b3143b9f8b68a23c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 337b62ab6e26e59337eb748710c0020c704126443416cef3db07f902f26ea6b5
+        checksum/config: 5554d4e4cf47bfde76b41ac6782ecf89b189ddd6da4a118427fbb9afcf32c050
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -55,7 +55,7 @@ spec:
           operator: Exists
       initContainers:
         - name: migrate-checkpoint
-          image: quay.io/signalfx/splunk-otel-collector:0.118.0
+          image: quay.io/signalfx/splunk-otel-collector:0.119.0
           imagePullPolicy: IfNotPresent
           command: ["/migratecheckpoint"]
           securityContext:
@@ -105,7 +105,7 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/secret-splunk.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/service-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/serviceAccount.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/target-allocator/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/target-allocator/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/target-allocator/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -326,3 +326,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 98ef32809fc3f904eae20273af60ad17d59676e1c3eeb21a4bbd3f71a3b41d54
+        checksum/config: 59546f3c10f2036f1443f0d45ec59f253e0f9ca070e1bf100b5f6a51fea84a4b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 40d2922b85afbb24c334a3d1a7b547e82c3d17029f07d5a772f6e8751a9b8a57
+        checksum/config: a19c8d64d1463482307a7bb5e2aee63f757207a165c109bc5a75e4b6c281fad6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a19c8d64d1463482307a7bb5e2aee63f757207a165c109bc5a75e4b6c281fad6
+        checksum/config: 98ef32809fc3f904eae20273af60ad17d59676e1c3eeb21a4bbd3f71a3b41d54
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/target-allocator/rendered_manifests/secret-splunk.yaml
+++ b/examples/target-allocator/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/target-allocator/rendered_manifests/service-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/target-allocator/rendered_manifests/serviceAccount.yaml
+++ b/examples/target-allocator/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/use-proxy/rendered_manifests/clusterRole.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/use-proxy/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -318,3 +318,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5eb71401eb3a1d4c94103254afa7361a1bbaedd05ef9374123e822239e593b35
+        checksum/config: e3bfbfa9de704e67d35c45e2ddcc65bf2cc0a06aac435fe570ece898bc96bacf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3752c67248b5e11391e1a8de2aa741d2990bfc1445d952131030976e3a87ad24
+        checksum/config: 8bbe8f7b9532522201698c0426760b708a1ad608560eec39b501c4b48f6eab18
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e3bfbfa9de704e67d35c45e2ddcc65bf2cc0a06aac435fe570ece898bc96bacf
+        checksum/config: 3752c67248b5e11391e1a8de2aa741d2990bfc1445d952131030976e3a87ad24
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/use-proxy/rendered_manifests/secret-splunk.yaml
+++ b/examples/use-proxy/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/use-proxy/rendered_manifests/service-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/use-proxy/rendered_manifests/serviceAccount.yaml
+++ b/examples/use-proxy/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/with-target-allocator/rendered_manifests/clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -183,11 +183,7 @@ data:
           - job_name: otel-agent
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -327,3 +327,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,6 @@ data:
                 prometheus:
                   host: localhost
                   port: 8889
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -82,11 +82,7 @@ data:
           - job_name: otel-k8s-cluster-receiver
             metric_relabel_configs:
             - action: drop
-              regex: otelcol_rpc_.*
-              source_labels:
-              - __name__
-            - action: drop
-              regex: otelcol_http_.*
+              regex: promhttp_metric_handler_errors.*
               source_labels:
               - __name__
             - action: drop

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6422bd347912cec6c9da2acf721602d737528c85e75e171b1455fa8a739b6ab3
+        checksum/config: 865cfe42a97cafca3c863720fbb2ffba058bd7a191566a19aee4d48b2bd4d298
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -86,7 +86,7 @@ spec:
           containerPort: 9411
           hostPort: 9411
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 865cfe42a97cafca3c863720fbb2ffba058bd7a191566a19aee4d48b2bd4d298
+        checksum/config: 80cccaeee325bddb8e9430fd6e343ee4bbdc34522b5c47d116505ab1ccb71de0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 80cccaeee325bddb8e9430fd6e343ee4bbdc34522b5c47d116505ab1ccb71de0
+        checksum/config: 054ff803341ebe66a111e8fbb5fbc44a28bef8871ad46e3afe7e50a8d8d53f80
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
+        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: da3283eeb9708564847b3e5e075a8eb9f627547e77b40c669289d43cba155a71
+        checksum/config: c42cb1583d693dc14d6ad2977c155843810e3a7c1e7fb3aae3daea5d8914879d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
     chart: splunk-otel-collector-0.118.0
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f25f2d1d33bf121655e8c42b63e4f17502bae29f2cc8aaa585764447976fdde8
+        checksum/config: e2a0cbca0c23f30a147739b3f14c67934ea1eca7b58460b749bc3ad873a020c1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -41,7 +41,7 @@ spec:
         command:
         - /otelcol
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.118.0
+        image: quay.io/signalfx/splunk-otel-collector:0.119.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/with-target-allocator/rendered_manifests/secret-splunk.yaml
+++ b/examples/with-target-allocator/rendered_manifests/secret-splunk.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/service-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/service-agent.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     component: otel-collector-agent
     chart: splunk-otel-collector-0.118.0

--- a/examples/with-target-allocator/rendered_manifests/serviceAccount.yaml
+++ b/examples/with-target-allocator/rendered_manifests/serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/targetAllocator-clusterRoleBinding.yaml
+++ b/examples/with-target-allocator/rendered_manifests/targetAllocator-clusterRoleBinding.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/targetAllocator-configmap.yaml
+++ b/examples/with-target-allocator/rendered_manifests/targetAllocator-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/examples/with-target-allocator/rendered_manifests/targetAllocator-serviceAccount.yaml
+++ b/examples/with-target-allocator/rendered_manifests/targetAllocator-serviceAccount.yaml
@@ -11,7 +11,7 @@ metadata:
     helm.sh/chart: splunk-otel-collector-0.118.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.119.0"
     app: splunk-otel-collector
     chart: splunk-otel-collector-0.118.0
     release: default

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: splunk-otel-collector
 version: 0.118.0
-appVersion: 0.118.0
+appVersion: 0.119.0
 description: Splunk OpenTelemetry Collector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png
 type: application

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -415,10 +415,8 @@ splunk_hec/platform_logs:
     {{- if .addPersistentStorage }}
     storage: file_storage/persistent_queue
     {{- end }}
-  {{- if not .Values.featureGates.noDropLogsPipeline }}
     num_consumers: {{ .Values.splunkPlatform.sendingQueue.numConsumers }}
-  {{- else }}
-    num_consumers: 25
+  {{- if .Values.featureGates.noDropLogsPipeline }}
   batcher:
     enabled: true
     flush_timeout: 200ms

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -545,11 +545,7 @@ prometheus/{{ $receiver }}:
     - job_name: "otel-{{ $job }}"
       metric_relabel_configs:
       - action: drop
-        regex: "otelcol_rpc_.*"
-        source_labels:
-        - __name__
-      - action: drop
-        regex: "otelcol_http_.*"
+        regex: "promhttp_metric_handler_errors.*"
         source_labels:
         - __name__
       - action: drop

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -860,6 +860,9 @@ service:
               prometheus:
                 host: localhost
                 port: 8889
+                without_scope_info: true
+                without_units: true
+                without_type_suffix: true
   extensions:
     {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (eq .Values.logsEngine "otel") }}
     - file_storage

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -150,6 +150,9 @@ service:
               prometheus:
                 host: localhost
                 port: 8889
+                without_scope_info: true
+                without_units: true
+                without_type_suffix: true
   extensions:
     - health_check
     - zpages

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -225,6 +225,9 @@ service:
               prometheus:
                 host: localhost
                 port: 8889
+                without_scope_info: true
+                without_units: true
+                without_type_suffix: true
   {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
   extensions: [health_check, k8s_observer]
   {{- else }}


### PR DESCRIPTION
Applied additional changes to adopt changes in the 0.119.0 image:
1. [Update internal metrics prometheus reader to default values](https://github.com/signalfx/splunk-otel-collector-chart/pull/1671/commits/dca8e9b89eaca43d1aeff7f7809b3107687407f2) to replicate default values in the new reader fields as set in https://github.com/open-telemetry/opentelemetry-collector/blob/main/service/telemetry/config.go#L92-L94
2. [Update default exclusion rules for internal metrics](https://github.com/signalfx/splunk-otel-collector-chart/pull/1671/commits/2801bf18222febe006b6f8279542fbd463c5ff1e) to avoid scraping redundant metrics as done in https://github.com/signalfx/splunk-otel-collector/pull/5918
3. [Remove bumped number of batch exporter workers in noDropLogsPipeline](https://github.com/signalfx/splunk-otel-collector-chart/pull/1671/commits/7fb7611fb68a9fd67a83efc03c34e0466e4d2738). The number of workers was initially increased to overcome https://github.com/open-telemetry/opentelemetry-collector/issues/10368. The new pulling batcher resolving the issue was enabled by default in 0.119.0. So increasing the number of workers isn't needed anymore.