### PR TITLE
Introduce image.otelcol.fips which set the appropriate repo/image and skips migrate-checkpoint if needed

### DIFF
--- a/.chloggen/fipsswitch.yaml
+++ b/.chloggen/fipsswitch.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: all
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Introduce a new option `image.otelcol.fips`, when set to true, it sets the appropriate repo/image and skips `migrate-checkpoint` when log is enabled
+# One or more tracking issues related to the change
+issues: [1756]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -210,7 +210,11 @@ Create the fluentd image name.
 Create the opentelemetry collector image name.
 */}}
 {{- define "splunk-otel-collector.image.otelcol" -}}
-{{- printf "%s:%s" .Values.image.otelcol.repository (.Values.image.otelcol.tag | default .Chart.AppVersion) -}}
+{{- if .Values.image.otelcol.fips -}}
+{{- printf "%s:%s" (.Values.image.otelcol.repository | default "quay.io/signalfx/splunk-otel-collector-fips" ) (.Values.image.otelcol.tag | default .Chart.AppVersion) -}}
+{{- else }}
+{{- printf "%s:%s" (.Values.image.otelcol.repository | default "quay.io/signalfx/splunk-otel-collector" ) (.Values.image.otelcol.tag | default .Chart.AppVersion) -}}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: fluentd-config-json
               mountPath: /fluentd/etc/json
         {{- else }}
-        {{- if not (eq .Values.distribution "gke/autopilot") }}
+        {{- if and (not (eq .Values.distribution "gke/autopilot")) (not .Values.image.otelcol.fips) }}
         - name: migrate-checkpoint
           image: {{ template "splunk-otel-collector.image.otelcol" . }}
           imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1111,6 +1111,10 @@
                 "Always",
                 "Never"
               ]
+            },
+            "fips": {
+              "description": "Use FIPS compliant image",
+              "type": "boolean"
             }
           }
         },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -970,14 +970,16 @@ image:
     pullPolicy: IfNotPresent
 
   otelcol:
-    # The registry and name of the opentelemetry collector image to pull
-    repository: quay.io/signalfx/splunk-otel-collector
-    # For the FIPS-140 enabled version, use this repository instead:
-    # repository: quay.io/signalfx/splunk-otel-collector-fips
+    # The non-default registry and name of the opentelemetry collector image to pull.
+    # Defaults to `quay.io/signalfx/splunk-otel-collector` when the fips option is not set or set to false
+    # and `quay.io/signalfx/splunk-otel-collector-fips` when the fips option is set to true
+    repository: ""
     # The tag of the Splunk OTel Collector image, default value is the chart appVersion
     tag: ""
     # The policy that specifies when the user wants the opentelemetry collector images to be pulled
     pullPolicy: IfNotPresent
+    # To enable FIPS-140, set fips to true
+    fips: false
 
   # Image to be used by init container that patches log directories on the host, so the collector can read from them as a non-root user.
   # Effective only if `agent.securityContext.runAsUser` and `agent.securityContext.runAsGroup` are set to non-zero values.


### PR DESCRIPTION
**Description:** 
FIPS images do not support [migratecheckpoint](https://github.com/signalfx/splunk-otel-collector/blob/5bac0670a4cfe1c7e6f361b028721c719aa378d7/packaging/docker-otelcol.sh#L73) to migrate checkpoints from fluentd when `logsEnabled` is set , this causes the pod to get into a crashloop.
```
create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/migratecheckpoint": stat /migratecheckpoint: no such file or directory: unknown
```

The fix introduces a new ` image.otelcol.fips` option, which will be used to set the default repo/image and skips `migratecheckpoint` init container if needed.

The default repo logic is moved into `splunk-otel-collector.image.otelcol` helper function so user can still set a custom repo if needed.