### PR TITLE
[chore] configuration switching tests stabilisation

### DIFF
--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -239,13 +239,13 @@ func testClusterReceiverEnabledOrDisabled(t *testing.T) {
 	logsObjectsHecEndpoint := fmt.Sprintf("http://%s:%d/services/collector", hostEp, internal.HECObjectsReceiverPort)
 
 	t.Run("check cluster receiver disabled", func(t *testing.T) {
-		internal.ResetLogsSink(t, logsObjectsConsumer)
 		replacements := map[string]interface{}{
 			"ClusterReceiverEnabled": false,
 			"LogObjectsHecEndpoint":  logsObjectsHecEndpoint,
 		}
 		deployChartsAndApps(t, valuesFileName, replacements)
 		internal.WaitForTerminatingPods(t, clientset, internal.Namespace)
+		internal.ResetLogsSink(t, logsObjectsConsumer)
 		pods := listPodsInNamespace(t, internal.Namespace)
 		assert.Len(t, pods.Items, 1)
 		assert.True(t, strings.HasPrefix(pods.Items[0].Name, "sock-splunk-otel-collector-agent"))
@@ -253,7 +253,6 @@ func testClusterReceiverEnabledOrDisabled(t *testing.T) {
 	})
 
 	t.Run("check cluster receiver enabled", func(t *testing.T) {
-		internal.ResetLogsSink(t, logsObjectsConsumer)
 		replacements := map[string]interface{}{
 			"ClusterReceiverEnabled": true,
 			"LogObjectsHecEndpoint":  logsObjectsHecEndpoint,

--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -206,6 +206,8 @@ func testIndexSwitch(t *testing.T) {
 			"Sourcetype":           nonDefaultSourcetype,
 		}
 		deployChartsAndApps(t, valuesFileName, replacements)
+		internal.ResetMetricsSink(t, hecMetricsConsumer)
+		internal.ResetLogsSink(t, agentLogsConsumer)
 
 		internal.WaitForLogs(t, 3, agentLogsConsumer)
 		logs := agentLogsConsumer.AllLogs()
@@ -221,6 +223,13 @@ func testIndexSwitch(t *testing.T) {
 }
 
 func testClusterReceiverEnabledOrDisabled(t *testing.T) {
+	testKubeConfig, setKubeConfig := os.LookupEnv("KUBECONFIG")
+	require.True(t, setKubeConfig, "the environment variable KUBECONFIG must be set")
+	config, err := clientcmd.BuildConfigFromFlags("", testKubeConfig)
+	require.NoError(t, err)
+	clientset, err := kubernetes.NewForConfig(config)
+	require.NoError(t, err)
+
 	valuesFileName := "values_cluster_receiver_switching.yaml.tmpl"
 	logsObjectsConsumer := globalSinks.logsObjectsConsumer
 	hostEp := internal.HostEndpoint(t)
@@ -236,6 +245,7 @@ func testClusterReceiverEnabledOrDisabled(t *testing.T) {
 			"LogObjectsHecEndpoint":  logsObjectsHecEndpoint,
 		}
 		deployChartsAndApps(t, valuesFileName, replacements)
+		internal.WaitForTerminatingPods(t, clientset, internal.Namespace)
 		pods := listPodsInNamespace(t, internal.Namespace)
 		assert.Len(t, pods.Items, 1)
 		assert.True(t, strings.HasPrefix(pods.Items[0].Name, "sock-splunk-otel-collector-agent"))
@@ -249,6 +259,7 @@ func testClusterReceiverEnabledOrDisabled(t *testing.T) {
 			"LogObjectsHecEndpoint":  logsObjectsHecEndpoint,
 		}
 		deployChartsAndApps(t, valuesFileName, replacements)
+		internal.WaitForTerminatingPods(t, clientset, internal.Namespace)
 		internal.ResetLogsSink(t, logsObjectsConsumer)
 		pods := listPodsInNamespace(t, internal.Namespace)
 		assert.Len(t, pods.Items, 2)


### PR DESCRIPTION
**Description:** tests stabilisation changes, recent improvements shown some flakiness in configuration switching tests, this PR adds additional logic which makes tests more stable.
Changes are addressing recent failures observed for following tests: 

- Test_Functions/logs_and_metrics_index_switch/non_default_source_type
- Test_Functions/cluster_receiver_enabled_or_disabled/check_cluster_receiver_disabled

