### PR TITLE
[chore] Update .pre-commit-config.yaml for check-added-large-files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,4 +21,4 @@ repos:
       exclude: "^helm-charts|operator-webhook.yaml"
       args: [ --allow-multiple-documents ]
     - id: check-added-large-files
-      args: [ --maxkb=1500 ]
+      args: [ --maxkb=5000 ]


### PR DESCRIPTION
Description:
- Update the .pre-commit-config.yaml check-added-large-files configuration to 5000kb
- Increases the pre-commit test check limit to accommodate files around 2100KB-5000KB. This adjustment helps us adopt new file additions for our rendered Helm template and functional test golden file content in the repo, ensuring it doesn't interfere with normal developer workflows. Without this change, I occasionally need to bypass Git commit hooks during my work.
