### PR TITLE
Don't hardcode the command in the pod specs

### DIFF
--- a/.chloggen/dont-hardcode-command.yaml
+++ b/.chloggen/dont-hardcode-command.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: all
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Don't hardcode the command in the pod specs
+# One or more tracking issues related to the change
+issues: [1758]

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -57,8 +57,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -39,8 +39,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         - --discovery
         ports:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -71,8 +71,7 @@ spec:
               name: collector-configmap
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/splunk-messages/config.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -124,8 +124,7 @@ spec:
         - name: tmp
           mountPath: /tmp
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -124,8 +124,7 @@ spec:
         - name: tmp
           mountPath: /tmp
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -54,10 +54,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - powershell.exe
-        - -command
-        - .\otelcol.exe
+        args:
         - --config=C:\\conf\relay.yaml
         ports:
         - name: fluentforward

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,10 +38,7 @@ spec:
           kubernetes.io/os: windows
       containers:
       - name: otel-collector
-        command:
-        - powershell.exe
-        - -command
-        - .\otelcol.exe
+        args:
         - --config=C:\\conf\relay.yaml
         image: quay.io/signalfx/splunk-otel-collector-windows:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -124,8 +124,7 @@ spec:
         - name: tmp
           mountPath: /tmp
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: otlp

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: otlp

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -56,8 +56,7 @@ spec:
       initContainers:
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: fluentforward

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -55,8 +55,7 @@ spec:
           operator: Exists
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         ports:
         - name: jaeger-grpc

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -38,8 +38,7 @@ spec:
           kubernetes.io/os: linux
       containers:
       - name: otel-collector
-        command:
-        - /otelcol
+        args:
         - --config=/conf/relay.yaml
         image: quay.io/signalfx/splunk-otel-collector:0.122.0
         imagePullPolicy: IfNotPresent

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -243,14 +243,15 @@ spec:
           mountPath: /tmp
       {{- end }}
       - name: otel-collector
+        {{- if (eq .Values.distribution "gke/autopilot") }}
         command:
+        - /otelcol
+        {{- else }}
+        args:
+        {{- end }}
         {{- if .Values.isWindows }}
-        - powershell.exe
-        - -command
-        - .\otelcol.exe
         - --config=C:\\conf\relay.yaml
         {{- else }}
-        - /otelcol
         - --config=/conf/relay.yaml
         {{- end }}
         {{- if .Values.agent.featureGates }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -111,19 +111,13 @@ spec:
       {{- end }}
       containers:
       - name: otel-collector
-        command:
+        args:
         {{- if .Values.isWindows }}
-        - powershell.exe
-        - -command
-        - .\otelcol.exe
         - --config=C:\\conf\relay.yaml
-        {{- else }}
-        - /otelcol
-        {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+        {{- else if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
         - --config=/splunk-messages/config.yaml
         {{- else }}
         - --config=/conf/relay.yaml
-        {{- end }}
         {{- end }}
         {{- if .Values.clusterReceiver.featureGates }}
         - --feature-gates={{ .Values.clusterReceiver.featureGates }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -68,14 +68,10 @@ spec:
       {{- end }}
       containers:
       - name: otel-collector
-        command:
+        args:
         {{- if .Values.isWindows }}
-        - powershell.exe
-        - -command
-        - .\otelcol.exe
         - --config=C:\\conf\relay.yaml
         {{- else }}
-        - /otelcol
         - --config=/conf/relay.yaml
         {{- end }}
         {{- if .Values.gateway.featureGates }}


### PR DESCRIPTION
Use the entrypoint defined in the image instead. This allows using the other images of the collector where the command is different, e.g. upstream core, k8s or contrib images.
