### PR TITLE
fixing missing logs while pod log file being rolled over

### DIFF
--- a/.chloggen/dropped-logs-while-logs-rolling-fix.yaml
+++ b/.chloggen/dropped-logs-while-logs-rolling-fix.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: a fix for a scenario where some logs might be missed due to the pod log file being rolled over during high load, set featureGates.fixMissedLogsDuringLogRotation to true to enable the fix
+# One or more tracking issues related to the change
+issues: [1690]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1387,3 +1387,6 @@ featureGates:
   explicitMountServiceAccountToken: false
   # Use a specific metrics pipeline to report control plane metrics as histograms.
   useControlPlaneMetricsHistogramData: false
+  # The feature gate provides a fix for a scenario where some logs might be missed due to the pod log file being
+  # rolled over during high load.
+  fixMissedLogsDuringLogRotation: false


### PR DESCRIPTION
**Description:** 
This PR contains changes related to the bug raised by one of our customer. They mentioned that not all logs were being collected from the log files due to the files being rotated.
The changes to fix above issue have been added by using `featureGates.fixMissedLogsDuringLogRotation` flag. Setting that flag to `true` will enable the fix and will allow connector to collect logs also from files which are being rolled over. 

<img width="886" alt="image" src="https://github.com/user-attachments/assets/e227e01d-1a93-4fa5-b658-82b32aa2388b" />


**Testing:** checked manually, no duplicated logs, no missed logs



