### PR TITLE
fix: enable configuring fipsEnabled otelcollector image

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -210,9 +210,12 @@ Create the fluentd image name.
 Create the opentelemetry collector image name.
 */}}
 {{- define "splunk-otel-collector.image.otelcol" -}}
-{{- printf "%s:%s" .Values.image.otelcol.repository (.Values.image.otelcol.tag | default .Chart.AppVersion) -}}
+{{- $repository := .Values.image.otelcol.repository -}}
+{{- if .Values.image.otelcol.fipsEnabled -}}
+{{- $repository = printf "%s-fips" $repository -}}
 {{- end -}}
-
+{{- printf "%s:%s" $repository (.Values.image.otelcol.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{/*
 Create the patch-log-dirs image name.
 */}}

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: fluentd-config-json
               mountPath: /fluentd/etc/json
         {{- else }}
-        {{- if not (eq .Values.distribution "gke/autopilot") }}
+        {{- if and (not (eq .Values.distribution "gke/autopilot")) (not .Values.image.otelcol.fipsEnabled) }}
         - name: migrate-checkpoint
           image: {{ template "splunk-otel-collector.image.otelcol" . }}
           imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1111,6 +1111,9 @@
                 "Always",
                 "Never"
               ]
+            },
+            "fipsEnabled": {
+              "type": "boolean"
             }
           }
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -963,12 +963,12 @@ image:
   otelcol:
     # The registry and name of the opentelemetry collector image to pull
     repository: quay.io/signalfx/splunk-otel-collector
-    # For the FIPS-140 enabled version, use this repository instead:
-    # repository: quay.io/signalfx/splunk-otel-collector-fips
     # The tag of the Splunk OTel Collector image, default value is the chart appVersion
     tag: ""
     # The policy that specifies when the user wants the opentelemetry collector images to be pulled
     pullPolicy: IfNotPresent
+    # To use the FIPS-140 enabled version, set this value to true
+    # As a result, the repository will become quay.io/signalfx/splunk-otel-collector-fips
     fipsEnabled: false
 
   # Image to be used by init container that patches log directories on the host, so the collector can read from them as a non-root user.

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -969,6 +969,7 @@ image:
     tag: ""
     # The policy that specifies when the user wants the opentelemetry collector images to be pulled
     pullPolicy: IfNotPresent
+    fipsEnabled: false
 
   # Image to be used by init container that patches log directories on the host, so the collector can read from them as a non-root user.
   # Effective only if `agent.securityContext.runAsUser` and `agent.securityContext.runAsGroup` are set to non-zero values.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Bugfix: When using the fips otelcollector image, the migratecheckpoint init container (and subsequently, the rest of the deployment) fails to start, as the [binary has been excluded from the fips image](https://github.com/signalfx/splunk-otel-collector/blob/e586a6f0f2f11b7e7686b9a7ac708d5149dd19bb/packaging/docker-otelcol.sh#L73). This change also edits the image.otelcol.repository such that `-fips` is appended to the repository.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>
None, but I have opened a case #3672212, and wanted to help push this fix effort along.

**Testing:** <Describe what testing was performed and which tests were added.>

Ran `helm template mytestchart . --values=values.test` with the following values:
```
clusterName: my-cluster
splunkPlatform:
  endpoint: "https://test.platform:8080/services/collector/event"
  index: test
  # A real certificate is not required in caFile as long as it exists in the splunk_hec_token secret
  # caFile requires a value so the Splunk OTeL Pods read the certificate from the splunk_hec_token secret
  caFile: enabled
  logsEnabled: true
  metricsEnabled: false
  tracesEnabled: false
secret:
  create: false
  name: ${secret_name}
cloudProvider: aws
distribution: eks
image:
  otelcol:
    fipsEnabled: true
```
The deployment started and ran as expected. When `fipsEnabled: false` as is default, the deployment fails with 
```
failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/migratecheckpoint": stat /migratecheckpoint: no such file or directory: unknown
```

**Documentation:** <Describe the documentation added.>
Documented in the [values](https://github.com/signalfx/splunk-otel-collector-chart/blob/bc6f0934eb9014a35169bb8e4b7e626b135d5746/helm-charts/splunk-otel-collector/values.yaml#L972):
```
    # To use the FIPS-140 enabled version, set this value to true
    # As a result, the repository will become quay.io/signalfx/splunk-otel-collector-fips
    fipsEnabled: false
```
