### PR TITLE
Bump operator from 0.71.2 to 0.80.2 in helm-charts/splunk-otel-collector/Chart.yaml

### DIFF
--- a/.chloggen/update-operator.yaml
+++ b/.chloggen/update-operator.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: operator
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump operator to 0.80.2 in helm-charts/splunk-otel-collector/Chart.yaml
+# One or more tracking issues related to the change
+issues: [235]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -6,12 +6,11 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/default-operator-serving-cert
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: webhook
   name: default-operator-mutation
 webhooks:
@@ -91,12 +90,11 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: default/default-operator-serving-cert
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: webhook
   name: default-operator-validation
 webhooks:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/certmanager.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/certmanager.yaml
@@ -7,12 +7,11 @@ metadata:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "1"
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: webhook
   name: default-operator-serving-cert
   namespace: default
@@ -36,12 +35,11 @@ metadata:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-weight: "1"
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: webhook
   name: default-operator-selfsigned-issuer
   namespace: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/clusterrole.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/clusterrole.yaml
@@ -4,12 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator-manager
 rules:
@@ -223,12 +222,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator-metrics
 rules:
@@ -242,12 +240,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator-proxy
 rules:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/clusterrolebinding.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/clusterrolebinding.yaml
@@ -4,12 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator-manager
 roleRef:
@@ -26,12 +25,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator-proxy
 roleRef:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/deployment.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/deployment.yaml
@@ -4,12 +4,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator
   namespace: default
@@ -34,13 +33,13 @@ spec:
             - --enable-leader-election
             - --health-probe-addr=:8081
             - --webhook-port=9443
-            - --collector-image=quay.io/signalfx/splunk-otel-collector:0.110.0
+            - --collector-image=quay.io/signalfx/splunk-otel-collector:0.117.0
           command:
             - /manager
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
-          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.110.0"
+          image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.117.0"
           name: manager
           ports:
             - containerPort: 8080
@@ -62,12 +61,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources: 
-            limits:
-              cpu: 100m
-              memory: 128Mi
-            requests:
-              cpu: 100m
-              memory: 64Mi
+            {}
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert
@@ -83,13 +77,6 @@ spec:
             - containerPort: 8443
               name: https
               protocol: TCP
-          resources: 
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
       serviceAccountName: operator
       terminationGracePeriodSeconds: 10
       volumes:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml
@@ -42,10 +42,10 @@ spec:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://default-splunk-otel-collector-agent.default.svc.cluster.local:4318
   go:
-    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-go:v0.10.1-alpha
+    image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.19.0-alpha
     env:
       - name: OTEL_RESOURCE_ATTRIBUTES
-        value: splunk.zc.method=autoinstrumentation-go:v0.10.1-alpha
+        value: splunk.zc.method=autoinstrumentation-go:v0.19.0-alpha
   java:
     image: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:v2.13.0
     env:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/role.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/role.yaml
@@ -4,12 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator-leader-election
   namespace: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/rolebinding.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/rolebinding.yaml
@@ -4,12 +4,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator-leader-election
   namespace: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/service.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/service.yaml
@@ -4,12 +4,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator
   namespace: default
@@ -32,12 +31,11 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   name: default-operator-webhook
   namespace: default

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/serviceaccount.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/serviceaccount.yaml
@@ -6,10 +6,9 @@ metadata:
   name: operator
   namespace: default
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/tests/test-certmanager-connection.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/tests/test-certmanager-connection.yaml
@@ -6,12 +6,11 @@ metadata:
   name: "default-operator-cert-manager"
   namespace: default
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: webhook
   annotations:
     "helm.sh/hook": test

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/tests/test-service-connection.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/tests/test-service-connection.yaml
@@ -6,12 +6,11 @@ metadata:
   name: "default-operator-metrics"
   namespace: default
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test
@@ -44,12 +43,11 @@ metadata:
   name: "default-operator-webhook"
   namespace: default
   labels:
-    helm.sh/chart: operator-0.71.2
+    helm.sh/chart: operator-0.80.2
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: "0.110.0"
+    app.kubernetes.io/version: "0.117.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    
     app.kubernetes.io/component: controller-manager
   annotations:
     "helm.sh/hook": test

--- a/functional_tests/testdata/expected_kind_values/expected_cluster_receiver.yaml
+++ b/functional_tests/testdata/expected_kind_values/expected_cluster_receiver.yaml
@@ -26,10 +26,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-67c98b89c8-g22j7
+                        stringValue: cert-manager-5d864474d-6fgxj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3ece0e7b-6f24-4bed-a51e-e0fcf81a5c26
+                        stringValue: 7918d738-3243-4a2e-855c-526270da5014
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -59,10 +59,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-cainjector-5c5695d979-4gn7v
+                        stringValue: cert-manager-cainjector-85d499d4cc-74qtd
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c67d333e-6b13-4486-8b36-c9622a794d1f
+                        stringValue: 87792135-b13b-456b-93f8-49f1f8fe387a
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -92,43 +92,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-webhook-7f9f8648b9-pjrwc
+                        stringValue: cert-manager-webhook-d499d9459-qvlwd
                     - key: k8s.pod.uid
                       value:
-                        stringValue: abf6af19-643c-4f88-96ae-beedc60f4f8e
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "2"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: dotnet-test-5479c475fc-8xpcw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c28fcde1-8d20-4cfc-a975-8b2c08de526f
+                        stringValue: c942d73c-5605-4d76-877c-23908fdc7a66
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -158,10 +125,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: java-test-5c4d6479b8-9w6fc
+                        stringValue: dotnet-test-7fd7cfb786-w4rd6
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 789291d9-e227-4281-ac96-3ade5e1512d6
+                        stringValue: 7824d56e-b27a-4879-a8d1-9eee338bf089
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -191,43 +158,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: nodejs-test-56b74df9ff-t7bkb
+                        stringValue: java-test-5b5c88f857-jwcnj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 7d03f4f5-6a6a-4dcb-a398-6b066c184e2f
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "2"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: prometheus-annotation-test-cfc77c7b9-xhlhw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 2a992a4b-e975-4d29-b17c-3288b0043a0e
+                        stringValue: 46e8dee6-2a42-4b63-85be-6986b40d6f13
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -257,10 +191,76 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: python-test-84856b7fcd-f9ptl
+                        stringValue: nodejs-test-5fbcbff576-wnhgv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 11e120c9-cd51-4872-8020-22153b6f4f19
+                        stringValue: f8f08d37-165c-4262-b193-7de9673922b4
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: prometheus-annotation-test-85c8b9cd98-gzdm6
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 10fe8146-3d0c-41ce-8abd-6a0695532471
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: python-test-57cc48d9bc-rvzlq
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 939048fc-23c6-43d6-bbbf-4310472ba13a
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -290,10 +290,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-869bddff5c-q62nw
+                        stringValue: sock-operator-7dc9bb794d-prbbv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
+                        stringValue: 20520f3f-b20f-4fbf-8599-eff795f71394
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -323,10 +323,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-6zqmr
+                        stringValue: sock-splunk-otel-collector-agent-r4bfn
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 4d0c9753-5f12-4ffb-a9c7-da33948c8c7f
+                        stringValue: 4d16bfb7-27df-4990-9f55-293c282cde65
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -356,10 +356,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665-tc4ss
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84bzbfpg
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c751b5f2-0b6b-418f-b71b-606330a83430
+                        stringValue: 0498823c-4da8-431a-83c8-8243fd6058e7
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -389,10 +389,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-26wmp
+                        stringValue: sock-splunk-otel-collector-ta-5f9dddf7f7-gf5zl
                     - key: k8s.pod.uid
                       value:
-                        stringValue: f4b8c20e-1dad-4eec-a849-6a15e9a08156
+                        stringValue: 144662ce-f00f-47b2-adf5-fa6c0d90faaa
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -422,10 +422,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-76f75df574-2gdxf
+                        stringValue: coredns-7db6d8ff4d-2k96n
                     - key: k8s.pod.uid
                       value:
-                        stringValue: cbe6b06d-1d5a-4235-8ded-a3d2b497138d
+                        stringValue: e081fcb4-47ae-4927-a08a-8c96276a2574
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -455,10 +455,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-76f75df574-j6vjb
+                        stringValue: coredns-7db6d8ff4d-6lfg2
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c0dd36df-1e0c-4feb-b1b7-419681595dd2
+                        stringValue: 79d91568-77b6-4f75-b4aa-4533eb1a4366
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -491,7 +491,7 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 53f92a39-92e9-4ae4-b3e5-6f32ac6fb705
+                        stringValue: 46a99fe6-a3ef-4dae-8026-c6b08411edbe
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -521,10 +521,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-b4pd7
+                        stringValue: kindnet-dd8mx
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 5c574843-642d-4ba6-bfd8-9aa160827de3
+                        stringValue: 73c54202-5d6d-436f-87d6-2c6119b2f9e0
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -557,7 +557,7 @@ resourceMetrics:
                         stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: a7644cdf-3844-439c-bd8f-dc0760623723
+                        stringValue: a99a3190-8680-4b67-ac17-ebc1ae666eb6
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -590,7 +590,7 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 80d09637-319b-4208-a062-393533fbf2ac
+                        stringValue: 1980550f-bbd3-4eeb-8864-737bf3a9570b
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -620,10 +620,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kube-proxy-w4pq8
+                        stringValue: kube-proxy-nmblc
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 7b25c613-e655-4679-9ad5-0ef0419f6aa7
+                        stringValue: 67814461-979c-4a2a-9e1e-886219ca48b9
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -656,7 +656,7 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 966d4695-d046-4416-927d-8162dbaab50b
+                        stringValue: ca1dede1-48a5-43cb-99a9-90a19b071baf
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -686,10 +686,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48-nl7dt
+                        stringValue: local-path-provisioner-988d74bc-trwfs
                     - key: k8s.pod.uid
                       value:
-                        stringValue: e6f3d494-3e4e-4ed4-9f3b-054c9675a785
+                        stringValue: 3f295075-3465-443e-823f-0335680df445
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -700,20 +700,20 @@ resourceMetrics:
             name: k8s.pod.phase
           - gauge:
               dataPoints:
-                - asInt: "1"
+                - asDouble: 0.2
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 003d3d03d91f08af36531d2160e85d83b3c497371e47017e42f21c538694b1b7
+                        stringValue: 0f5239bc2a7647625edbf1f6609faa94fcf8c5659cdc362729ccbb0f6435b742
                     - key: container.image.name
                       value:
-                        stringValue: quay.io/splunko11ytest/dotnet_test
+                        stringValue: quay.io/signalfx/splunk-otel-collector
                     - key: container.image.tag
                       value:
-                        stringValue: latest
+                        stringValue: 0.119.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -725,7 +725,7 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: dotnet-test
+                        stringValue: otel-collector
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -734,10 +734,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: dotnet-test-5479c475fc-8xpcw
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84bzbfpg
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c28fcde1-8d20-4cfc-a975-8b2c08de526f
+                        stringValue: 0498823c-4da8-431a-83c8-8243fd6058e7
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -745,20 +745,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+                - asDouble: 0.1
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 004389c5623d8aabe7d71bb7a33cf264f880ed445a250140b686b6faf5976200
+                        stringValue: b7048875d08174381238d55c712e9990b1831698a69953d23bb37a26cd93dfc6
                     - key: container.image.name
                       value:
-                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+                        stringValue: docker.io/kindest/kindnetd
                     - key: container.image.tag
                       value:
-                        stringValue: v0.105.0
+                        stringValue: v20240202-8f1494ea
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -770,7 +770,52 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: targetallocator
+                        stringValue: kindnet-cni
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kindnet-dd8mx
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 73c54202-5d6d-436f-87d6-2c6119b2f9e0
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asDouble: 0.2
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dcdf253b455c8f73ecafcccfc41ff6df35be1c64b64c3336e6c6da3bb0fa58cb
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -779,10 +824,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-26wmp
+                        stringValue: sock-splunk-otel-collector-agent-r4bfn
                     - key: k8s.pod.uid
                       value:
-                        stringValue: f4b8c20e-1dad-4eec-a849-6a15e9a08156
+                        stringValue: 4d16bfb7-27df-4990-9f55-293c282cde65
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -790,14 +835,62 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+            name: k8s.container.cpu_limit
+          - gauge:
+              dataPoints:
+                - asDouble: 0.2
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 08712584e737fe9c61d06351d7b205d6344a412e5f8231863cd7b591d2ebe729
+                        stringValue: 0f5239bc2a7647625edbf1f6609faa94fcf8c5659cdc362729ccbb0f6435b742
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84bzbfpg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 0498823c-4da8-431a-83c8-8243fd6058e7
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asDouble: 0.1
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6ad0adf04da15ce9624c986151a469755c8a2d80f5682388f79079517de3f7f1
                     - key: container.image.name
                       value:
                         stringValue: registry.k8s.io/coredns/coredns
@@ -824,10 +917,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-76f75df574-j6vjb
+                        stringValue: coredns-7db6d8ff4d-2k96n
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c0dd36df-1e0c-4feb-b1b7-419681595dd2
+                        stringValue: e081fcb4-47ae-4927-a08a-8c96276a2574
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -835,20 +928,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+                - asDouble: 0.1
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 15ff7b753a6950674b9e78ec8274e73bd135699d5e2e5744e22287da8d27fadc
+                        stringValue: 79ccc3e7ec08b3d30eddd27f8e5e9630c1e06b2e6d8f3b2deb62f9e447195820
                     - key: container.image.name
                       value:
-                        stringValue: docker.io/kindest/kindnetd
+                        stringValue: registry.k8s.io/coredns/coredns
                     - key: container.image.tag
                       value:
-                        stringValue: v20230511-dc714da8
+                        stringValue: v1.11.1
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -860,7 +953,7 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: kindnet-cni
+                        stringValue: coredns
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -869,10 +962,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-b4pd7
+                        stringValue: coredns-7db6d8ff4d-6lfg2
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 5c574843-642d-4ba6-bfd8-9aa160827de3
+                        stringValue: 79d91568-77b6-4f75-b4aa-4533eb1a4366
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -880,335 +973,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+                - asDouble: 0.2
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 2676c08fa9df42f1b1d7dd55856946f2e9440b793ce98424575b56ffb32b991f
+                        stringValue: 85f7c6f411e7cfd79c796ba001d00e09760c941f0831bca893ff02f6c0b9ece7
                     - key: container.image.name
                       value:
-                        stringValue: quay.io/jetstack/cert-manager-webhook
+                        stringValue: registry.k8s.io/kube-controller-manager-amd64
                     - key: container.image.tag
                       value:
-                        stringValue: v1.14.4
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-webhook
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-webhook-7f9f8648b9-pjrwc
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: abf6af19-643c-4f88-96ae-beedc60f4f8e
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2a5891c6055ebcb2aab796034ab47117e538b784d450d036bcba82caf56c0de2
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-apiserver
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-apiserver
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-apiserver-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: a7644cdf-3844-439c-bd8f-dc0760623723
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 33ab498497f4b362fd83ec43b1e0c1ad26d37e8dfb524e3ba2a19050a5af59ed
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/splunko11ytest/httpd
-                    - key: container.image.tag
-                      value:
-                        stringValue: latest
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: prometheus-annotation-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: prometheus-annotation-test-cfc77c7b9-xhlhw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 2a992a4b-e975-4d29-b17c-3288b0043a0e
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 50b808281e95714072a15e744c529bba4c3462043e9bfb45b2bb451ea787dd73
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665-tc4ss
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c751b5f2-0b6b-418f-b71b-606330a83430
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 5eb6066cb19df83f23df91e843654e456e334a1fb7eadf2c699fcf5106506b74
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-6zqmr
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 4d0c9753-5f12-4ffb-a9c7-da33948c8c7f
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 691a447c6f0f931e19e15831507ebf96e742c77315fe17f14dffcfa9dc148f4f
-                    - key: container.image.name
-                      value:
-                        stringValue: docker.io/kindest/local-path-provisioner
-                    - key: container.image.tag
-                      value:
-                        stringValue: v20230511-dc714da8
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: local-path-provisioner
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: local-path-storage
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: local-path-provisioner-6f8956fb48-nl7dt
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: e6f3d494-3e4e-4ed4-9f3b-054c9675a785
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 73670e794cf1a1c6b3e5a410cec652bcdb78c02a4793c3ed5beb4e93a0b4c8a2
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-proxy
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-proxy-w4pq8
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 7b25c613-e655-4679-9ad5-0ef0419f6aa7
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 844cdc39f6c38dfee2410beaf59f434017f01f1600a03601d06acc022b65e7de
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-controller-manager
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
+                        stringValue: v1.30.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -1232,7 +1010,7 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 80d09637-319b-4208-a062-393533fbf2ac
+                        stringValue: 1980550f-bbd3-4eeb-8864-737bf3a9570b
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -1240,20 +1018,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+                - asDouble: 0.1
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: afc7413fdca060dddc8be931db2d2974c5348f058d7267fd13830251ad78fd69
+                        stringValue: a929c8132d93ef47b317c71ab579d8bf88db7e9a6504dce556dc85d963067ef7
                     - key: container.image.name
                       value:
-                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
+                        stringValue: registry.k8s.io/kube-scheduler-amd64
                     - key: container.image.tag
                       value:
-                        stringValue: 0.110.0
+                        stringValue: v1.30.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -1265,19 +1043,19 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: manager
+                        stringValue: kube-scheduler
                     - key: k8s.namespace.name
                       value:
-                        stringValue: default
+                        stringValue: kube-system
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-869bddff5c-q62nw
+                        stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
+                        stringValue: ca1dede1-48a5-43cb-99a9-90a19b071baf
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -1285,20 +1063,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+                - asDouble: 0.1
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: b1e0c654ae5151efa4dbd3ca88f6bdf1e1f332393ed611328099b9fff0ad87d5
+                        stringValue: b7048875d08174381238d55c712e9990b1831698a69953d23bb37a26cd93dfc6
                     - key: container.image.name
                       value:
-                        stringValue: quay.io/jetstack/cert-manager-controller
+                        stringValue: docker.io/kindest/kindnetd
                     - key: container.image.tag
                       value:
-                        stringValue: v1.14.4
+                        stringValue: v20240202-8f1494ea
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -1310,19 +1088,19 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: cert-manager-controller
+                        stringValue: kindnet-cni
                     - key: k8s.namespace.name
                       value:
-                        stringValue: cert-manager
+                        stringValue: kube-system
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-67c98b89c8-g22j7
+                        stringValue: kindnet-dd8mx
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 3ece0e7b-6f24-4bed-a51e-e0fcf81a5c26
+                        stringValue: 73c54202-5d6d-436f-87d6-2c6119b2f9e0
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -1330,20 +1108,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+                - asDouble: 0.1
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: c260d848811ce9c4f324718840ef701569a548e7e769be413d466e1586b6606c
+                        stringValue: bd4e025b1a90ccbc58d3052af6c882f278bf61589ffe3c47aa4029ddea4a8751
                     - key: container.image.name
                       value:
                         stringValue: registry.k8s.io/etcd
                     - key: container.image.tag
                       value:
-                        stringValue: 3.5.10-0
+                        stringValue: 3.5.12-0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -1367,7 +1145,646 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 53f92a39-92e9-4ae4-b3e5-6f32ac6fb705
+                        stringValue: 46a99fe6-a3ef-4dae-8026-c6b08411edbe
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asDouble: 0.2
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dcdf253b455c8f73ecafcccfc41ff6df35be1c64b64c3336e6c6da3bb0fa58cb
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-r4bfn
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 4d16bfb7-27df-4990-9f55-293c282cde65
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asDouble: 0.25
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: df7457dbcf77bbaaf7c61601889754797dd446e8333405c4ff6751f0c1e9ef54
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/kube-apiserver-amd64
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.30.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-apiserver
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-apiserver-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: a99a3190-8680-4b67-ac17-ebc1ae666eb6
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+            name: k8s.container.cpu_request
+          - gauge:
+              dataPoints:
+                - asInt: "524288000"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 0f5239bc2a7647625edbf1f6609faa94fcf8c5659cdc362729ccbb0f6435b742
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84bzbfpg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 0498823c-4da8-431a-83c8-8243fd6058e7
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "178257920"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6ad0adf04da15ce9624c986151a469755c8a2d80f5682388f79079517de3f7f1
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/coredns/coredns
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.11.1
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-7db6d8ff4d-2k96n
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e081fcb4-47ae-4927-a08a-8c96276a2574
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "178257920"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 79ccc3e7ec08b3d30eddd27f8e5e9630c1e06b2e6d8f3b2deb62f9e447195820
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/coredns/coredns
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.11.1
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-7db6d8ff4d-6lfg2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 79d91568-77b6-4f75-b4aa-4533eb1a4366
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "52428800"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: b7048875d08174381238d55c712e9990b1831698a69953d23bb37a26cd93dfc6
+                    - key: container.image.name
+                      value:
+                        stringValue: docker.io/kindest/kindnetd
+                    - key: container.image.tag
+                      value:
+                        stringValue: v20240202-8f1494ea
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kindnet-cni
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kindnet-dd8mx
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 73c54202-5d6d-436f-87d6-2c6119b2f9e0
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "524288000"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dcdf253b455c8f73ecafcccfc41ff6df35be1c64b64c3336e6c6da3bb0fa58cb
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-r4bfn
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 4d16bfb7-27df-4990-9f55-293c282cde65
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+            name: k8s.container.memory_limit
+          - gauge:
+              dataPoints:
+                - asInt: "524288000"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 0f5239bc2a7647625edbf1f6609faa94fcf8c5659cdc362729ccbb0f6435b742
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84bzbfpg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 0498823c-4da8-431a-83c8-8243fd6058e7
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "73400320"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6ad0adf04da15ce9624c986151a469755c8a2d80f5682388f79079517de3f7f1
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/coredns/coredns
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.11.1
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-7db6d8ff4d-2k96n
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: e081fcb4-47ae-4927-a08a-8c96276a2574
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "73400320"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 79ccc3e7ec08b3d30eddd27f8e5e9630c1e06b2e6d8f3b2deb62f9e447195820
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/coredns/coredns
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.11.1
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-7db6d8ff4d-6lfg2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 79d91568-77b6-4f75-b4aa-4533eb1a4366
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "52428800"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: b7048875d08174381238d55c712e9990b1831698a69953d23bb37a26cd93dfc6
+                    - key: container.image.name
+                      value:
+                        stringValue: docker.io/kindest/kindnetd
+                    - key: container.image.tag
+                      value:
+                        stringValue: v20240202-8f1494ea
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kindnet-cni
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kindnet-dd8mx
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 73c54202-5d6d-436f-87d6-2c6119b2f9e0
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "104857600"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bd4e025b1a90ccbc58d3052af6c882f278bf61589ffe3c47aa4029ddea4a8751
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/etcd
+                    - key: container.image.tag
+                      value:
+                        stringValue: 3.5.12-0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: etcd
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: etcd-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 46a99fe6-a3ef-4dae-8026-c6b08411edbe
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "524288000"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dcdf253b455c8f73ecafcccfc41ff6df35be1c64b64c3336e6c6da3bb0fa58cb
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-r4bfn
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 4d16bfb7-27df-4990-9f55-293c282cde65
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+            name: k8s.container.memory_request
+          - gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 0f5239bc2a7647625edbf1f6609faa94fcf8c5659cdc362729ccbb0f6435b742
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84bzbfpg
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 0498823c-4da8-431a-83c8-8243fd6058e7
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -1382,7 +1799,52 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: d5b98f53c3b61471d924aa1eeaed91f8c4d71119b776d409386b14fa851e0344
+                        stringValue: 3b00c3f1d5e92b1cc41079829523316a7aab3519ccaf4c0c4bbb3dbeb7b4c67e
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/kube-proxy-amd64
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.30.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-proxy
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-proxy-nmblc
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 67814461-979c-4a2a-9e1e-886219ca48b9
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 493ae1c9b912b74181382bbd547760d7891099a8ac67ab726b94e267055c94bf
                     - key: container.image.name
                       value:
                         stringValue: quay.io/jetstack/cert-manager-cainjector
@@ -1409,10 +1871,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-cainjector-5c5695d979-4gn7v
+                        stringValue: cert-manager-cainjector-85d499d4cc-74qtd
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c67d333e-6b13-4486-8b36-c9622a794d1f
+                        stringValue: 87792135-b13b-456b-93f8-49f1f8fe387a
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -1427,52 +1889,7 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: e26453afede340680ddff9cde881a88300ce30b850f21e7f05703c0c341e3726
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-scheduler
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-scheduler
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-scheduler-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 966d4695-d046-4416-927d-8162dbaab50b
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: f463a6bb8e665cbe3927a3e0ae395a54955cdf6228c2957da1e925807d9f816f
+                        stringValue: 4e353df40498f00219c12516fb733c031c3a4a856642eebd7347f79f2eb82f38
                     - key: container.image.name
                       value:
                         stringValue: quay.io/brancz/kube-rbac-proxy
@@ -1499,10 +1916,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-869bddff5c-q62nw
+                        stringValue: sock-operator-7dc9bb794d-prbbv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
+                        stringValue: 20520f3f-b20f-4fbf-8599-eff795f71394
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -1517,7 +1934,52 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f981b0fd2934f376127fbe25d53a62eb4637e7a6eb554b34aa0cbfe0d1fadaa3
+                        stringValue: 6a57c87a52f0c629d16a297a53653c91f2219ef4439bb5cce74fe317227ffeb2
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/jetstack/cert-manager-webhook
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.14.4
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-webhook
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-webhook-d499d9459-qvlwd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: c942d73c-5605-4d76-877c-23908fdc7a66
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6ad0adf04da15ce9624c986151a469755c8a2d80f5682388f79079517de3f7f1
                     - key: container.image.name
                       value:
                         stringValue: registry.k8s.io/coredns/coredns
@@ -1544,10 +2006,505 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-76f75df574-2gdxf
+                        stringValue: coredns-7db6d8ff4d-2k96n
                     - key: k8s.pod.uid
                       value:
-                        stringValue: cbe6b06d-1d5a-4235-8ded-a3d2b497138d
+                        stringValue: e081fcb4-47ae-4927-a08a-8c96276a2574
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 79ccc3e7ec08b3d30eddd27f8e5e9630c1e06b2e6d8f3b2deb62f9e447195820
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/coredns/coredns
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.11.1
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: coredns
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: coredns-7db6d8ff4d-6lfg2
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 79d91568-77b6-4f75-b4aa-4533eb1a4366
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 85f7c6f411e7cfd79c796ba001d00e09760c941f0831bca893ff02f6c0b9ece7
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/kube-controller-manager-amd64
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.30.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-controller-manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-controller-manager-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 1980550f-bbd3-4eeb-8864-737bf3a9570b
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 8c8a156fefa39b6b3a0f16574de845aac7d1eb3fed262aef79b2e6a43b2c853d
+                    - key: container.image.name
+                      value:
+                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+                    - key: container.image.tag
+                      value:
+                        stringValue: v0.105.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: targetallocator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-ta-5f9dddf7f7-gf5zl
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 144662ce-f00f-47b2-adf5-fa6c0d90faaa
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: a4b38d3d2b4ead39063d15d25342621b80d5b68e849afa9947cb6269e1c1c9b5
+                    - key: container.image.name
+                      value:
+                        stringValue: docker.io/kindest/local-path-provisioner
+                    - key: container.image.tag
+                      value:
+                        stringValue: v20240202-8f1494ea
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: local-path-provisioner
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: local-path-storage
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: local-path-provisioner-988d74bc-trwfs
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 3f295075-3465-443e-823f-0335680df445
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: a929c8132d93ef47b317c71ab579d8bf88db7e9a6504dce556dc85d963067ef7
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/kube-scheduler-amd64
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.30.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-scheduler
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-scheduler-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: ca1dede1-48a5-43cb-99a9-90a19b071baf
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: b66d9590795c3daf51a686861634e15fa3b8092f192a8d3aac6664eb41862350
+                    - key: container.image.name
+                      value:
+                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.117.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: manager
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-operator-7dc9bb794d-prbbv
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 20520f3f-b20f-4fbf-8599-eff795f71394
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: b7048875d08174381238d55c712e9990b1831698a69953d23bb37a26cd93dfc6
+                    - key: container.image.name
+                      value:
+                        stringValue: docker.io/kindest/kindnetd
+                    - key: container.image.tag
+                      value:
+                        stringValue: v20240202-8f1494ea
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kindnet-cni
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kindnet-dd8mx
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 73c54202-5d6d-436f-87d6-2c6119b2f9e0
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: bd4e025b1a90ccbc58d3052af6c882f278bf61589ffe3c47aa4029ddea4a8751
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/etcd
+                    - key: container.image.tag
+                      value:
+                        stringValue: 3.5.12-0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: etcd
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: etcd-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 46a99fe6-a3ef-4dae-8026-c6b08411edbe
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: c97dbbb60d36cc359c19e041096a09b7e9f79399805b32e0b7a903e3f5721921
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/jetstack/cert-manager-controller
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.14.4
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-controller
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-5d864474d-6fgxj
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 7918d738-3243-4a2e-855c-526270da5014
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: dcdf253b455c8f73ecafcccfc41ff6df35be1c64b64c3336e6c6da3bb0fa58cb
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/signalfx/splunk-otel-collector
+                    - key: container.image.tag
+                      value:
+                        stringValue: 0.119.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: otel-collector
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: sock-splunk-otel-collector-agent-r4bfn
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: 4d16bfb7-27df-4990-9f55-293c282cde65
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "1"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: df7457dbcf77bbaaf7c61601889754797dd446e8333405c4ff6751f0c1e9ef54
+                    - key: container.image.name
+                      value:
+                        stringValue: registry.k8s.io/kube-apiserver-amd64
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.30.0
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: kube-apiserver
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: kube-system
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: kube-apiserver-kind-control-plane
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: a99a3190-8680-4b67-ac17-ebc1ae666eb6
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -1565,328 +2522,13 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 003d3d03d91f08af36531d2160e85d83b3c497371e47017e42f21c538694b1b7
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/splunko11ytest/dotnet_test
-                    - key: container.image.tag
-                      value:
-                        stringValue: latest
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: dotnet-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: dotnet-test-5479c475fc-8xpcw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c28fcde1-8d20-4cfc-a975-8b2c08de526f
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 004389c5623d8aabe7d71bb7a33cf264f880ed445a250140b686b6faf5976200
-                    - key: container.image.name
-                      value:
-                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
-                    - key: container.image.tag
-                      value:
-                        stringValue: v0.105.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: targetallocator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4-26wmp
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: f4b8c20e-1dad-4eec-a849-6a15e9a08156
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 08712584e737fe9c61d06351d7b205d6344a412e5f8231863cd7b591d2ebe729
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/coredns/coredns
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.11.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-76f75df574-j6vjb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c0dd36df-1e0c-4feb-b1b7-419681595dd2
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 15ff7b753a6950674b9e78ec8274e73bd135699d5e2e5744e22287da8d27fadc
-                    - key: container.image.name
-                      value:
-                        stringValue: docker.io/kindest/kindnetd
-                    - key: container.image.tag
-                      value:
-                        stringValue: v20230511-dc714da8
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kindnet-cni
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kindnet-b4pd7
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 5c574843-642d-4ba6-bfd8-9aa160827de3
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2676c08fa9df42f1b1d7dd55856946f2e9440b793ce98424575b56ffb32b991f
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/jetstack/cert-manager-webhook
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.14.4
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-webhook
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-webhook-7f9f8648b9-pjrwc
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: abf6af19-643c-4f88-96ae-beedc60f4f8e
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2a5891c6055ebcb2aab796034ab47117e538b784d450d036bcba82caf56c0de2
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-apiserver
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-apiserver
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-apiserver-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: a7644cdf-3844-439c-bd8f-dc0760623723
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 33ab498497f4b362fd83ec43b1e0c1ad26d37e8dfb524e3ba2a19050a5af59ed
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/splunko11ytest/httpd
-                    - key: container.image.tag
-                      value:
-                        stringValue: latest
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: prometheus-annotation-test
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: prometheus-annotation-test-cfc77c7b9-xhlhw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 2a992a4b-e975-4d29-b17c-3288b0043a0e
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 50b808281e95714072a15e744c529bba4c3462043e9bfb45b2bb451ea787dd73
+                        stringValue: 0f5239bc2a7647625edbf1f6609faa94fcf8c5659cdc362729ccbb0f6435b742
                     - key: container.image.name
                       value:
                         stringValue: quay.io/signalfx/splunk-otel-collector
                     - key: container.image.tag
                       value:
-                        stringValue: 0.117.0
+                        stringValue: 0.119.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -1907,10 +2549,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665-tc4ss
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84bzbfpg
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c751b5f2-0b6b-418f-b71b-606330a83430
+                        stringValue: 0498823c-4da8-431a-83c8-8243fd6058e7
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -1925,103 +2567,13 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 5eb6066cb19df83f23df91e843654e456e334a1fb7eadf2c699fcf5106506b74
+                        stringValue: 3b00c3f1d5e92b1cc41079829523316a7aab3519ccaf4c0c4bbb3dbeb7b4c67e
                     - key: container.image.name
                       value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
+                        stringValue: registry.k8s.io/kube-proxy-amd64
                     - key: container.image.tag
                       value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-6zqmr
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 4d0c9753-5f12-4ffb-a9c7-da33948c8c7f
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 691a447c6f0f931e19e15831507ebf96e742c77315fe17f14dffcfa9dc148f4f
-                    - key: container.image.name
-                      value:
-                        stringValue: docker.io/kindest/local-path-provisioner
-                    - key: container.image.tag
-                      value:
-                        stringValue: v20230511-dc714da8
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: local-path-provisioner
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: local-path-storage
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: local-path-provisioner-6f8956fb48-nl7dt
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: e6f3d494-3e4e-4ed4-9f3b-054c9675a785
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 73670e794cf1a1c6b3e5a410cec652bcdb78c02a4793c3ed5beb4e93a0b4c8a2
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-proxy
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
+                        stringValue: v1.30.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -2042,10 +2594,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kube-proxy-w4pq8
+                        stringValue: kube-proxy-nmblc
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 7b25c613-e655-4679-9ad5-0ef0419f6aa7
+                        stringValue: 67814461-979c-4a2a-9e1e-886219ca48b9
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2060,187 +2612,7 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 844cdc39f6c38dfee2410beaf59f434017f01f1600a03601d06acc022b65e7de
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-controller-manager
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-controller-manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-controller-manager-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 80d09637-319b-4208-a062-393533fbf2ac
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: afc7413fdca060dddc8be931db2d2974c5348f058d7267fd13830251ad78fd69
-                    - key: container.image.name
-                      value:
-                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.110.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-869bddff5c-q62nw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: b1e0c654ae5151efa4dbd3ca88f6bdf1e1f332393ed611328099b9fff0ad87d5
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/jetstack/cert-manager-controller
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.14.4
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: cert-manager-controller
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: cert-manager
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: cert-manager-67c98b89c8-g22j7
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 3ece0e7b-6f24-4bed-a51e-e0fcf81a5c26
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: c260d848811ce9c4f324718840ef701569a548e7e769be413d466e1586b6606c
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/etcd
-                    - key: container.image.tag
-                      value:
-                        stringValue: 3.5.10-0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: etcd
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: etcd-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 53f92a39-92e9-4ae4-b3e5-6f32ac6fb705
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: d5b98f53c3b61471d924aa1eeaed91f8c4d71119b776d409386b14fa851e0344
+                        stringValue: 493ae1c9b912b74181382bbd547760d7891099a8ac67ab726b94e267055c94bf
                     - key: container.image.name
                       value:
                         stringValue: quay.io/jetstack/cert-manager-cainjector
@@ -2267,10 +2639,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: cert-manager-cainjector-5c5695d979-4gn7v
+                        stringValue: cert-manager-cainjector-85d499d4cc-74qtd
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c67d333e-6b13-4486-8b36-c9622a794d1f
+                        stringValue: 87792135-b13b-456b-93f8-49f1f8fe387a
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2285,52 +2657,7 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: e26453afede340680ddff9cde881a88300ce30b850f21e7f05703c0c341e3726
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-scheduler
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-scheduler
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-scheduler-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 966d4695-d046-4416-927d-8162dbaab50b
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: f463a6bb8e665cbe3927a3e0ae395a54955cdf6228c2957da1e925807d9f816f
+                        stringValue: 4e353df40498f00219c12516fb733c031c3a4a856642eebd7347f79f2eb82f38
                     - key: container.image.name
                       value:
                         stringValue: quay.io/brancz/kube-rbac-proxy
@@ -2357,10 +2684,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-869bddff5c-q62nw
+                        stringValue: sock-operator-7dc9bb794d-prbbv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
+                        stringValue: 20520f3f-b20f-4fbf-8599-eff795f71394
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2375,7 +2702,52 @@ resourceMetrics:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f981b0fd2934f376127fbe25d53a62eb4637e7a6eb554b34aa0cbfe0d1fadaa3
+                        stringValue: 6a57c87a52f0c629d16a297a53653c91f2219ef4439bb5cce74fe317227ffeb2
+                    - key: container.image.name
+                      value:
+                        stringValue: quay.io/jetstack/cert-manager-webhook
+                    - key: container.image.tag
+                      value:
+                        stringValue: v1.14.4
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.container.name
+                      value:
+                        stringValue: cert-manager-webhook
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: cert-manager
+                    - key: k8s.node.name
+                      value:
+                        stringValue: kind-control-plane
+                    - key: k8s.pod.name
+                      value:
+                        stringValue: cert-manager-webhook-d499d9459-qvlwd
+                    - key: k8s.pod.uid
+                      value:
+                        stringValue: c942d73c-5605-4d76-877c-23908fdc7a66
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: container.id
+                      value:
+                        stringValue: 6ad0adf04da15ce9624c986151a469755c8a2d80f5682388f79079517de3f7f1
                     - key: container.image.name
                       value:
                         stringValue: registry.k8s.io/coredns/coredns
@@ -2402,10 +2774,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-76f75df574-2gdxf
+                        stringValue: coredns-7db6d8ff4d-2k96n
                     - key: k8s.pod.uid
                       value:
-                        stringValue: cbe6b06d-1d5a-4235-8ded-a3d2b497138d
+                        stringValue: e081fcb4-47ae-4927-a08a-8c96276a2574
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2413,17 +2785,14 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-            name: k8s.container.restarts
-          - gauge:
-              dataPoints:
-                - asDouble: 0.1
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 08712584e737fe9c61d06351d7b205d6344a412e5f8231863cd7b591d2ebe729
+                        stringValue: 79ccc3e7ec08b3d30eddd27f8e5e9630c1e06b2e6d8f3b2deb62f9e447195820
                     - key: container.image.name
                       value:
                         stringValue: registry.k8s.io/coredns/coredns
@@ -2450,10 +2819,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: coredns-76f75df574-j6vjb
+                        stringValue: coredns-7db6d8ff4d-6lfg2
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c0dd36df-1e0c-4feb-b1b7-419681595dd2
+                        stringValue: 79d91568-77b6-4f75-b4aa-4533eb1a4366
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2461,200 +2830,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asDouble: 0.1
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 15ff7b753a6950674b9e78ec8274e73bd135699d5e2e5744e22287da8d27fadc
+                        stringValue: 85f7c6f411e7cfd79c796ba001d00e09760c941f0831bca893ff02f6c0b9ece7
                     - key: container.image.name
                       value:
-                        stringValue: docker.io/kindest/kindnetd
+                        stringValue: registry.k8s.io/kube-controller-manager-amd64
                     - key: container.image.tag
                       value:
-                        stringValue: v20230511-dc714da8
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kindnet-cni
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kindnet-b4pd7
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 5c574843-642d-4ba6-bfd8-9aa160827de3
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asDouble: 0.25
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 2a5891c6055ebcb2aab796034ab47117e538b784d450d036bcba82caf56c0de2
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-apiserver
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-apiserver
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kube-apiserver-kind-control-plane
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: a7644cdf-3844-439c-bd8f-dc0760623723
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asDouble: 0.2
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 50b808281e95714072a15e744c529bba4c3462043e9bfb45b2bb451ea787dd73
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665-tc4ss
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c751b5f2-0b6b-418f-b71b-606330a83430
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asDouble: 0.2
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 5eb6066cb19df83f23df91e843654e456e334a1fb7eadf2c699fcf5106506b74
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-6zqmr
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 4d0c9753-5f12-4ffb-a9c7-da33948c8c7f
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asDouble: 0.2
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 844cdc39f6c38dfee2410beaf59f434017f01f1600a03601d06acc022b65e7de
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/kube-controller-manager
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.29.0
+                        stringValue: v1.30.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -2678,7 +2867,7 @@ resourceMetrics:
                         stringValue: kube-controller-manager-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 80d09637-319b-4208-a062-393533fbf2ac
+                        stringValue: 1980550f-bbd3-4eeb-8864-737bf3a9570b
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2686,20 +2875,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asDouble: 0.1
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: afc7413fdca060dddc8be931db2d2974c5348f058d7267fd13830251ad78fd69
+                        stringValue: 8c8a156fefa39b6b3a0f16574de845aac7d1eb3fed262aef79b2e6a43b2c853d
                     - key: container.image.name
                       value:
-                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
+                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
                     - key: container.image.tag
                       value:
-                        stringValue: 0.110.0
+                        stringValue: v0.105.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -2711,7 +2900,7 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: manager
+                        stringValue: targetallocator
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -2720,10 +2909,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-869bddff5c-q62nw
+                        stringValue: sock-splunk-otel-collector-ta-5f9dddf7f7-gf5zl
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
+                        stringValue: 144662ce-f00f-47b2-adf5-fa6c0d90faaa
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2731,20 +2920,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asDouble: 0.1
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: c260d848811ce9c4f324718840ef701569a548e7e769be413d466e1586b6606c
+                        stringValue: a4b38d3d2b4ead39063d15d25342621b80d5b68e849afa9947cb6269e1c1c9b5
                     - key: container.image.name
                       value:
-                        stringValue: registry.k8s.io/etcd
+                        stringValue: docker.io/kindest/local-path-provisioner
                     - key: container.image.tag
                       value:
-                        stringValue: 3.5.10-0
+                        stringValue: v20240202-8f1494ea
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -2756,19 +2945,19 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: etcd
+                        stringValue: local-path-provisioner
                     - key: k8s.namespace.name
                       value:
-                        stringValue: kube-system
+                        stringValue: local-path-storage
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: etcd-kind-control-plane
+                        stringValue: local-path-provisioner-988d74bc-trwfs
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 53f92a39-92e9-4ae4-b3e5-6f32ac6fb705
+                        stringValue: 3f295075-3465-443e-823f-0335680df445
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2776,20 +2965,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asDouble: 0.1
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: e26453afede340680ddff9cde881a88300ce30b850f21e7f05703c0c341e3726
+                        stringValue: a929c8132d93ef47b317c71ab579d8bf88db7e9a6504dce556dc85d963067ef7
                     - key: container.image.name
                       value:
-                        stringValue: registry.k8s.io/kube-scheduler
+                        stringValue: registry.k8s.io/kube-scheduler-amd64
                     - key: container.image.tag
                       value:
-                        stringValue: v1.29.0
+                        stringValue: v1.30.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -2813,7 +3002,7 @@ resourceMetrics:
                         stringValue: kube-scheduler-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 966d4695-d046-4416-927d-8162dbaab50b
+                        stringValue: ca1dede1-48a5-43cb-99a9-90a19b071baf
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -2821,293 +3010,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asDouble: 0.005
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f463a6bb8e665cbe3927a3e0ae395a54955cdf6228c2957da1e925807d9f816f
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/brancz/kube-rbac-proxy
-                    - key: container.image.tag
-                      value:
-                        stringValue: v0.18.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-rbac-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-869bddff5c-q62nw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asDouble: 0.1
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: f981b0fd2934f376127fbe25d53a62eb4637e7a6eb554b34aa0cbfe0d1fadaa3
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/coredns/coredns
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.11.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-76f75df574-2gdxf
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: cbe6b06d-1d5a-4235-8ded-a3d2b497138d
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-            name: k8s.container.cpu_request
-          - gauge:
-              dataPoints:
-                - asInt: "178257920"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 08712584e737fe9c61d06351d7b205d6344a412e5f8231863cd7b591d2ebe729
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/coredns/coredns
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.11.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-76f75df574-j6vjb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c0dd36df-1e0c-4feb-b1b7-419681595dd2
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "52428800"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 15ff7b753a6950674b9e78ec8274e73bd135699d5e2e5744e22287da8d27fadc
-                    - key: container.image.name
-                      value:
-                        stringValue: docker.io/kindest/kindnetd
-                    - key: container.image.tag
-                      value:
-                        stringValue: v20230511-dc714da8
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kindnet-cni
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kindnet-b4pd7
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 5c574843-642d-4ba6-bfd8-9aa160827de3
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "524288000"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 50b808281e95714072a15e744c529bba4c3462043e9bfb45b2bb451ea787dd73
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665-tc4ss
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c751b5f2-0b6b-418f-b71b-606330a83430
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "524288000"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 5eb6066cb19df83f23df91e843654e456e334a1fb7eadf2c699fcf5106506b74
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-6zqmr
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 4d0c9753-5f12-4ffb-a9c7-da33948c8c7f
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "134217728"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: afc7413fdca060dddc8be931db2d2974c5348f058d7267fd13830251ad78fd69
+                        stringValue: b66d9590795c3daf51a686861634e15fa3b8092f192a8d3aac6664eb41862350
                     - key: container.image.name
                       value:
                         stringValue: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
                     - key: container.image.tag
                       value:
-                        stringValue: 0.110.0
+                        stringValue: 0.117.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3128,10 +3044,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-869bddff5c-q62nw
+                        stringValue: sock-operator-7dc9bb794d-prbbv
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
+                        stringValue: 20520f3f-b20f-4fbf-8599-eff795f71394
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3139,158 +3055,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "134217728"
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f463a6bb8e665cbe3927a3e0ae395a54955cdf6228c2957da1e925807d9f816f
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/brancz/kube-rbac-proxy
-                    - key: container.image.tag
-                      value:
-                        stringValue: v0.18.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-rbac-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-869bddff5c-q62nw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "178257920"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: f981b0fd2934f376127fbe25d53a62eb4637e7a6eb554b34aa0cbfe0d1fadaa3
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/coredns/coredns
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.11.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-76f75df574-2gdxf
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: cbe6b06d-1d5a-4235-8ded-a3d2b497138d
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-            name: k8s.container.memory_limit
-          - gauge:
-              dataPoints:
-                - asInt: "73400320"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 08712584e737fe9c61d06351d7b205d6344a412e5f8231863cd7b591d2ebe729
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/coredns/coredns
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.11.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-76f75df574-j6vjb
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c0dd36df-1e0c-4feb-b1b7-419681595dd2
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "52428800"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 15ff7b753a6950674b9e78ec8274e73bd135699d5e2e5744e22287da8d27fadc
+                        stringValue: b7048875d08174381238d55c712e9990b1831698a69953d23bb37a26cd93dfc6
                     - key: container.image.name
                       value:
                         stringValue: docker.io/kindest/kindnetd
                     - key: container.image.tag
                       value:
-                        stringValue: v20230511-dc714da8
+                        stringValue: v20240202-8f1494ea
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3311,10 +3089,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: kindnet-b4pd7
+                        stringValue: kindnet-dd8mx
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 5c574843-642d-4ba6-bfd8-9aa160827de3
+                        stringValue: 73c54202-5d6d-436f-87d6-2c6119b2f9e0
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3322,155 +3100,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "524288000"
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 50b808281e95714072a15e744c529bba4c3462043e9bfb45b2bb451ea787dd73
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665-tc4ss
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: c751b5f2-0b6b-418f-b71b-606330a83430
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "524288000"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 5eb6066cb19df83f23df91e843654e456e334a1fb7eadf2c699fcf5106506b74
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.117.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: otel-collector
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-splunk-otel-collector-agent-6zqmr
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 4d0c9753-5f12-4ffb-a9c7-da33948c8c7f
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "67108864"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: afc7413fdca060dddc8be931db2d2974c5348f058d7267fd13830251ad78fd69
-                    - key: container.image.name
-                      value:
-                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.110.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-869bddff5c-q62nw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "104857600"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: c260d848811ce9c4f324718840ef701569a548e7e769be413d466e1586b6606c
+                        stringValue: bd4e025b1a90ccbc58d3052af6c882f278bf61589ffe3c47aa4029ddea4a8751
                     - key: container.image.name
                       value:
                         stringValue: registry.k8s.io/etcd
                     - key: container.image.tag
                       value:
-                        stringValue: 3.5.10-0
+                        stringValue: 3.5.12-0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3494,7 +3137,7 @@ resourceMetrics:
                         stringValue: etcd-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 53f92a39-92e9-4ae4-b3e5-6f32ac6fb705
+                        stringValue: 46a99fe6-a3ef-4dae-8026-c6b08411edbe
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3502,20 +3145,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "67108864"
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f463a6bb8e665cbe3927a3e0ae395a54955cdf6228c2957da1e925807d9f816f
+                        stringValue: c97dbbb60d36cc359c19e041096a09b7e9f79399805b32e0b7a903e3f5721921
                     - key: container.image.name
                       value:
-                        stringValue: quay.io/brancz/kube-rbac-proxy
+                        stringValue: quay.io/jetstack/cert-manager-controller
                     - key: container.image.tag
                       value:
-                        stringValue: v0.18.1
+                        stringValue: v1.14.4
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3527,19 +3170,19 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: kube-rbac-proxy
+                        stringValue: cert-manager-controller
                     - key: k8s.namespace.name
                       value:
-                        stringValue: default
+                        stringValue: cert-manager
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-operator-869bddff5c-q62nw
+                        stringValue: cert-manager-5d864474d-6fgxj
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
+                        stringValue: 7918d738-3243-4a2e-855c-526270da5014
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3547,113 +3190,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "73400320"
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: f981b0fd2934f376127fbe25d53a62eb4637e7a6eb554b34aa0cbfe0d1fadaa3
-                    - key: container.image.name
-                      value:
-                        stringValue: registry.k8s.io/coredns/coredns
-                    - key: container.image.tag
-                      value:
-                        stringValue: v1.11.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: coredns
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: coredns-76f75df574-2gdxf
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: cbe6b06d-1d5a-4235-8ded-a3d2b497138d
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-            name: k8s.container.memory_request
-          - gauge:
-              dataPoints:
-                - asDouble: 0.1
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 15ff7b753a6950674b9e78ec8274e73bd135699d5e2e5744e22287da8d27fadc
-                    - key: container.image.name
-                      value:
-                        stringValue: docker.io/kindest/kindnetd
-                    - key: container.image.tag
-                      value:
-                        stringValue: v20230511-dc714da8
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kindnet-cni
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: kube-system
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: kindnet-b4pd7
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 5c574843-642d-4ba6-bfd8-9aa160827de3
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asDouble: 0.2
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: 50b808281e95714072a15e744c529bba4c3462043e9bfb45b2bb451ea787dd73
+                        stringValue: dcdf253b455c8f73ecafcccfc41ff6df35be1c64b64c3336e6c6da3bb0fa58cb
                     - key: container.image.name
                       value:
                         stringValue: quay.io/signalfx/splunk-otel-collector
                     - key: container.image.tag
                       value:
-                        stringValue: 0.117.0
+                        stringValue: 0.119.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3674,10 +3224,10 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665-tc4ss
+                        stringValue: sock-splunk-otel-collector-agent-r4bfn
                     - key: k8s.pod.uid
                       value:
-                        stringValue: c751b5f2-0b6b-418f-b71b-606330a83430
+                        stringValue: 4d16bfb7-27df-4990-9f55-293c282cde65
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3685,20 +3235,20 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asDouble: 0.2
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
                         stringValue: ci-k8s-cluster
                     - key: container.id
                       value:
-                        stringValue: 5eb6066cb19df83f23df91e843654e456e334a1fb7eadf2c699fcf5106506b74
+                        stringValue: df7457dbcf77bbaaf7c61601889754797dd446e8333405c4ff6751f0c1e9ef54
                     - key: container.image.name
                       value:
-                        stringValue: quay.io/signalfx/splunk-otel-collector
+                        stringValue: registry.k8s.io/kube-apiserver-amd64
                     - key: container.image.tag
                       value:
-                        stringValue: 0.117.0
+                        stringValue: v1.30.0
                     - key: customfield1
                       value:
                         stringValue: customvalue1
@@ -3710,19 +3260,19 @@ resourceMetrics:
                         stringValue: dev-operator
                     - key: k8s.container.name
                       value:
-                        stringValue: otel-collector
+                        stringValue: kube-apiserver
                     - key: k8s.namespace.name
                       value:
-                        stringValue: default
+                        stringValue: kube-system
                     - key: k8s.node.name
                       value:
                         stringValue: kind-control-plane
                     - key: k8s.pod.name
                       value:
-                        stringValue: sock-splunk-otel-collector-agent-6zqmr
+                        stringValue: kube-apiserver-kind-control-plane
                     - key: k8s.pod.uid
                       value:
-                        stringValue: 4d0c9753-5f12-4ffb-a9c7-da33948c8c7f
+                        stringValue: a99a3190-8680-4b67-ac17-ebc1ae666eb6
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3730,97 +3280,7 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asDouble: 0.1
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: afc7413fdca060dddc8be931db2d2974c5348f058d7267fd13830251ad78fd69
-                    - key: container.image.name
-                      value:
-                        stringValue: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-                    - key: container.image.tag
-                      value:
-                        stringValue: 0.110.0
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: manager
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-869bddff5c-q62nw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asDouble: 0.5
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: container.id
-                      value:
-                        stringValue: f463a6bb8e665cbe3927a3e0ae395a54955cdf6228c2957da1e925807d9f816f
-                    - key: container.image.name
-                      value:
-                        stringValue: quay.io/brancz/kube-rbac-proxy
-                    - key: container.image.tag
-                      value:
-                        stringValue: v0.18.1
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.container.name
-                      value:
-                        stringValue: kube-rbac-proxy
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.pod.name
-                      value:
-                        stringValue: sock-operator-869bddff5c-q62nw
-                    - key: k8s.pod.uid
-                      value:
-                        stringValue: 60ad83a5-2a3f-4943-91a5-5cf771eb42c9
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-            name: k8s.container.cpu_limit
+            name: k8s.container.restarts
           - gauge:
               dataPoints:
                 - asInt: "1"
@@ -3842,7 +3302,7 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: c5128346-03c0-426c-946c-72769ec6cd0e
+                        stringValue: ac79c59b-b73b-415c-a981-315ca3d351cd
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3869,7 +3329,7 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: 4041dac3-5365-4b4f-9727-edba78c405d3
+                        stringValue: 291c3fb5-4806-4d26-84d8-50a54e2fd156
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3896,7 +3356,7 @@ resourceMetrics:
                         stringValue: kube-node-lease
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: b5b704d1-3e89-4ff8-b3f1-813dcc762d1e
+                        stringValue: fc40c878-7e52-4cc6-b8f4-1d696718bf35
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3923,7 +3383,7 @@ resourceMetrics:
                         stringValue: kube-public
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: 28138937-7c9c-495b-ab56-238c299ab484
+                        stringValue: 595a2e47-377a-467c-b4db-73d4b9bed9fb
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3950,7 +3410,7 @@ resourceMetrics:
                         stringValue: kube-system
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: 8819e4f7-83c6-42b6-a46f-e8049bf06498
+                        stringValue: 0e62fdcd-a81c-4648-9acc-3624717f31f8
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -3977,7 +3437,7 @@ resourceMetrics:
                         stringValue: local-path-storage
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: 7e93cb2d-58bd-4e65-8238-ae99e4291970
+                        stringValue: c6d8ea53-b00c-48c6-9554-cc2d5c5e131c
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -4004,7 +3464,7 @@ resourceMetrics:
                         stringValue: ns-w-exclude
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: 7f169b1a-7749-49f9-9fd6-eb9ba7a5ccff
+                        stringValue: 27d96c42-7585-4c83-819e-5d67d532a3a4
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -4031,7 +3491,7 @@ resourceMetrics:
                         stringValue: ns-w-index
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: 71da66e5-f834-40e4-8326-72bf8be9876c
+                        stringValue: e6baf89e-b6b5-4217-b7f5-17a712a22f77
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -4058,7 +3518,7 @@ resourceMetrics:
                         stringValue: ns-wo-index
                     - key: k8s.namespace.uid
                       value:
-                        stringValue: cd4399fe-98cd-405c-9e87-142cfc4d78fb
+                        stringValue: 613478ec-3c82-4e71-9f8b-b16ebe18e925
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -4088,7 +3548,7 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 56b9ded6-8560-4fa3-836e-45e2ad634a81
+                        stringValue: 91cb6788-57ea-45c2-ad32-0bb715214bc8
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -4118,7 +3578,7 @@ resourceMetrics:
                         stringValue: cert-manager-cainjector
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: b5cb47e6-3199-4e9c-838e-c438dd2061b1
+                        stringValue: 1154addc-117b-45bb-96d7-57f162f5c979
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -4148,7 +3608,7 @@ resourceMetrics:
                         stringValue: cert-manager-webhook
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: b9e1669e-b519-4c4d-b070-69f0197443b7
+                        stringValue: bbdc1118-0c06-4d1a-8a02-dc9ed338ae7d
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -4178,7 +3638,7 @@ resourceMetrics:
                         stringValue: coredns
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 8c6389e5-f954-4872-9674-6ffbac869c8f
+                        stringValue: c865a900-1f74-4a69-85ef-07ffecfe8522
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -4189,7 +3649,7 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
@@ -4208,7 +3668,7 @@ resourceMetrics:
                         stringValue: dotnet-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 0e90fccf-fbb6-49ae-93c6-f628023425fe
+                        stringValue: e246c9bf-d399-42bc-97bd-df87f8b36cd1
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4238,7 +3698,7 @@ resourceMetrics:
                         stringValue: java-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 0395fdfe-3f1d-404c-b310-a246ea64e9af
+                        stringValue: d21015eb-6116-41c0-a7db-8b81a8bff725
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4268,7 +3728,7 @@ resourceMetrics:
                         stringValue: local-path-provisioner
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 2b348aa7-d104-4ecf-9fd9-093202f4e23b
+                        stringValue: 602b50f2-a2fc-4bd4-8f37-f264423156e6
                     - key: k8s.namespace.name
                       value:
                         stringValue: local-path-storage
@@ -4298,7 +3758,7 @@ resourceMetrics:
                         stringValue: nodejs-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: af333bc4-b7fd-4e04-83bb-b0f056aa4065
+                        stringValue: d58c784b-442b-4b6d-9f4f-23b8dab8c3f3
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4309,7 +3769,7 @@ resourceMetrics:
                       value:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
-                - asInt: "1"
+                - asInt: "0"
                   attributes:
                     - key: cluster_name
                       value:
@@ -4328,7 +3788,7 @@ resourceMetrics:
                         stringValue: prometheus-annotation-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 00b5a036-dbd8-4066-a0e8-b3c41a4403f3
+                        stringValue: 23dfdd11-cb02-494d-aa8a-0116e5d841f2
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4358,7 +3818,7 @@ resourceMetrics:
                         stringValue: python-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 85a71a2c-c0f7-4a5f-99ef-06a704b7783e
+                        stringValue: 61cbac2e-da1b-42a0-b0de-91895ea8390c
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4388,7 +3848,7 @@ resourceMetrics:
                         stringValue: sock-operator
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: fbc6eaca-0133-4f3d-95ab-b4bce254f467
+                        stringValue: c8e6168d-79bb-4f5e-aaca-e73591757bbc
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4418,7 +3878,7 @@ resourceMetrics:
                         stringValue: sock-splunk-otel-collector-k8s-cluster-receiver
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: f3c90ac1-c9de-46a6-9479-d8326990abc7
+                        stringValue: f0387cdc-86ef-44f1-846c-0654cbb8c953
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4448,7 +3908,7 @@ resourceMetrics:
                         stringValue: sock-splunk-otel-collector-ta
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: b8a608b5-b7cf-4ec6-abbe-2f4d9b17948e
+                        stringValue: 83fa70f2-3ad2-421b-b901-d589073a019a
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4481,7 +3941,7 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 56b9ded6-8560-4fa3-836e-45e2ad634a81
+                        stringValue: 91cb6788-57ea-45c2-ad32-0bb715214bc8
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -4511,7 +3971,7 @@ resourceMetrics:
                         stringValue: cert-manager-cainjector
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: b5cb47e6-3199-4e9c-838e-c438dd2061b1
+                        stringValue: 1154addc-117b-45bb-96d7-57f162f5c979
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -4541,7 +4001,7 @@ resourceMetrics:
                         stringValue: cert-manager-webhook
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: b9e1669e-b519-4c4d-b070-69f0197443b7
+                        stringValue: bbdc1118-0c06-4d1a-8a02-dc9ed338ae7d
                     - key: k8s.namespace.name
                       value:
                         stringValue: cert-manager
@@ -4571,7 +4031,7 @@ resourceMetrics:
                         stringValue: coredns
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 8c6389e5-f954-4872-9674-6ffbac869c8f
+                        stringValue: c865a900-1f74-4a69-85ef-07ffecfe8522
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -4601,7 +4061,7 @@ resourceMetrics:
                         stringValue: dotnet-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 0e90fccf-fbb6-49ae-93c6-f628023425fe
+                        stringValue: e246c9bf-d399-42bc-97bd-df87f8b36cd1
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4631,7 +4091,7 @@ resourceMetrics:
                         stringValue: java-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 0395fdfe-3f1d-404c-b310-a246ea64e9af
+                        stringValue: d21015eb-6116-41c0-a7db-8b81a8bff725
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4661,7 +4121,7 @@ resourceMetrics:
                         stringValue: local-path-provisioner
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 2b348aa7-d104-4ecf-9fd9-093202f4e23b
+                        stringValue: 602b50f2-a2fc-4bd4-8f37-f264423156e6
                     - key: k8s.namespace.name
                       value:
                         stringValue: local-path-storage
@@ -4691,7 +4151,7 @@ resourceMetrics:
                         stringValue: nodejs-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: af333bc4-b7fd-4e04-83bb-b0f056aa4065
+                        stringValue: d58c784b-442b-4b6d-9f4f-23b8dab8c3f3
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4721,7 +4181,7 @@ resourceMetrics:
                         stringValue: prometheus-annotation-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 00b5a036-dbd8-4066-a0e8-b3c41a4403f3
+                        stringValue: 23dfdd11-cb02-494d-aa8a-0116e5d841f2
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4751,7 +4211,7 @@ resourceMetrics:
                         stringValue: python-test
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: 85a71a2c-c0f7-4a5f-99ef-06a704b7783e
+                        stringValue: 61cbac2e-da1b-42a0-b0de-91895ea8390c
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4781,7 +4241,7 @@ resourceMetrics:
                         stringValue: sock-operator
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: fbc6eaca-0133-4f3d-95ab-b4bce254f467
+                        stringValue: c8e6168d-79bb-4f5e-aaca-e73591757bbc
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4811,7 +4271,7 @@ resourceMetrics:
                         stringValue: sock-splunk-otel-collector-k8s-cluster-receiver
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: f3c90ac1-c9de-46a6-9479-d8326990abc7
+                        stringValue: f0387cdc-86ef-44f1-846c-0654cbb8c953
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4841,7 +4301,7 @@ resourceMetrics:
                         stringValue: sock-splunk-otel-collector-ta
                     - key: k8s.deployment.uid
                       value:
-                        stringValue: b8a608b5-b7cf-4ec6-abbe-2f4d9b17948e
+                        stringValue: 83fa70f2-3ad2-421b-b901-d589073a019a
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -4874,10 +4334,10 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: cert-manager-67c98b89c8
+                        stringValue: cert-manager-5d864474d
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 7955e1fb-2dec-4ddb-86af-77fe5d382112
+                        stringValue: 87118ed1-cfa2-4d97-8982-fc3efe6406b4
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -4904,10 +4364,10 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: cert-manager-cainjector-5c5695d979
+                        stringValue: cert-manager-cainjector-85d499d4cc
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: b7c85c60-c92c-470a-b95c-01b6409ae208
+                        stringValue: b6a48f05-f0e4-4d46-93b6-36c137387142
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -4934,40 +4394,10 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: cert-manager-webhook-7f9f8648b9
+                        stringValue: cert-manager-webhook-d499d9459
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 51f90033-ab38-47ef-b7d9-8872b5ee6a7b
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.replicaset.name
-                      value:
-                        stringValue: dotnet-test-5479c475fc
-                    - key: k8s.replicaset.uid
-                      value:
-                        stringValue: 4fce340a-8293-41a7-a36e-c81037c9df20
+                        stringValue: b51367e0-7169-44c9-9a8a-7ad206718960
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -4994,10 +4424,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: java-test-5c4d6479b8
+                        stringValue: dotnet-test-7fd7cfb786
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: da7e6a0b-c32f-4981-85b2-746d5b7ddb4f
+                        stringValue: ac8c326a-d7fa-4985-a938-5eb518a6b19b
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5024,40 +4454,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: nodejs-test-56b74df9ff
+                        stringValue: java-test-5b5c88f857
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 96f4ceac-b674-40f6-8609-19a547166de4
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.namespace.name
-                      value:
-                        stringValue: default
-                    - key: k8s.replicaset.name
-                      value:
-                        stringValue: prometheus-annotation-test-cfc77c7b9
-                    - key: k8s.replicaset.uid
-                      value:
-                        stringValue: a5a38e86-34fd-4e48-9fe4-f994b133de5f
+                        stringValue: 20ee611a-8802-4653-829b-666a848b9d6b
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5084,10 +4484,70 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: python-test-84856b7fcd
+                        stringValue: nodejs-test-5fbcbff576
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 2025ae2b-3811-4eb8-950f-e923912c56c7
+                        stringValue: 40b79550-bbf9-46f6-bff3-c5ed1ad47783
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.replicaset.name
+                      value:
+                        stringValue: prometheus-annotation-test-85c8b9cd98
+                    - key: k8s.replicaset.uid
+                      value:
+                        stringValue: 3c8f44cd-348b-416d-85dd-1b346388d249
+                    - key: metric_source
+                      value:
+                        stringValue: kubernetes
+                    - key: receiver
+                      value:
+                        stringValue: k8scluster
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cluster_name
+                      value:
+                        stringValue: ci-k8s-cluster
+                    - key: customfield1
+                      value:
+                        stringValue: customvalue1
+                    - key: customfield2
+                      value:
+                        stringValue: customvalue2
+                    - key: k8s.cluster.name
+                      value:
+                        stringValue: dev-operator
+                    - key: k8s.namespace.name
+                      value:
+                        stringValue: default
+                    - key: k8s.replicaset.name
+                      value:
+                        stringValue: python-test-57cc48d9bc
+                    - key: k8s.replicaset.uid
+                      value:
+                        stringValue: 6cf746a8-ef51-4339-85dd-a29d2d405d29
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5114,10 +4574,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: sock-operator-869bddff5c
+                        stringValue: sock-operator-7dc9bb794d
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 41d19321-fa22-4cf9-8677-c492ae1bce8a
+                        stringValue: 1a31a222-0d5c-4b04-abe5-695e086a4012
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5144,10 +4604,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84b
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: c9e689cb-687c-44ec-b64f-2bebcb8c5dea
+                        stringValue: 16b32119-ce2b-4fad-a374-0e89060cf567
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5174,10 +4634,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4
+                        stringValue: sock-splunk-otel-collector-ta-5f9dddf7f7
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 2efa97c0-3892-4823-92c9-ee8428e7b418
+                        stringValue: 666bbf78-fb09-4911-ba81-6800c1bf0a4f
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5204,10 +4664,10 @@ resourceMetrics:
                         stringValue: kube-system
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: coredns-76f75df574
+                        stringValue: coredns-7db6d8ff4d
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: f0dd7d65-4a71-4526-902f-b7bb2efbff68
+                        stringValue: 9eb6d1b8-793f-405e-9e09-a490e41bce95
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5234,10 +4694,10 @@ resourceMetrics:
                         stringValue: local-path-storage
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48
+                        stringValue: local-path-provisioner-988d74bc
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: ca1166e9-97b0-4381-94c9-556666747e39
+                        stringValue: 9bda9930-a52c-4289-8ea7-1a5fc32a022e
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5267,10 +4727,10 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: cert-manager-67c98b89c8
+                        stringValue: cert-manager-5d864474d
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 7955e1fb-2dec-4ddb-86af-77fe5d382112
+                        stringValue: 87118ed1-cfa2-4d97-8982-fc3efe6406b4
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5297,10 +4757,10 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: cert-manager-cainjector-5c5695d979
+                        stringValue: cert-manager-cainjector-85d499d4cc
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: b7c85c60-c92c-470a-b95c-01b6409ae208
+                        stringValue: b6a48f05-f0e4-4d46-93b6-36c137387142
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5327,10 +4787,10 @@ resourceMetrics:
                         stringValue: cert-manager
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: cert-manager-webhook-7f9f8648b9
+                        stringValue: cert-manager-webhook-d499d9459
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 51f90033-ab38-47ef-b7d9-8872b5ee6a7b
+                        stringValue: b51367e0-7169-44c9-9a8a-7ad206718960
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5357,10 +4817,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: dotnet-test-5479c475fc
+                        stringValue: dotnet-test-7fd7cfb786
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 4fce340a-8293-41a7-a36e-c81037c9df20
+                        stringValue: ac8c326a-d7fa-4985-a938-5eb518a6b19b
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5387,10 +4847,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: java-test-5c4d6479b8
+                        stringValue: java-test-5b5c88f857
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: da7e6a0b-c32f-4981-85b2-746d5b7ddb4f
+                        stringValue: 20ee611a-8802-4653-829b-666a848b9d6b
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5417,10 +4877,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: nodejs-test-56b74df9ff
+                        stringValue: nodejs-test-5fbcbff576
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 96f4ceac-b674-40f6-8609-19a547166de4
+                        stringValue: 40b79550-bbf9-46f6-bff3-c5ed1ad47783
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5447,10 +4907,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: prometheus-annotation-test-cfc77c7b9
+                        stringValue: prometheus-annotation-test-85c8b9cd98
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: a5a38e86-34fd-4e48-9fe4-f994b133de5f
+                        stringValue: 3c8f44cd-348b-416d-85dd-1b346388d249
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5477,10 +4937,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: python-test-84856b7fcd
+                        stringValue: python-test-57cc48d9bc
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 2025ae2b-3811-4eb8-950f-e923912c56c7
+                        stringValue: 6cf746a8-ef51-4339-85dd-a29d2d405d29
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5507,10 +4967,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: sock-operator-869bddff5c
+                        stringValue: sock-operator-7dc9bb794d
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 41d19321-fa22-4cf9-8677-c492ae1bce8a
+                        stringValue: 1a31a222-0d5c-4b04-abe5-695e086a4012
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5537,10 +4997,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-59674d665
+                        stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6cc968b84b
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: c9e689cb-687c-44ec-b64f-2bebcb8c5dea
+                        stringValue: 16b32119-ce2b-4fad-a374-0e89060cf567
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5567,10 +5027,10 @@ resourceMetrics:
                         stringValue: default
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: sock-splunk-otel-collector-ta-7f6c9fdf4
+                        stringValue: sock-splunk-otel-collector-ta-5f9dddf7f7
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: 2efa97c0-3892-4823-92c9-ee8428e7b418
+                        stringValue: 666bbf78-fb09-4911-ba81-6800c1bf0a4f
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5597,10 +5057,10 @@ resourceMetrics:
                         stringValue: kube-system
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: coredns-76f75df574
+                        stringValue: coredns-7db6d8ff4d
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: f0dd7d65-4a71-4526-902f-b7bb2efbff68
+                        stringValue: 9eb6d1b8-793f-405e-9e09-a490e41bce95
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5627,10 +5087,10 @@ resourceMetrics:
                         stringValue: local-path-storage
                     - key: k8s.replicaset.name
                       value:
-                        stringValue: local-path-provisioner-6f8956fb48
+                        stringValue: local-path-provisioner-988d74bc
                     - key: k8s.replicaset.uid
                       value:
-                        stringValue: ca1166e9-97b0-4381-94c9-556666747e39
+                        stringValue: 9bda9930-a52c-4289-8ea7-1a5fc32a022e
                     - key: metric_source
                       value:
                         stringValue: kubernetes
@@ -5660,7 +5120,7 @@ resourceMetrics:
                         stringValue: kindnet
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 5a546023-5d3b-4040-ab88-614a405accc2
+                        stringValue: daa82d4f-b43e-4279-88e7-509f8c3475dc
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5690,7 +5150,7 @@ resourceMetrics:
                         stringValue: kube-proxy
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 0759557b-9910-4f4e-809b-e26348076bb1
+                        stringValue: 0c6f9bf4-499f-4671-8d94-98e35ed04bbf
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5720,7 +5180,7 @@ resourceMetrics:
                         stringValue: sock-splunk-otel-collector-agent
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 92574a9b-f1b0-4eb5-bf59-ca54edef93ef
+                        stringValue: ea5115f5-93ff-4c3d-b21f-060cf60a9718
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -5753,7 +5213,7 @@ resourceMetrics:
                         stringValue: kindnet
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 5a546023-5d3b-4040-ab88-614a405accc2
+                        stringValue: daa82d4f-b43e-4279-88e7-509f8c3475dc
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5783,7 +5243,7 @@ resourceMetrics:
                         stringValue: kube-proxy
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 0759557b-9910-4f4e-809b-e26348076bb1
+                        stringValue: 0c6f9bf4-499f-4671-8d94-98e35ed04bbf
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5813,7 +5273,7 @@ resourceMetrics:
                         stringValue: sock-splunk-otel-collector-agent
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 92574a9b-f1b0-4eb5-bf59-ca54edef93ef
+                        stringValue: ea5115f5-93ff-4c3d-b21f-060cf60a9718
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -5846,7 +5306,7 @@ resourceMetrics:
                         stringValue: kindnet
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 5a546023-5d3b-4040-ab88-614a405accc2
+                        stringValue: daa82d4f-b43e-4279-88e7-509f8c3475dc
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5876,7 +5336,7 @@ resourceMetrics:
                         stringValue: kube-proxy
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 0759557b-9910-4f4e-809b-e26348076bb1
+                        stringValue: 0c6f9bf4-499f-4671-8d94-98e35ed04bbf
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5906,7 +5366,7 @@ resourceMetrics:
                         stringValue: sock-splunk-otel-collector-agent
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 92574a9b-f1b0-4eb5-bf59-ca54edef93ef
+                        stringValue: ea5115f5-93ff-4c3d-b21f-060cf60a9718
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -5939,7 +5399,7 @@ resourceMetrics:
                         stringValue: kindnet
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 5a546023-5d3b-4040-ab88-614a405accc2
+                        stringValue: daa82d4f-b43e-4279-88e7-509f8c3475dc
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5969,7 +5429,7 @@ resourceMetrics:
                         stringValue: kube-proxy
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 0759557b-9910-4f4e-809b-e26348076bb1
+                        stringValue: 0c6f9bf4-499f-4671-8d94-98e35ed04bbf
                     - key: k8s.namespace.name
                       value:
                         stringValue: kube-system
@@ -5999,7 +5459,7 @@ resourceMetrics:
                         stringValue: sock-splunk-otel-collector-agent
                     - key: k8s.daemonset.uid
                       value:
-                        stringValue: 92574a9b-f1b0-4eb5-bf59-ca54edef93ef
+                        stringValue: ea5115f5-93ff-4c3d-b21f-060cf60a9718
                     - key: k8s.namespace.name
                       value:
                         stringValue: default
@@ -6032,7 +5492,7 @@ resourceMetrics:
                         stringValue: kind-control-plane
                     - key: k8s.node.uid
                       value:
-                        stringValue: e879976d-29c7-441f-926a-e4d94e6e3795
+                        stringValue: 1098b47c-7df6-495e-a511-2e0473c3bf95
                     - key: metric_source
                       value:
                         stringValue: kubernetes

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -32,7 +32,7 @@ dependencies:
     alias: operatorcrds
     condition: operatorcrds.install
   - name: opentelemetry-operator
-    version: 0.71.2
+    version: 0.80.2
     alias: operator
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: operator.enabled

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1295,8 +1295,8 @@ instrumentation:
       - name: OTEL_DOTNET_AUTO_PLUGINS
         value: Splunk.OpenTelemetry.AutoInstrumentation.Plugin,Splunk.OpenTelemetry.AutoInstrumentation
   go:
-    repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-go
-    tag: v0.10.1-alpha
+    repository: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go
+    tag: v0.19.0-alpha
     # env:
     #   - name: GO_ENV_VAR
     #     value: go_value


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Bumping the operator subchart version
- The functional tests started to fail because the included target allocator started emitting more metrics for our k8s cluster receiver integration. Had to update the expected test data in expected_cluster_receiver.yaml content.
