### PR TITLE
signalfxexporter: send otlp histograms by default

### DIFF
--- a/.chloggen/sfxhistograms.yaml
+++ b/.chloggen/sfxhistograms.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent, gateway
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update signalfx exporter in agent and gateway to send OTLP histograms without translation
+# One or more tracking issues related to the change
+issues: [1710]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 76e27410deac41c48ba5dbb34e16d6352db629410fdb3feb42b6fc45ab9dbd9d
+        checksum/config: ed4815a5ed7dfe038731564d1f743d769919741e1eda7616c73bce8e685667cb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6fc986f6d2cd0dd5a5f9d0203baf8e43a5f80d1cb886a792219f7492fe473530
+        checksum/config: 721c21728ee6b078e52cc7c2060bc2165080b9cf5b33149e2ee3cfa5f9595779
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6a65ddbb6009c661c1e09a637e99f346de613c5a9d861cb569e90f94a799f215
+        checksum/config: 0f54cc6c450fd953062b5faf51f277c0875d57f1504edf325d54b0956174d7fc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0ea2b53d65e482b737bc6da17fa8ef5525a6e8e8cfe81559d5e91552d836d785
+        checksum/config: 29be780577a81a4d693c1ea54e6499dc5646798f155b7a85e67e8dcd7ab657d4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b63f6f2779c03ebb30de2d1e631bd99834202366c038ec05f6aab8eb69d8b51
+        checksum/config: 3f01f27c43b6c07242fd62abda78b83261db02446ffe9c23819ed8787ecadcb7
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ddb27f66d519b7ada876969b5c5b6dcbbaeb2615dc064f5c7955429463afe310
+        checksum/config: 10cc3bf271cdf8e067a66b9790b3a3e06748912f968d92f4950b63275fb697d7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -31,6 +31,7 @@ data:
         api_url: http://default-splunk-otel-collector:6060
         correlation: null
         ingest_url: http://default-splunk-otel-collector:9943
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -29,6 +29,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sending_queue:
           num_consumers: 32
     extensions:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bb0bdbbe1c794e84372db7a4e8d6c533d3ea96ee48db0a38ae0bd1687c302491
+        checksum/config: 212b69de23adc1d1a43d86e73d6e1ea0652148954886247b824fcbb936b7e354
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6e30bca9e823a9fb95429012845ce5773cebfbb354c6de1a4e697d51a1cac0d5
+        checksum/config: 07cc51d4b266e28ad09b25b7e0f9ae92f43d9315d4e173ec6e8f658e2eed378e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -29,6 +29,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sending_queue:
           num_consumers: 32
     extensions:

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6e30bca9e823a9fb95429012845ce5773cebfbb354c6de1a4e697d51a1cac0d5
+        checksum/config: 07cc51d4b266e28ad09b25b7e0f9ae92f43d9315d4e173ec6e8f658e2eed378e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       signalfx/histograms:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2e8c719caf09ad64ec43813f032aaac213552e870046d2b33ef41c6f345213ee
+        checksum/config: 2b7a76fb55aec54ec0536cb401401f4895b34e974836cf7517b0c3cdadc0c2f7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ddb27f66d519b7ada876969b5c5b6dcbbaeb2615dc064f5c7955429463afe310
+        checksum/config: 10cc3bf271cdf8e067a66b9790b3a3e06748912f968d92f4950b63275fb697d7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ddb27f66d519b7ada876969b5c5b6dcbbaeb2615dc064f5c7955429463afe310
+        checksum/config: 10cc3bf271cdf8e067a66b9790b3a3e06748912f968d92f4950b63275fb697d7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f5c5c43cc3cf804ff2ce44be003d7f9c1533fc84a2b1f19f56cb1b782106b350
+        checksum/config: 331defb1786c8b955eeb9347fe0a21effe5390ded884a4d5e3239bbb8c15a921
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b6567fe68eb6ec963594b02b1722851c89f2f040a0b222d7b60753fb48343290
+        checksum/config: 4734aff09d2c1ec99fec67334678ab4eeaad36eecc5e57d2a860b200d3e4b3a6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -29,6 +29,7 @@ data:
         access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         api_url: https://api.CHANGEME.signalfx.com
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sending_queue:
           num_consumers: 32
     extensions:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 3d8d6c37e1d1a0b03e9c3a4752a8bec1737f17f7a302750a614cea8f86f7d67d
+        checksum/config: 71c2cf2e7af396c9a880ecbfd6d99f2a404f3a3a7f0cc856597e15344f1091db
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 587aef953a0872759a37780cb670b9a9121d99030fd2558c763dba7dc526c68d
+        checksum/config: 9067b5bb397a63431f44791e866fccd439f7d7b9b3176937c1a0237131f6d6ae
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: df96edc6f9889f3db99e9bf386c5697891e3e9dc69efc4de77584d9e10d23548
+        checksum/config: 2c6e534846219198f268196040f9c8b079447afa26a91fd5fb98447eb09de76f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b518e3f38c798451be42d79398ec2aad84c488ebd8574dbb9f8559cbfe8d286
+        checksum/config: c582bca500358a0761fad392c8f11c26ef8b5d3ecc51a79320bf1cfa31eb94c4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fc08b4613f35816a19843ed7ff0c593f02f4b8f92985df05739111f3ceb42c19
+        checksum/config: 908ce72dbd8ef42af650a275b9d70d510cbc588d67a707b39cce0a1c0b793fe7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.us0.signalfx.com
         correlation: null
         ingest_url: https://ingest.us0.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5b42906bab0c48fc8030f2c43a8ab44f444228b4deef9e9d665509ff823547a1
+        checksum/config: aad6066ee3d2c8d882f69774059b97b44359537f538b92ea7163391a2aebf22c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 55b84d97b37fb67b0abb810294097be0a9e63311d93c3d3aa8a876abd42dfa05
+        checksum/config: 99a60403892db8592932bf41b0eedc5f0caef99f962d2ca70ef5793733c1e2ae
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f2431671e52027420e3e76362e0a3dd5ff48c4882c042ff2dcde1b28304812ea
+        checksum/config: d0235add26d22f12fee77e56fe6a987e07330eec3e5cbe844ea5e387cb6ea71b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6dee24d6bf14da823481b011e65abb5d9def6d186a0b8f132b05fb7f81cf737f
+        checksum/config: cde8ccde6a8aae9d47c9154080a3cf2ff89496a035af09c7575aa7190d6e7841
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3eccc57931a2fe6007f188abee8f2941b839c803dbcd19f8bc3c4e17f6a70051
+        checksum/config: 74382ff33baf36105081303cc0f07ba10bb5bc4667dd1df5af739e9c240cb6dd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 484c51587291610ea63cf66d947575dfb27d0dc283d81c6065e62ebda41270d7
+        checksum/config: dadbbec3546ab89804ec2d888bf0823aefaf29fcde46f19d606d74cf02627e18
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-agent.yaml
@@ -27,6 +27,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3235b89e685d3c724e9e7e831818e58a342c9f8e5f124739a6b9fb7e5f611d4e
+        checksum/config: 5438de6ad6fd04a8d9eaa2362e48a3cf7778e95c73439a56f96ebe6a232e7cfe
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-agent.yaml
@@ -27,6 +27,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 19a4fc5776fc55cf7a751b2c901315ff590c6851a2f69bfe4115852502e841f6
+        checksum/config: ef2aadeae199d426bab0fef5cc29417687c1033d6be18ec0427517c78460c00c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -27,6 +27,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3442f38e4010fbc4d4d5fd3434927a40a05b459f1eacabffdf1e204e7f42c0eb
+        checksum/config: 83ae8c920e85a0fc41ce727d1ae1fdc16a5fe84e6db05f2a6b6ed42621f89e9a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -27,6 +27,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c2e2d96c57610d89d4b525be77c6716e86c4f14c676e01ab51226bcaa9207460
+        checksum/config: 31e61022a381fc58b9bffd4c469ef0e442fe6c98f616196d36937b0ab6afea6b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 150e1e2d5b2287b6e47a7b3470122a0c103feb5fed1950635e1c86ad2f4d2bc0
+        checksum/config: d7014b03d837c5643b0e203c6e0d3c6ed636d7912d71c52d690ea0c18c4788cb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -36,6 +36,7 @@ data:
         api_url: http://<custom-gateway-url>:6060
         correlation: null
         ingest_url: http://<custom-gateway-url>:9943
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 762126b6ded86ec5e63db668621135dfcb2a56c9b3a807cfa4846593f9451e0f
+        checksum/config: 9bf9649f910ab3471fe2a72e307b8ede17efa2f0ccd385bf4543d47321ba20e4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -27,6 +27,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
       splunk_hec/o11y:
         disable_compression: true

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: baead5c9577a932ade72d5edea788830e2b9811731fd71003e599a8038550d4e
+        checksum/config: 598d15757097846010459ef4c89304aeda2ea5f9b478f4e0a8e278660be8ffb0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6409eae2fc67840090db24f734252d77375fbcf4b4f59e1f554ff73e89563f52
+        checksum/config: 43d5b6cd13e4fd69aead92e72128160dfb2806b87d31ca011a24a090835f2e2f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ddb27f66d519b7ada876969b5c5b6dcbbaeb2615dc064f5c7955429463afe310
+        checksum/config: 10cc3bf271cdf8e067a66b9790b3a3e06748912f968d92f4950b63275fb697d7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -32,6 +32,7 @@ data:
         api_url: https://api.CHANGEME.signalfx.com
         correlation: null
         ingest_url: https://ingest.CHANGEME.signalfx.com
+        send_otlp_histograms: true
         sync_host_metadata: true
     extensions:
       health_check:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b1a1a31f5a376befa1b3232734456a3b0e83e3b6f14237d29791a901d711b549
+        checksum/config: a2a6524738ec97660c91e6b92c0cc1b2a4b1f98f7a1f963a979c4ef2d5136cbf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1279,9 +1279,7 @@ func testPrometheusAnnotationMetrics(t *testing.T) {
 		"istio_agent_go_gc_cycles_total_gc_cycles_total",
 		"istio_agent_go_gc_duration_seconds_sum",
 		"istio_agent_go_gc_duration_seconds_count",
-		"istio_agent_go_gc_heap_allocs_by_size_bytes_total_bucket",
-		"istio_agent_go_gc_heap_allocs_by_size_bytes_total_sum",
-		"istio_agent_go_gc_heap_allocs_by_size_bytes_total_count",
+		"istio_agent_go_gc_heap_allocs_by_size_bytes_total",
 	}
 	// when scraping via prometheus.io/scrape annotation, no additional attributes are present.
 	checkMetricsAreEmitted(t, agentMetricsConsumer, metricNames, func(name string, attrs pcommon.Map) bool {

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -862,6 +862,7 @@ exporters:
     {{- end }}
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     sync_host_metadata: true
+    send_otlp_histograms: true
 
   # To send entities (applicable only if discovery mode is enabled)
   otlphttp/entities:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -110,6 +110,7 @@ exporters:
     access_token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     sending_queue:
       num_consumers: 32
+    send_otlp_histograms: true
   {{- end }}
 
   {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}


### PR DESCRIPTION
Set `send_otlp_histograms:true` on `signalfx` exporter in the agent and gateway config to export OTLP histograms without translations.