### PR TITLE
Restore values of `service.name` resource attribute

### DIFF
--- a/.chloggen/restore-service-name-values.yaml
+++ b/.chloggen/restore-service-name-values.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: all
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Restore values of `service.name` resource attribute for internal metrics changed in 0.120.0"
+# One or more tracking issues related to the change
+issues: [1692]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The value of `service.name` resource attribute was changed to `otelcol` due to a library upgrade
+  in the Prometheus receiver. This change restores the values that were set before the based on the
+  collector mode: `otel-agent`, `otel-collector` or `otel-k8s-cluster-receiver`.

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -504,3 +504,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bb0569318e2bd629678bb47f463e2af6290909306a1cc22fd536614206ecc4cb
+        checksum/config: 88a61f772a830d7b57eff3b987ad81767b8d308fa5e7c085269290ab11e61f2f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -454,3 +454,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 87dfed92a17c2c4fde4c5074e9367b461a13eec19a30615415dd43e0b495af20
+        checksum/config: ca2b22ef8f9466d7111bbad9daeed320335577ba85fd97d2d0beac8f4cbcd684
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -332,3 +332,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1dc9bae1dbf9b66d7e05ce5335b27944d45a28af7df54c2ed30b9c995c78c82c
+        checksum/config: d0aea86f9a62115d00707bdc1ff000ef11b851e12cae92295bc42c35f5c459c8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -321,3 +321,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 152c52ad8af64b715e6d2b673a73ede2c2efde5677a10cbbb40c0ddbb19c28a2
+        checksum/config: 5e2f822c7db380709011a3df11ea21d4ded6ca72af2f0b19debb813f9a840aa1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -496,3 +496,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d9f18e3f656d7db7f250d4a02bebb8b14b7e074914e989a568eb7617ab3f08ba
+        checksum/config: 2090721bf75a3bd5b7319ff2af77539bc870aa0a4cfab743873f9a975e52c384
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -317,3 +317,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b785f4900df0628c3f854329cbf7d6fb4875d1a0d0646bf01f078241d826e19
+        checksum/config: 48ec2739d8647831f778aad2724f3f4211b477dec23a232688d5c72689e97438
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -301,3 +301,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -228,3 +228,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-collector

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4e4fa9c1ad7feedf306c00d1dafbb6ec4e3aa6d220d53f89024d14e0a2e1067a
+        checksum/config: d2aeb58870e725f513fe356de0bd0e81fbf422bd3f093ca037563887f1a733d7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 82e349a132b20f4c21cca4d3baaa8cfbbf9f46ed942f18c20d9d4dac81737b36
+        checksum/config: 05c65d695f8db76b3ee175a9c1ac46a3fef39a122004d280cadcd16dcb1ed42d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -184,3 +184,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2375bfaa6874fa298f691f0a636a7be034b68e541a3ce507adc885d6c31fae99
+        checksum/config: c1519af3592effec9d730342c24b83201af65992aa06d5dee3b88f7556369316
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -228,3 +228,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-collector

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 82e349a132b20f4c21cca4d3baaa8cfbbf9f46ed942f18c20d9d4dac81737b36
+        checksum/config: 05c65d695f8db76b3ee175a9c1ac46a3fef39a122004d280cadcd16dcb1ed42d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -357,3 +357,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 281b7a13c07e6ba3441a3df5f2c17c246267f369e4ca058b8557728655459f5f
+        checksum/config: e758be4c0afe277ae4444d457a95962e1e933dead3b751c4aef99984b229172d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -317,3 +317,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b785f4900df0628c3f854329cbf7d6fb4875d1a0d0646bf01f078241d826e19
+        checksum/config: 48ec2739d8647831f778aad2724f3f4211b477dec23a232688d5c72689e97438
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -317,3 +317,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b785f4900df0628c3f854329cbf7d6fb4875d1a0d0646bf01f078241d826e19
+        checksum/config: 48ec2739d8647831f778aad2724f3f4211b477dec23a232688d5c72689e97438
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -537,3 +537,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -176,3 +176,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c646df94e4d08caf3d44b7eb44febf333bad5d93d5c1a276c6fb679ce28dd6c4
+        checksum/config: 0d57932a5bd2bdd4f08fd8b27d767fd9f601f1c36d342cd2502116ec2eab2076
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bfb8def17eb3be631bf0aeb4881eaafac6a654f928d2e03200eb952a9888a16a
+        checksum/config: f139a99aea7cfbfdd9d7d34a58aec68562300ec6101d50df06f36ecdd309bbce
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -317,6 +317,8 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent
   discovery.properties: |
     splunk.discovery:
       extensions:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f00e9fb8ced736fa74e6a17b60fceaaaff1f75ce1e5bec439cc0937992148d79
+        checksum/config: da5b5152c2b5b5297b5f8e3bedca5f4645a8dbd13c6b5f309d7099ec0d1f2c28
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -275,3 +275,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -132,3 +132,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c1771dcca9620de10eb61170a101beffea772ba7ae82bf3765bb2d9fc6ed6d8b
+        checksum/config: c7b95f6e6a4b3fd6d6778a444c884234af62ef1a54f8007304637bb15b5090e8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 63f6aa0d8d3def96ba91db9421f73578a64a16d5d57d35fbaf9a5967022c0d14
+        checksum/config: 2fd19b361b206532d9cae158c4df2caf9c3a845c0aa9d1b746c2d50e814ebc23
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -161,3 +161,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -230,3 +230,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-collector

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: cb1b13bdc9f21725ba424f2ced1bb0b43351d75a7d08674c23cc52a74421b84b
+        checksum/config: 63e563eea90f65936b0c71fc40749c3a2d244e4dff0af9b2d09d40fbf6474bbc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 073b1777187ddea0ea910b42a9ffab93b2c9bdb857d742e51b0a9b71b33a88fd
+        checksum/config: dde80857db81e3f511d8d4198e00aa16516eb029af1f503535b952d31246d33e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -275,3 +275,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -151,3 +151,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c4645405e053cb08af95b7cedbae9d748f521c3b36c0d1e6c948b3662d133d44
+        checksum/config: 352e600a4d32b612cba50e8df17c6c5786e24e259630296ef3e4d0b022013fd8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 00d99432ad4c8e1a9e7fe65ecd30fc2b9f966e57d683cd6133b96746db81da72
+        checksum/config: acff9d7143ac6c76094b941101bbda1546c037e297c2eedecf4316ba848075ae
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -274,3 +274,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7f2e3ef1c2137ff7f7fe6918932182f7de2b3efc18e20fa40c0697a6834a8e06
+        checksum/config: ce6e389930ad5c1edcb9f3baed112acec200bf8e9f1558cc4949dc3e8667cc5f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: af8db89e13fdfd9108d3c497ab0ed3558533dbf411b7f75ac21facd053a5ba47
+        checksum/config: 068c4440af4ded84aab05475ea99b58297d0281a91797a62736ea42acd83dace
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -274,3 +274,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7a00227d8ee00a4fac82aa44b062bd72c9fc223d9e816e38de8f706767adfc53
+        checksum/config: 2e32f7a6ddf585dc9de4d70aaddf6489e3989dccce1faab43fa6cc865f33a036
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: af8db89e13fdfd9108d3c497ab0ed3558533dbf411b7f75ac21facd053a5ba47
+        checksum/config: 068c4440af4ded84aab05475ea99b58297d0281a91797a62736ea42acd83dace
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -325,3 +325,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,3 +131,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 73ed04fe27e4e10a7c9fd9913144b573acb1dff007f7719d4888b50609025674
+        checksum/config: 6fb39f66f2f599e835229e21838ae6a2047a5e339390188bc453907b8b0f080d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3f24449bc15b66dad2540ff469f96f386828170e384851b9640638cb38e9af5c
+        checksum/config: 0998d7306f665d30f76df48b24990a6058aeb44600f74607c2515fcdb39b2adc
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -458,3 +458,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 203fc6ec65d6af1b501b3ed0a0d2cf12128778151b559ffff668e90280c580a7
+        checksum/config: 911ea29b0633472397aa24d05a09aca9a4339074b9efeeb97832da8c74ff94c6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a6da70bf01b051ba41c9ec9300776a935118cfc118211f3e2dcb3e5d4338683
+        checksum/config: 85d91f39e1603f48746b956e27e59ded3d091d0776d2be9d2d48e0985f847f03
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -537,3 +537,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -176,3 +176,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a1bd16ff5a7b3ba44a8045dbf0801b4ea25f364249e199aeae729b007882df00
+        checksum/config: 6eea9313b137899a678f9c0bc8596fd9b109901dab2e8832df69c94a0df92434
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bfb8def17eb3be631bf0aeb4881eaafac6a654f928d2e03200eb952a9888a16a
+        checksum/config: f139a99aea7cfbfdd9d7d34a58aec68562300ec6101d50df06f36ecdd309bbce
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -230,3 +230,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4b49860b1affa8acbc2b35295814746ab0b5743ab812c8d6393f11ee418e8d72
+        checksum/config: ef6cb59c9e3707028724dc88a81d6f81f7f929b12e2e391977cace6c27bce29a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -319,3 +319,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0c1a917c4d1b1497d567f464aa1754170a03fa668c4d1800e11333c3b9b0bb43
+        checksum/config: 0bb3f0f558c7dbfe9a2da8d455508ba823f4c184f02cccfbb1ba77b2600491d5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -350,3 +350,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 76d355ba1fe90e7cee81afcd3a03f82d391ed16ec4a2b2a382355bf52c571b45
+        checksum/config: fa685c74b27fa208fc5101a7b7ca8f469e179606d02fb5c6b3df0fb0952f699c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -350,3 +350,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 09692d33047c3546aef95f0b33691160da23c4d2bbbaacf21d41c4914d91b438
+        checksum/config: 574b8c62dfb4909e2119e10f9beb7e4df1a8b62b91f8fc75816ec8358adda14e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -456,3 +456,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0be85d8c19ba16680a3fe0c516167e1b631a08b100b964c435871d9155922212
+        checksum/config: 60fffb835a072d71614aab8efee592e07869b1bf6fa037d7f862b71026b717b0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -487,3 +487,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -176,3 +176,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c990bc0b4392410b06019043a4c81bd2492bf3ce839e0132966f0764b5fc5fa5
+        checksum/config: 12080b80c948155231daff62a430dbd062e6f238bf24df7c20ea630026c7a8dc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bfb8def17eb3be631bf0aeb4881eaafac6a654f928d2e03200eb952a9888a16a
+        checksum/config: f139a99aea7cfbfdd9d7d34a58aec68562300ec6101d50df06f36ecdd309bbce
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -229,3 +229,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 552bd0dc798e0409b241b67d87f1c444d4947670ac0ff1a48568d8e1bfecfea2
+        checksum/config: 5a38eabd84526051aa98b9770de27584c1fbae6f443d444af91d94ccf97ef90b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -365,3 +365,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 39565b50586b259c73a6a01fa30bce2a23ae2e4845cb2b4d2ea111ff6dc6c025
+        checksum/config: e2f9f3be4df0ed3d3f465f3910ed47c773b233aabf956c23c2e40682c5677e1a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -368,3 +368,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9b704551e5d0c59bacba806c034b4ec2c37260bfb27e9b493215872aee55f43c
+        checksum/config: 3d3d4cb252dd56e84cf866459c0edddde7b63e6d7beb08d7ff22476f98e778ae
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -334,3 +334,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -176,3 +176,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b15b7f5a14c2467dfe2b8eef6e300d0b409b1dfccd97d79ea94c190512c55343
+        checksum/config: ec079ba6a012cc8ad59793899c2de733a30f99ce7d359991c0672120a3cd948b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bfb8def17eb3be631bf0aeb4881eaafac6a654f928d2e03200eb952a9888a16a
+        checksum/config: f139a99aea7cfbfdd9d7d34a58aec68562300ec6101d50df06f36ecdd309bbce
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -286,3 +286,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 93fec05e611f73886b0ef9397514eec8f55aa8ee9538b03f013a4c24d8b8e07f
+        checksum/config: 77274494051928e6d286ae49cba7bd8f3278b330dedcef04754395787a708772
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -226,3 +226,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c43e27a52300490676ed9010c896d8292f9bcf7a42ddbfa3bd93c9d13540fce5
+        checksum/config: 61e98e859d636d7fefb488f6555e90611c91e8235332b1b02f004464dfbcd577
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -324,3 +324,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 32d3bd9b07200365684fcd111358487ea29f75898d719fa7cd1e38a51defc541
+        checksum/config: c20e64cab382b1bf887f3c31a4ba24eca9a77c42b03f95202844b215738a2635
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bbf025fca58046a39f078b556d06b730ab8f890e21e5edbf795a71187864bc35
+        checksum/config: 0b4b5767db6880fe86fb5f01fa05e854bb05108c4418684ef1824e297d358e53
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -330,3 +330,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2944ae13602a32b00dfb90435e47d6c20fd179f92ac09fc9e9d6d474402ed61f
+        checksum/config: c251cf639efd1afaa32a8afdd31e32315d2aa286b97d4bf6215445a77e09397a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -333,3 +333,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 48f8cc23d6e9227a6cbe4d5d19efbe99c1572c8a38a03a6abfe0cdd1d22d976c
+        checksum/config: 4efd5411252ced29a54a2107c64bf57fe50b2c47bd60b6cc5caf8bc14ff9479b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -325,3 +325,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 077ea2ba0f63cc04cb807b407fe2cd1db961c4d40c40cbcf9504b089cf5a660e
+        checksum/config: 379588df3696a924b7258c4e45e716c139be2d47a3bd19ed7a7c94194c12c623
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -317,3 +317,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b785f4900df0628c3f854329cbf7d6fb4875d1a0d0646bf01f078241d826e19
+        checksum/config: 48ec2739d8647831f778aad2724f3f4211b477dec23a232688d5c72689e97438
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -326,3 +326,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-agent

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,3 +130,5 @@ data:
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true
+        resource:
+          service.name: otel-k8s-cluster-receiver

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 45caf7a0291d5a6851710584a3343895666bd4e9cfc2aad1faa0c15314c3670a
+        checksum/config: 5b4caa225f33580480f2528ff074c35a176d8311aa8ad510dda8dd1ba4e3f335
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 91987f4db922dfbd2abeb6d5d1600511b4725f6eaa914bc51a77ee747bbcf028
+        checksum/config: 6777488399676ecd220543e6fd3520f980bc3af2add4d3fb5bd7311a41747738
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -853,6 +853,8 @@ exporters:
 
 service:
   telemetry:
+    resource:
+      service.name: otel-agent
     metrics:
       readers:
         - pull:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -143,6 +143,8 @@ exporters:
   {{- end }}
 service:
   telemetry:
+    resource:
+      service.name: otel-collector
     metrics:
       readers:
         - pull:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -218,6 +218,8 @@ exporters:
 
 service:
   telemetry:
+    resource:
+      service.name: otel-k8s-cluster-receiver
     metrics:
       readers:
         - pull:


### PR DESCRIPTION
The value of `service.name` resource attribute was changed to `otelcol` in version 0.120.0 due to a library upgrade in the Prometheus receiver. This change restores the values that were set before the based on the collector mode: `otel-agent`, `otel-collector` or `otel-k8s-cluster-receiver`.
