### PR TITLE
[chore] Increase functional tests timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ unittest: ## Run unittests on the Helm chart
 .PHONY: functionaltest
 functionaltest: ## Run functional tests for this Helm chart with optional tags and environment variables
 	@echo "Running functional tests for this helm chart..."
-	cd functional_tests && go test -v ./$(SUITE)/... || exit 1
+	cd functional_tests && go test -v -timeout 20m ./$(SUITE)/... || exit 1
 
 ##@ Changelog
 # Tasks related to changelog management


### PR DESCRIPTION
Increase timeout for functional tests from 10 minutes to 20 minutes to avoid running into https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/13860115940/job/38786242031?pr=1721
