### PR TITLE
remove deprecation warning for clusterReceiver.evensEnabled

### DIFF
--- a/.chloggen/rm-warning-events.yaml
+++ b/.chloggen/rm-warning-events.yaml
@@ -1,0 +1,14 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removes warning from chart when the clusterReceiver.eventsEnabled flag is set to true.
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The clusterReceiver.eventsEnabled option which used k8s_events receiver is not being deprecated.
+  This change removes the warning that was previously displayed when this flag was set to true.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -366,9 +366,8 @@ operator:
 ## 0.67.0 to 0.68.0
 
 There is a new receiver: [Kubernetes Objects Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sobjectsreceiver) that can pull or watch any object from Kubernetes API server.
-It will replace the [Kubernetes Events Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver) in the future.
 
-To migrate from Kubernetes Events Receiver to Kubernetes Object Receiver, configure `clusterReceiver` values.yaml section with:
+To use the Kubernetes Object Receiver instead of the Kubernetes Events Receiver to collect k8s events, configure `clusterReceiver` values.yaml section with:
 
 ```yaml
 k8sObjects:

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -71,11 +71,6 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
 [WARNING] "clusterReceiver.k8sEventsEnabled" parameter is deprecated. Please use clusterReceiver.eventsEnabled and splunkObservability.infrastructureMonitoringEventsEnabled.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0532-to-0540
 {{ end }}
-{{- $crEventsEnabled := toString $clusterReceiver.eventsEnabled }}
-{{- if not (or (eq $crEventsEnabled "<nil>") (eq $crEventsEnabled "false")) }}
-[WARNING] "clusterReceiver.eventsEnabled" parameter is deprecated. Soon it will be replaced with "clusterReceiver.k8sObjects".
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0670-to-0680
-{{ end }}
 {{- if .Values.operator.enabled }}
 [INFO] You've enabled the operator's auto-instrumentation feature (operator.enabled=true)! The operator can automatically instrument Kubernetes hosted applications.
   - Status: Instrumentation language maturity varies. See `operator.instrumentation.spec` and documentation for utilized instrumentation details.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
We do not plan to remove the option `clusterReceiver.evensEnabled` from our chart. This PR removes the warning a user sees when they enable this option.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
