### PR TITLE
Update functional_test_v2.yaml to fix upgrade test

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -214,7 +214,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: base
-          ref: splunk-otel-collector-0.109.0
+          ref: splunk-otel-collector-0.120.0
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Quick fix to get the upgrade tests to run when we know previous versions had breaking changes. We should try to figure out how to make this more dynamic in the future.
