### PR TITLE
[chore] fix flaky histogram tests

### DIFF
--- a/functional_tests/histogram/histogram_test.go
+++ b/functional_tests/histogram/histogram_test.go
@@ -208,7 +208,7 @@ func testHistogramMetrics(t *testing.T) {
 		assert.NotNil(tt, controllerManagerMetrics)
 		assert.NotNil(tt, etcdMetrics)
 
-	}, 3*time.Minute, 5*time.Second)
+	}, 5*time.Minute, 5*time.Second)
 
 	require.NotNil(t, corednsMetrics)
 	require.NotNil(t, schedulerMetrics)

--- a/functional_tests/histogram/testdata/values/test_values.yaml.tmpl
+++ b/functional_tests/histogram/testdata/values/test_values.yaml.tmpl
@@ -12,6 +12,10 @@ agent:
     - name: SPLUNK_DEBUG_CONFIG_SERVER
       value: "true"
   config:
+    # disable batching as the control plain metrics are compared separately for each receiver
+    processor:
+      batch:
+        timeout: 0
     service:
       telemetry:
         logs:


### PR DESCRIPTION
- Increase listening timeout
- Disable batching to avoid metrics from different receivers to be merged