### PR TITLE
Remove smartagent/signalfx-forwarder from the agent default config

### DIFF
--- a/.chloggen/remove-signalfx-forwarder.yaml
+++ b/.chloggen/remove-signalfx-forwarder.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove smartagent/signalfx-forwarder from the agent default config.
+# One or more tracking issues related to the change
+issues: [1759]

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -413,9 +413,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -491,7 +488,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6098c69fc8e3ad39371a2ed7aa76b84a3dfb4791042ed8a92a5da361aa8c2492
+        checksum/config: 54ac9b3de88f99d7e59ad7212b223a6a498e96ac0771eb715d133349dd195035
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -78,10 +78,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/add-filter-processor/rendered_manifests/service-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -369,9 +369,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -441,7 +438,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e921a8575b47bf0fc91bfbc9121744e6a5b0141b0f29031a69166c8817cc1e62
+        checksum/config: bb16fc5c2fdd5e2d3b9c1938df2de4f26597ec71c3f65e95e14e421d982310cb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -78,10 +78,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/add-kafkametrics-receiver/rendered_manifests/service-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -259,9 +259,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -319,7 +316,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9c0dc72f436055b9f02bc0eb409f1cf1efd56fbeefcb76c17e1e31c6e7e388b5
+        checksum/config: a08cd5d0ee2cdbbf3308ab8d9481978b1564e0840b5c5409d4845d3368715bfa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/add-receiver-creator/rendered_manifests/service-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -247,9 +247,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -308,7 +305,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2b18ed28fb84a410466b04949467a8ece60e3b1243a0576602c6de8e4f8e0ec9
+        checksum/config: 9bb9c46a91bd347526999e29d2ed69e3952fd76179814d4b3f85dcf559ed8c6a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/add-sampler/rendered_manifests/service-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -405,9 +405,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -483,7 +480,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fca2adcca3a64aaf80b1de46d3ba18f945cd50542f9d290fec4c6b3425746f42
+        checksum/config: b8c42d555d22c971eda49ad0f7aea6cf23309bb521f4081291de5a7d95c0213d
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:
@@ -79,10 +79,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/autodetect-istio/rendered_manifests/service-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -244,9 +244,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -304,7 +301,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7eceb0e8ddc67f041710d414703023056c5bf84f5f76e3962ac721078ac644e3
+        checksum/config: c1d493f6d9b1565ec9b95c595a5a5cfb4791bb0eeb8025fa860eb497d46263a0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/collector-agent-only/rendered_manifests/service-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -226,9 +226,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -286,7 +283,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2be8d61fe570af949986706f8a636909be8274bbe89863dc4b237b24801ecb0f
+        checksum/config: c89d1ac7f54604f13a794f8d852eb714453336654efcb27abe38529adf2cd00d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/collector-all-modes/rendered_manifests/service-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -274,9 +274,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -344,7 +341,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c90cd6a297bd93edf1a133414c5d0dbc7f631ce464200c40ae410eb755b4d17f
+        checksum/config: c511d05b83450f6a5a5ab5e0f717b4e32a02e3cf2b395f2ac6b555ec0b03f09b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/controlplane-histogram-metrics/rendered_manifests/service-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -244,9 +244,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -304,7 +301,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7eceb0e8ddc67f041710d414703023056c5bf84f5f76e3962ac721078ac644e3
+        checksum/config: c1d493f6d9b1565ec9b95c595a5a5cfb4791bb0eeb8025fa860eb497d46263a0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/crio-logging/rendered_manifests/service-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -244,9 +244,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -304,7 +301,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7eceb0e8ddc67f041710d414703023056c5bf84f5f76e3962ac721078ac644e3
+        checksum/config: c1d493f6d9b1565ec9b95c595a5a5cfb4791bb0eeb8025fa860eb497d46263a0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/default/rendered_manifests/service-agent.yaml
+++ b/examples/default/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -79,10 +79,6 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
-          protocol: TCP
         - name: signalfx
           containerPort: 9943
           hostPort: 9943

--- a/examples/disable-persistence-queue-traces/rendered_manifests/service-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -244,9 +244,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -304,7 +301,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e6046be20479ec86180e7c9dbb5ede3643f5aac05851b1c7f9daaffcd3f7c751
+        checksum/config: fb102307b42900137ab7274f088e3d27325f536c3fd0feadd21fe401937a62b8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -74,10 +74,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/discovery-mode/rendered_manifests/service-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -202,9 +202,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -262,7 +259,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6f403ecb916a336bfe4096fdcb07794b555bcab7198080913cf6d6930d8b0460
+        checksum/config: 195641a8097404e79fff5f4b46eaed93e9ff38862418e71d2c9849acadcad1e1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/distribution-aks/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -202,9 +202,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -262,7 +259,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c96366d1319033379da0ddc872074dcf38a314e4c1dd1cd2e8fe5edd86a8248a
+        checksum/config: d66e2f2cc8d253f25131ffa8fbb8f5ed0f9f547998323528f16ebd70973d023e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/distribution-eks/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -201,9 +201,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -261,7 +258,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1d31ce0ca559919ea0715ef8e91c195658db6f7fe49a59cf512c484395c8b5c6
+        checksum/config: 73ee4adccc8ff7d3ef183d71a17607cec67c527b8af0f196a9b4e689533453c5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/distribution-gke-autopilot/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -201,9 +201,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -261,7 +258,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2e0dd41859ea9246f5b2357e6963b057a3f33747c8efdec23a167cbd681068d5
+        checksum/config: 31d455a8d753c59a2eff6fed16469a5f528395b250bc8984ea6f16752b98fa4e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/distribution-gke/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -252,9 +252,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -312,7 +309,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 27ae506d874e6f3dd22318daeb5a82e145c2dbe115ec3f8b97357610acf7d897
+        checksum/config: f1e9009d318172ce519691f0473fa257b2d335103f6bb27fb420374cddfbf262
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/distribution-openshift/rendered_manifests/service-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -367,9 +367,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -445,7 +442,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3cdd807b65f922aa3b02a6817b4087575c0cb6b128622db1b0f16eec79c0f941
+        checksum/config: 9e9fe5169abad67888000c09aa130cb5dc25fe51867220ef3d3b449e31a2bc3c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -78,10 +78,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/service-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -79,10 +79,6 @@ spec:
         - name: otlp-http
           containerPort: 4318
           protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
-          protocol: TCP
         - name: signalfx
           containerPort: 9943
           hostPort: 9943

--- a/examples/enable-persistence-queue/rendered_manifests/service-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -171,9 +171,6 @@ data:
             static_configs:
             - targets:
               - localhost:8889
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -217,7 +214,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ed03dd1a4274edbe22e9d667834bb1fc7a2b074b82d060a30cc6e2b4fc0cab88
+        checksum/config: be9ed3ebb00b3d0f0f01ea4be9556dae7548e0a03ff9c349c33175a4a8ce127f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: zipkin
           containerPort: 9411

--- a/examples/enable-trace-sampling/rendered_manifests/service-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: zipkin
     port: 9411
     targetPort: zipkin

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -245,9 +245,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -306,7 +303,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d5125e76f80823365a4d0161e4905c885ab3b8965485727726214c979bcb34ec
+        checksum/config: 9001b49932e353eebb79d342d696412f32b55a1676581129729500cbf6af66d3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/enabled-pprof-extension/rendered_manifests/service-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -262,9 +262,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -337,7 +334,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c76bf717920b86c3735208fb9ff926054c5c2deb08b3ab6092ccdd1b1e50e38f
+        checksum/config: ec08a44b0ecc07b01d1462feab4b912aad50411e38ea269c54b491d8d8287d1a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -146,10 +146,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/service-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -262,9 +262,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -337,7 +334,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 87cfb39705d2801373839521444f1eaf06b23518068d3829580fcf16312d13fe
+        checksum/config: 6e18c55118fe9767f825d7894db166b3501d4278abcff2c787c9bca2a40f8f23
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -146,10 +146,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/fluentd-refresh-interval/rendered_manifests/service-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -366,9 +366,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -443,7 +440,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 95bfc3521685c7c14d79721947e91ea6e1620ddddfbd866fba969978f52e9e24
+        checksum/config: bb1ecc409b253fd53cb3b9bcefcc2f54a9d48e490d05fa0fd4471cda1197ab21
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet
@@ -78,10 +78,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/kubernetes-windows-nodes/rendered_manifests/service-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/service-agent.yaml
@@ -40,10 +40,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -168,9 +168,6 @@ data:
             static_configs:
             - targets:
               - localhost:8889
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -213,7 +210,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5017f125077aa486c9487a01c1c214a92548ffa299deab53fad56c83c1e34b6c
+        checksum/config: 4c497c7b47aa050505cdbf412d1dcc637db21f8e362f771891d30c8309eb1e40
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: zipkin
           containerPort: 9411

--- a/examples/only-traces/rendered_manifests/service-agent.yaml
+++ b/examples/only-traces/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: zipkin
     port: 9411
     targetPort: zipkin

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -248,9 +248,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -311,7 +308,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ff2706453ccd2470cdfecec0d7242fbc4c85b19286ca896d616adf6e4a5bb75c
+        checksum/config: 546ee59b9915b101317c6856c50eda88adcf31ea09e4a61a293194dde3488510
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/service-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -252,9 +252,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -312,7 +309,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 94588988d6ee5a9e1dc2e19123f89b6436a44108506d7cc3cdf909ea2f99c760
+        checksum/config: 62557e7211f84ff30d3f3584351e935210d1533f6e2bbd170691ad42daaa113e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/target-allocator/rendered_manifests/service-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -244,9 +244,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -304,7 +301,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7eceb0e8ddc67f041710d414703023056c5bf84f5f76e3962ac721078ac644e3
+        checksum/config: c1d493f6d9b1565ec9b95c595a5a5cfb4791bb0eeb8025fa860eb497d46263a0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/use-proxy/rendered_manifests/service-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -252,9 +252,6 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      smartagent/signalfx-forwarder:
-        listenAddress: 0.0.0.0:9080
-        type: signalfx-forwarder
       zipkin:
         endpoint: 0.0.0.0:9411
     service:
@@ -313,7 +310,6 @@ data:
           receivers:
           - otlp
           - jaeger
-          - smartagent/signalfx-forwarder
           - zipkin
       telemetry:
         metrics:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7fe15deb7113a47be88f2105e8ee27501a102a32a25682c07bba870d58c1ae28
+        checksum/config: baf1630e46b3beff7999f688b76fcef06dd9b5a8f81376a65eefebfc8f3b2eb9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -73,10 +73,6 @@ spec:
           protocol: TCP
         - name: otlp-http
           containerPort: 4318
-          protocol: TCP
-        - name: sfx-forwarder
-          containerPort: 9080
-          hostPort: 9080
           protocol: TCP
         - name: signalfx
           containerPort: 9943

--- a/examples/with-target-allocator/rendered_manifests/service-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/service-agent.yaml
@@ -36,10 +36,6 @@ spec:
     port: 4318
     targetPort: otlp-http
     protocol: TCP
-  - name: sfx-forwarder
-    port: 9080
-    targetPort: sfx-forwarder
-    protocol: TCP
   - name: signalfx
     port: 9943
     targetPort: signalfx

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -392,12 +392,6 @@ receivers:
     endpoint: 0.0.0.0:9943
   {{- end }}
 
-  {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" .) "true") }}
-  smartagent/signalfx-forwarder:
-    type: signalfx-forwarder
-    listenAddress: 0.0.0.0:9080
-  {{- end }}
-
   {{- if .Values.targetAllocator.enabled  }}
   prometheus/ta:
     config:
@@ -1008,9 +1002,6 @@ service:
       receivers:
         - otlp
         - jaeger
-        {{- if (eq (include "splunk-otel-collector.o11yTracesEnabled" $) "true") }}
-        - smartagent/signalfx-forwarder
-        {{- end }}
         - zipkin
       processors:
         - memory_limiter

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -363,11 +363,6 @@ agent:
       containerPort: 4318
       protocol: TCP
       enabled_for: [metrics, traces, logs, profiling]
-    sfx-forwarder:
-      containerPort: 9080
-      hostPort: 9080
-      protocol: TCP
-      enabled_for: [traces]
     zipkin:
       containerPort: 9411
       hostPort: 9411


### PR DESCRIPTION
The old SignalFx instrumentation libraries are not supported anymore. So we don't need to keep the forwarder in the default config. Use Splunk OpenTelemetry instrumentation libraries to send traces in OTLP format instead.

If you need to keep the receiver for longer, add the following section to your values.yaml file:
```yaml
agent:
  ports:
    sfx-forwarder:
      containerPort: 9080
      hostPort: 9080
      protocol: TCP
      enabled_for: [traces]
  config:
    receivers:
      smartagent/signalfx-forwarder:
        listenAddress: 0.0.0.0:9080
        type: signalfx-forwarder
    service:
      pipelines:
        traces:
          receivers:
            - otlp
            - jaeger
            - smartagent/signalfx-forwarder
            - zipkin
```