### PR TITLE
allow control plane metrics from all distro

### DIFF
--- a/.chloggen/controlplaneMetrics.yaml
+++ b/.chloggen/controlplaneMetrics.yaml
@@ -1,0 +1,23 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow featureGates.useControlPlaneMetricsHistogramData to work with any distribution of k8s cluster.
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Users can enable agent.controlPlaneMetrics for k8s components which run on worker nodes
+  such as kubedns (gke), coredns (aks, eks) and kube-proxy (eks) with the feature gate
+  featureGates.useControlPlaneMetricsHistogramData set to true.
+  To disable collection of metrics from specific control plane components, set the corresponding
+  component to false in the agent.controlPlaneMetrics configuration. For example:
+  agent:
+    controlPlaneMetrics:
+      coredns:
+        enabled: false
+      proxy:
+        enabled: false

--- a/.chloggen/controlplaneMetrics.yaml
+++ b/.chloggen/controlplaneMetrics.yaml
@@ -5,7 +5,7 @@ component: agent
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Allow featureGates.useControlPlaneMetricsHistogramData to work with any distribution of k8s cluster.
 # One or more tracking issues related to the change
-issues: []
+issues: [1760]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -311,6 +311,8 @@ agent:
       enabled: true
     coredns:
       # Specifies whether to collect coredns metrics.
+      # Note - when using GKE, and this is enabled, the chart will create a
+      # receiver for kubedns instead of coredns.
       enabled: true
     etcd:
       # Specifies whether to collect etcd metrics.
@@ -344,6 +346,8 @@ agent:
       skipVerify: true
     proxy:
       # Specifies whether to collect proxy metrics.
+      # Note - the prometheus receiver introduced for this component might match
+      # kube-proxy deployed in managed k8s cluster like EKS.
       enabled: true
     scheduler:
       # Specifies whether to collect scheduler metrics.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This PR introduces support for receiver_creator configuration for control plane components across any distribution of Kubernetes clusters. This functionality is applicable when both featureGates.useControlPlaneMetricsHistogramData and the relevant components in agent.controlPlaneMetrics are set to true.

I tested these configs in EKS, AKS and GKE clusters and have a few findings -

1. EKS - coredns and kube-proxy, both receiver's rules match, and so if `featureGates.useControlPlaneMetricsHistogramData=true` the agent will collect metrics for both these components.
2. AKS - coredns rule matches AKS' coredns addon in the cluster but kube-proxy rule does not. The rule can be updated to match these by matching for `labels["component"] == "kube-proxy"`.
3. GKE - the default dns addon in GKE is not coredns. For `distribution = gke`, the receiver_creator config will include a `prometheus/kubedns` receiver which matches GKE's default kubedns addon pods. Another thing to note, kube-proxy rule which matches AKS also matches GKE but, I didn't find an exposed metric port for these.

Given the above findings and inconsistencies across managed clusters, I wonder if we want to proceed with enabling all control plane receivers? Should we include only the DNS receivers (coredns and kubedns) instead? 

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
