### PR TITLE
[chore] migrate from using the "Ignore Tests" PR label to "Skip Upgrade Tests"

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -47,7 +47,6 @@ jobs:
           - k8sevents
           - istio
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -101,7 +100,6 @@ jobs:
   eks-test:
     name: Test helm install in EKS - credentials needed
     needs: kubernetes-test
-    if: github.event.pull_request.head.repo.full_name == github.repository
     concurrency:
       group: eks-access
     env:
@@ -109,7 +107,6 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -140,7 +137,7 @@ jobs:
   eks-upgrade-test:
     name: Test helm upgrade in EKS - credentials needed
     needs: kubernetes-test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'Skip Upgrade Tests') }}
     concurrency:
       group: eks-access
     env:
@@ -148,7 +145,6 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout main if in a PR
@@ -205,7 +201,7 @@ jobs:
   eks-upgrade-from-release-test:
     name: Test helm upgrade from release in EKS - credentials needed
     needs: kubernetes-test
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'Skip Upgrade Tests') }}
     concurrency:
       group: eks-access
     env:
@@ -213,7 +209,6 @@ jobs:
       KUBE_TEST_ENV: eks
       SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout old release
@@ -267,7 +262,6 @@ jobs:
       KUBE_TEST_ENV: gke/autopilot
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -305,7 +299,6 @@ jobs:
       KUBE_TEST_ENV: gke/autopilot
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - name: Checkout main if in a PR
@@ -364,7 +357,6 @@ jobs:
       KUBE_TEST_ENV: aks
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -403,7 +395,6 @@ jobs:
       KUBE_TEST_ENV: gce
       SKIP_TESTS: "true"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- This repository's settings won't allow us to use the github worfklow "continue-on-error" clause and "Ignore Tests" PR label as originally intended. When using "continue-on-error" it would still cause our required checks to fail if a step failed, granted downstream workflows from that step would still run.
- We'll have to migrate to using a github worfklow "if" clause and a label like "Skip Upgrade Tests". I tested this approach in my forked repository, I don't for see any issues with this approach in this repository.
 