### PR TITLE
[chore] Fix flaky k8s objects functional test

### DIFF
--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -96,6 +96,9 @@ func Test_K8SEvents(t *testing.T) {
 		// the following attributes are added by the k8sattributes processor which might not be ready when the test runs
 		removeFlakyLogRecordAttr(k8sObjectsLogs, "container.image.name")
 		removeFlakyLogRecordAttr(k8sObjectsLogs, "container.image.tag")
+		removeFlakyLogRecordAttr(k8sObjectsLogs, "k8s.node.name")
+		removeFlakyLogRecordAttr(k8sObjectsLogs, "k8s.pod.name")
+		removeFlakyLogRecordAttr(k8sObjectsLogs, "k8s.pod.uid")
 
 		expectedObjectsLogsFile := "testdata/expected_k8sobjects.yaml"
 		expectedObjectsLogs, err := golden.ReadLogs(expectedObjectsLogsFile)
@@ -106,7 +109,6 @@ func Test_K8SEvents(t *testing.T) {
 			plogtest.IgnoreObservedTimestamp(),
 			plogtest.IgnoreResourceAttributeValue("host.name"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.object.uid"),
-			plogtest.IgnoreLogRecordAttributeValue("k8s.pod.uid"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.object.resource_version"),
 			plogtest.IgnoreResourceAttributeValue("com.splunk.index"), // this is flaky, the index can be the value from pod annotation due to the k8sattributes processor in the pipeline or main
 			plogtest.IgnoreResourceLogsOrder(),

--- a/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
@@ -31,15 +31,6 @@ resourceLogs:
               - key: k8s.namespace.name
                 value:
                   stringValue: k8sevents-test
-              - key: k8s.node.name
-                value:
-                  stringValue: kind-control-plane
-              - key: k8s.pod.name
-                value:
-                  stringValue: k8sevents-test-0
-              - key: k8s.pod.uid
-                value:
-                  stringValue: ce3f6e1c-f11a-404d-bfd3-5f41811f9133
               - key: k8s.resource.name
                 value:
                   stringValue: services


### PR DESCRIPTION
Couple more attributes inconsistently added by k8sattributes processor https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/13777796906/job/38530407185?pr=1704. Similar to https://github.com/signalfx/splunk-otel-collector-chart/pull/1705