### PR TITLE
Add useMemoryLimitPercentage feature gate

### DIFF
--- a/.chloggen/useMemoryLimitPercentage-fg.yaml
+++ b/.chloggen/useMemoryLimitPercentage-fg.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: all
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add useMemoryLimitPercentage feature gate
+# One or more tracking issues related to the change
+issues: [1761]

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -228,10 +228,10 @@ Create the validateSecret image name.
 {{- end -}}
 
 {{/*
-  This helper converts the input value of memory to MiB.
+  This helper converts the input value of memory to Bytes.
   Input needs to be a valid value as supported by k8s memory resource field.
  */}}
-{{- define "splunk-otel-collector.convertMemToMib" }}
+{{- define "splunk-otel-collector.convertMemToBytes" }}
 {{- $mem := lower . -}}
 {{- if hasSuffix "e" $mem -}}
 {{- $mem = mulf (trimSuffix "e" $mem | float64) 1e18 -}}
@@ -258,7 +258,15 @@ Create the validateSecret image name.
 {{- else if hasSuffix "ki" $mem -}}
 {{- $mem = mulf (trimSuffix "ki" $mem | float64) 0x1p10 -}}
 {{- end }}
-{{- divf $mem 0x1p20 | floor -}}
+{{- $mem }}
+{{- end }}
+
+{{/*
+  This helper converts the input value of memory to MiB.
+  Input needs to be a valid value as supported by k8s memory resource field.
+ */}}
+{{- define "splunk-otel-collector.convertMemToMib" }}
+{{- divf (include "splunk-otel-collector.convertMemToBytes" .) 0x1p20 | floor -}}
 {{- end }}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -6,7 +6,11 @@ memory_limiter:
   # check_interval is the time between measurements of memory usage.
   check_interval: 2s
   # By default limit_mib is set to 90% of container memory limit
+  {{- if .Values.featureGates.useMemoryLimitPercentage }}
+  limit_percentage: 90
+  {{- else }}
   limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
+  {{- end }}
 {{- end }}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -274,8 +274,13 @@ spec:
           {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $agent.securityContext "setRunAsUser" true) | nindent 10 }}
         {{- end }}
         env:
+          {{- if .Values.featureGates.useMemoryLimitPercentage }}
+          - name: GOMEMLIMIT
+            value: "{{ include "splunk-otel-collector.convertMemToBytes" $agent.resources.limits.memory | int64 }}"
+          {{- else }}
           - name: SPLUNK_MEMORY_TOTAL_MIB
             value: "{{ include "splunk-otel-collector.convertMemToMib" $agent.resources.limits.memory | int64 }}"
+          {{- end }}
           - name: K8S_NODE_NAME
             valueFrom:
               fieldRef:

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -129,8 +129,13 @@ spec:
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:
+          {{- if .Values.featureGates.useMemoryLimitPercentage }}
+          - name: GOMEMLIMIT
+            value: "{{ include "splunk-otel-collector.convertMemToBytes" $clusterReceiver.resources.limits.memory | int64 }}"
+          {{- else }}
           - name: SPLUNK_MEMORY_TOTAL_MIB
             value: "{{ include "splunk-otel-collector.convertMemToMib" $clusterReceiver.resources.limits.memory | int64 }}"
+          {{- end }}
           - name: K8S_NODE_NAME
             valueFrom:
               fieldRef:

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -84,8 +84,13 @@ spec:
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
         env:
+          {{- if .Values.featureGates.useMemoryLimitPercentage }}
+          - name: GOMEMLIMIT
+            value: "{{ include "splunk-otel-collector.convertMemToBytes" $gateway.resources.limits.memory | int64 }}"
+          {{- else }}
           - name: SPLUNK_MEMORY_TOTAL_MIB
             value: "{{ include "splunk-otel-collector.convertMemToMib" $gateway.resources.limits.memory | int64 }}"
+          {{- end }}
           - name: K8S_NODE_NAME
             valueFrom:
               fieldRef:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1406,3 +1406,6 @@ featureGates:
   # The feature gate provides a fix for a scenario where some logs might be missed due to the pod log file being
   # rolled over during high load.
   fixMissedLogsDuringLogRotation: false
+  # The feature gate enables the use of the memory_limiter processor based on the percentage.
+  # It is required if the helm chart is used with another collector image from upstream.
+  useMemoryLimitPercentage: false


### PR DESCRIPTION
Add `useMemoryLimitPercentage` feature gate that enables the use of the memory_limiter processor based on the percentage. It is required if the helm chart is used with another collector image from upstream.
