### PR TITLE
[chore] Fix upgrade tests on main

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -143,22 +143,11 @@ jobs:
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout main if in a PR
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
-        with:
-          path: base
-          ref: main
-      - name: Checkout previous main commit if in main
-        if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
-        with:
-          path: base
-          ref: HEAD
-          fetch-depth: 2
-      - name: Checkout previous main commit if in main
-        if: github.event_name != 'pull_request'
-        run: cd base && git checkout HEAD^
+      - name: Download the latest published release to use as a base for the upgrade
+        run: |
+          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
+          helm repo update
+          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -174,12 +163,12 @@ jobs:
           aws eks update-kubeconfig --name rotel-eks --region us-west-1
       - name: Update dependencies
         run: |
-          make dep-update && cd base && make dep-update
+          make dep-update
       - name: run functional tests
         env:
           HOST_ENDPOINT: 0.0.0.0
           UPGRADE_FROM_VALUES: aws_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base
+          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
         run: |
           TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
 
@@ -232,22 +221,11 @@ jobs:
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout main if in a PR
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
-        with:
-          path: base
-          ref: main
-      - name: Checkout previous main commit if in main
-        if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
-        with:
-          path: base
-          ref: HEAD
-          fetch-depth: 2
-      - name: Checkout previous main commit if in main
-        if: github.event_name != 'pull_request'
-        run: cd base && git checkout HEAD^
+      - name: Download the latest published release to use as a base for the upgrade
+        run: |
+          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
+          helm repo update
+          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -266,12 +244,12 @@ jobs:
           project_id: ${{ secrets.GKE_PROJECT }}
       - name: Update dependencies
         run: |
-          make dep-update && cd base && make dep-update
+          make dep-update
       - name: run functional tests
         env:
           HOST_ENDPOINT: 0.0.0.0
           UPGRADE_FROM_VALUES: gke_autopilot_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base
+          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
         run: |
           TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
 

--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -70,7 +70,7 @@ func deployChartsAndApps(t *testing.T, valuesFileName string, repl map[string]in
 	client, err := kubernetes.NewForConfig(kubeConfig)
 	require.NoError(t, err)
 
-	chart := internal.LoadCollectorChart(t, "")
+	chart := internal.LoadCollectorChart(t)
 
 	var valuesBytes []byte
 	valuesBytes, err = os.ReadFile(filepath.Join(testDir, valuesDir, valuesFileName))

--- a/functional_tests/histogram/histogram_test.go
+++ b/functional_tests/histogram/histogram_test.go
@@ -59,7 +59,7 @@ func deployChartsAndApps(t *testing.T) {
 	testKubeConfig, setKubeConfig := os.LookupEnv("KUBECONFIG")
 	require.True(t, setKubeConfig, "the environment variable KUBECONFIG must be set")
 
-	chart := internal.LoadCollectorChart(t, "")
+	chart := internal.LoadCollectorChart(t)
 
 	valuesBytes, err := os.ReadFile(filepath.Join("testdata", valuesDir, "test_values.yaml.tmpl"))
 	require.NoError(t, err)

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -168,8 +168,12 @@ func LabelNamespace(t *testing.T, clientset *kubernetes.Clientset, name, key, va
 	require.NoError(t, err)
 }
 
-func LoadCollectorChart(t *testing.T, subdir string) *chart.Chart {
-	chartPath := filepath.Join("..", "..", subdir, "helm-charts", "splunk-otel-collector")
+func LoadCollectorChart(t *testing.T) *chart.Chart {
+	return LoadCollectorChartFromDir(t, "helm-charts/splunk-otel-collector")
+}
+
+func LoadCollectorChartFromDir(t *testing.T, dir string) *chart.Chart {
+	chartPath := filepath.Join("..", "..", dir)
 	c, err := loader.Load(chartPath)
 	require.NoError(t, err)
 	return c

--- a/functional_tests/istio/istio_test.go
+++ b/functional_tests/istio/istio_test.go
@@ -120,7 +120,7 @@ func deployIstioAndCollector(t *testing.T) {
 	// Send traffic through ingress gateways
 	sendWorkloadHTTPRequests(t)
 
-	chart := internal.LoadCollectorChart(t, "")
+	chart := internal.LoadCollectorChart(t)
 
 	valuesBytes, err := os.ReadFile(filepath.Join("testdata", "istio_values.yaml.tmpl"))
 	require.NoError(t, err)

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -153,7 +153,7 @@ func deployWorkloadAndCollector(t *testing.T) {
 	k8sClient, err := k8stest.NewK8sClient(testKubeConfig)
 	require.NoError(t, err)
 
-	chart := internal.LoadCollectorChart(t, "")
+	chart := internal.LoadCollectorChart(t)
 
 	valuesBytes, err := os.ReadFile(filepath.Join("testdata", "k8sevents_values.yaml.tmpl"))
 	require.NoError(t, err)


### PR DESCRIPTION
Failing tests: https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/13818988629/job/38659440962

This change simplifies the tests to always use the latest published version of the chart as a base for the upgrade
