### PR TITLE
[chore] removing certmanager dependency update workflow

### DIFF
--- a/.github/workflows/update_chart_dependencies.yaml
+++ b/.github/workflows/update_chart_dependencies.yaml
@@ -27,10 +27,6 @@ jobs:
       matrix:
         # Chart dependencies to check for version updates
         include:
-          - name: 'certmanager'
-            component: 'operator'
-            yaml_file_path: 'helm-charts/splunk-otel-collector/Chart.yaml'
-            dependency_name: 'cert-manager'
           - name: 'operator'
             component: 'operator'
             yaml_file_path: 'helm-charts/splunk-otel-collector/Chart.yaml'


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
With certmanager as subchart deprecated, removing the workflow which keeps up with new releases of this deprecated dependency.

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
