### PR TITLE
[check] Do not block tests in the cloud accounts

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -97,7 +97,6 @@ jobs:
 
   eks-test:
     name: Test helm install in EKS - credentials needed
-    needs: kubernetes-test
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.ref == 'refs/heads/main')
@@ -133,7 +132,6 @@ jobs:
 
   eks-upgrade-test:
     name: Test helm upgrade in EKS - credentials needed
-    needs: kubernetes-test
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.ref == 'refs/heads/main')
@@ -187,7 +185,6 @@ jobs:
 
   gke-autopilot-test:
     name: Test helm install in GKE/Autopilot - credentials needed
-    needs: kubernetes-test
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.ref == 'refs/heads/main')
@@ -225,7 +222,6 @@ jobs:
 
   gke-autopilot-upgrade-test:
     name: Test helm upgrade in GKE/Autopilot - credentials needed
-    needs: kubernetes-test
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.ref == 'refs/heads/main')
@@ -281,7 +277,6 @@ jobs:
 
   aks-windows-test:
     name: Test helm install in AKS - credentials needed
-    needs: kubernetes-test
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.ref == 'refs/heads/main')
@@ -320,7 +315,6 @@ jobs:
 
   gce-autopilot-test:
     name: Test helm install in GCE (kops) - credentials needed
-    needs: kubernetes-test
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.ref == 'refs/heads/main')


### PR DESCRIPTION
Given that the concurrency is not an issue anymore, there is no reason to block tests in the cloud accounts until the generic functional tests are done
