### PR TITLE
deprecation of certmanager as a dependency

### DIFF
--- a/.chloggen/deprecate-certmanager.yaml
+++ b/.chloggen/deprecate-certmanager.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Installing certmanager as part of the splunk-otel-collector helm chart is deprecated and will be removed in a future release.
+# One or more tracking issues related to the change
+issues: [1763]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -34,14 +34,14 @@ these frameworks often have pre-built instrumentation capabilities already avail
 - **TLS Certificate Management (Required)**
   - **Automatically Generate a Self-Signed Certificate with Helm (Recommended)**
     - `operator.admissionWebhooks.autoGenerateCert.enabled`: Set to `true` to enable Helm to automatically create a self-signed certificate.
-      - **Use Case**: Suitable when cert-manager is not installed or preferred.
+      - **Use Case**: Suitable when cert-manager is not already installed.
 
   - **Alternative Methods**
 
-    - **Using cert-manager (Deprecated)**
-      - `certmanager.enabled`: Enable cert-manager by setting to `true`.
-        - **Check Before Enabling**: Ensure cert-manager is not already installed to avoid multiple instances.
-        - **Recommended**: Cert-manager simplifies the management of TLS certificates, automating issuance and renewal.
+    - **Using cert-manager**
+      -  Use an already installed certmanager by setting `operator.admissionWebhooks.certManager.enabled` to `true`.
+        -  **Use Case**: Ideal for environments already leveraging `certmanager` for certificate management.
+      -  _NOTE_ - The option to install `certmanager` with our chart is deprecated and will be removed in future releases.
 
     - **Provide Your Own Certificate**
       - Ensure both `operator.admissionWebhooks.certManager.enabled` and `operator.admissionWebhooks.autoGenerateCert.enabled` are set to `false`.

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -32,15 +32,17 @@ these frameworks often have pre-built instrumentation capabilities already avail
     - **Required**: This configuration is necessary for the operator's deployment within your cluster.
 
 - **TLS Certificate Management (Required)**
-  - **Using cert-manager (Recommended)**
-    - `certmanager.enabled`: Enable cert-manager by setting to `true`.
-      - **Check Before Enabling**: Ensure cert-manager is not already installed to avoid multiple instances.
-      - **Recommended**: Cert-manager simplifies the management of TLS certificates, automating issuance and renewal.
+  - **Automatically Generate a Self-Signed Certificate with Helm (Recommended)**
+    - `operator.admissionWebhooks.autoGenerateCert.enabled`: Set to `true` to enable Helm to automatically create a self-signed certificate.
+      - **Use Case**: Suitable when cert-manager is not installed or preferred.
 
   - **Alternative Methods**
-    - **Automatically Generate a Self-Signed Certificate with Helm**
-      - `operator.admissionWebhooks.autoGenerateCert.enabled`: Set to `true` to enable Helm to automatically create a self-signed certificate.
-        - **Use Case**: Suitable when cert-manager is not installed or preferred.
+
+    - **Using cert-manager (Deprecated)**
+      - `certmanager.enabled`: Enable cert-manager by setting to `true`.
+        - **Check Before Enabling**: Ensure cert-manager is not already installed to avoid multiple instances.
+        - **Recommended**: Cert-manager simplifies the management of TLS certificates, automating issuance and renewal.
+
     - **Provide Your Own Certificate**
       - Ensure both `operator.admissionWebhooks.certManager.enabled` and `operator.admissionWebhooks.autoGenerateCert.enabled` are set to `false`.
       - `operator.admissionWebhooks.cert_file`: Path to your PEM-encoded certificate.
@@ -502,7 +504,7 @@ operator:
       enabled: true
 ```
 
-##### Option 2: **Deploy cert-manager and the operator together**
+##### Option 2: **Deploy cert-manager and the operator together (Deprecated)**
 
 If you need to install `cert-manager` along with the operator, use a Helm post-install or post-upgrade hook to ensure that the certificate is created after cert-manager CRDs are installed.
 

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -32,7 +32,7 @@ these frameworks often have pre-built instrumentation capabilities already avail
     - **Required**: This configuration is necessary for the operator's deployment within your cluster.
 
 - **TLS Certificate Management (Required)**
-  - **Automatically Generate a Self-Signed Certificate with Helm (Recommended)**
+  - **Automatically Generate a Self-Signed Certificate with Helm (Default)**
     - `operator.admissionWebhooks.autoGenerateCert.enabled`: Set to `true` to enable Helm to automatically create a self-signed certificate.
       - **Use Case**: Suitable when cert-manager is not already installed.
 

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -34,7 +34,6 @@ these frameworks often have pre-built instrumentation capabilities already avail
 - **TLS Certificate Management (Required)**
   - **Automatically Generate a Self-Signed Certificate with Helm (Default)**
     - `operator.admissionWebhooks.autoGenerateCert.enabled`: Set to `true` to enable Helm to automatically create a self-signed certificate.
-      - **Use Case**: Suitable when cert-manager is not already installed.
 
   - **Alternative Methods**
 

--- a/docs/auto-instrumentation-introduction.md
+++ b/docs/auto-instrumentation-introduction.md
@@ -34,7 +34,7 @@ When using the Splunk OTel Collector chart with the [OpenTelemetry Operator](htt
 ### Quick Start
 To use auto-instrumentation via the operator, these are the high-level steps:
 
-1. Deploy OpenTelemetry components to your Kubernetes cluster including cert-manager, Splunk OTel Collector, OpenTelemetry Operator, and Auto-Instrumentation Spec.
+1. Deploy OpenTelemetry components to your Kubernetes cluster including Splunk OTel Collector, OpenTelemetry Operator, and Auto-Instrumentation Spec.
 2. Apply annotations at the pod or namespace level for the Operator to know which pods to apply auto-instrumentation to.
 3. Now, allow the Operator to do the work. As Kuberenetes api requests for create and update annotated pods are processed, the Operator will intercept and alter those requests so that the internal pod application containers are instrumented.
 

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1809,8 +1809,9 @@
       }
     },
     "certmanager": {
-      "description": "cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.",
+      "description": "[Deprecated] cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.",
       "type": "object",
+      "deprecated": true,
       "additionalProperties": true
     },
     "cert-manager": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1335,6 +1335,9 @@ instrumentation:
     #     value: nginx_value
   # Auto-instrumentation Libraries (End)
 
+# Note - Installing certmanager as a subchart is deprecated and will be removed in the future.
+# The recommended approach is to use the chart's default of generating self-signed cert or
+# to install cert-manager separately.
 # The cert-manager is a CNCF application deployed as a subchart and used for supporting operators that require TLS certificates.
 # Full list of Helm value configurations: https://artifacthub.io/packages/helm/cert-manager/cert-manager?modal=values
 certmanager:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Officially deprecate the option to install certmanager as part of the Splunk Otel Collector helm chart.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
