### PR TITLE
[chore] Fix flaky k8sevents functional test

### DIFF
--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -58,7 +58,7 @@ func Test_K8SEvents(t *testing.T) {
 			return re.ReplaceAllString(body, `Successfully pulled image "$1:latest" in <time> (<time> including waiting)`)
 		})
 
-		// These container attributes may not get added by the k8sattributesprocessor on the events about container image pull/start
+		// the following attributes are added by the k8sattributes processor which might not be ready when the test runs
 		removeFlakyLogRecordAttr(k8sEventsLogs, "container.id")
 		removeFlakyLogRecordAttr(k8sEventsLogs, "container.image.name")
 		removeFlakyLogRecordAttr(k8sEventsLogs, "container.image.tag")
@@ -92,6 +92,10 @@ func Test_K8SEvents(t *testing.T) {
 		k8sObjectsLogs = updateLogRecordBody(k8sObjectsLogs, []string{"object", "metadata", "creationTimestamp"}, "2025-03-04T01:59:10Z")
 		k8sObjectsLogs = updateLogRecordBody(k8sObjectsLogs, []string{"object", "metadata", "managedFields", "0", "time"}, "2025-03-04T01:59:10Z")
 		k8sObjectsLogs = updateLogRecordBody(k8sObjectsLogs, []string{"object", "metadata", "managedFields", "0", "manager"}, "k8sevents.test") // changes when the test name which runs k8s client changes
+
+		// the following attributes are added by the k8sattributes processor which might not be ready when the test runs
+		removeFlakyLogRecordAttr(k8sObjectsLogs, "container.image.name")
+		removeFlakyLogRecordAttr(k8sObjectsLogs, "container.image.tag")
 
 		expectedObjectsLogsFile := "testdata/expected_k8sobjects.yaml"
 		expectedObjectsLogs, err := golden.ReadLogs(expectedObjectsLogsFile)

--- a/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
@@ -16,12 +16,6 @@ resourceLogs:
     scopeLogs:
       - logRecords:
           - attributes:
-              - key: container.image.name
-                value:
-                  stringValue: alpine
-              - key: container.image.tag
-                value:
-                  stringValue: latest
               - key: deployment.environment
                 value:
                   stringValue: dev


### PR DESCRIPTION
Ignoring attributes added by the k8sattributes processor in the k8sClusterReceiver pipelines. This potentially can be fixed by enabling `wait_for_metadata` config option. However, the usage of that processor is questionable, I don't think we should delay the start because of it.

Test failure example: https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/13730833154/job/38407459000