### PR TITLE
[chore] Update workflow to include CRDs

### DIFF
--- a/.github/workflows/update_chart_dependencies.yaml
+++ b/.github/workflows/update_chart_dependencies.yaml
@@ -43,6 +43,11 @@ jobs:
 
           make update-chart-dep CHART_PATH=${{ matrix.yaml_file_path }} SUBCHART_NAME='${{ matrix.dependency_name }}' DEBUG_MODE=$DEBUG_MODE
 
+      - name: Check for Operator CRD Updates
+        if: ${{ matrix.name == 'operator' }}
+        run: |
+          make update-crds DEBUG_MODE=$DEBUG_MODE
+
       - name: Install Skopeo
         run: |
           sudo apt-get update
@@ -69,6 +74,15 @@ jobs:
           make update-chart-dep CHART_PATH=${{ matrix.yaml_file_path }} SUBCHART_NAME='${{ matrix.dependency_name }}' DEBUG_MODE=$DEBUG_MODE
           make render
           make chlog-new FILENAME="update-${{ matrix.name }}" CHANGE_TYPE=enhancement COMPONENT=${{ matrix.component }} NOTE="Bump ${{ matrix.name }} to ${{ steps.check_for_update.outputs.LATEST_VER }} in ${{ matrix.yaml_file_path }}" ISSUES=[${{ steps.open_pr.outputs.pull-request-number }}]
+
+      - name: Operator CRDs update
+        env:
+          COMPONENT: opentelemetry-operator-crds
+        if: ${{ steps.check_for_update.outputs.CRDS_NEED_UPDATE == 1 }}
+        run: |
+          make update-operator-crds DEBUG_MODE=$DEBUG_MODE
+          make render
+          make chlog-new FILENAME="update-operator-crds" CHANGE_TYPE=enhancement COMPONENT=$COMPONENT NOTE="Bump subchart $COMPONENT to ${{ steps.check_for_update.outputs.CRDS_LATEST_VER }}" ISSUES=[${{ steps.open_pr.outputs.pull-request-number }}]
 
       - name: Finalize PR with updates
         if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 }}

--- a/Makefile
+++ b/Makefile
@@ -217,3 +217,7 @@ tidy-all:
 		echo "Running go mod tidy in $$dir"; \
 		(cd "$$dir" && rm -f go.sum && go mod tidy); \
 	done
+
+.PHONY: update-operator-crds
+update-operator-crds: ## Update CRDs in the opentelemetry-operator-crds subchart
+	ci_scripts/update-crds.sh

--- a/ci_scripts/update-crds.sh
+++ b/ci_scripts/update-crds.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Purpose: Updates CRDs for the OpenTelemetry Operator in the opentelemetry-operator-crds subchart
+# The script compares the current CRDs with those found in the appVersion of the Opentelemetry Operator
+# we are using as dependency. If they differ, it updates the CRDs in the opentelemetry-operator-crds subchart.
+
+# Include the base utility functions for setting and debugging variables
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}/base_util.sh"
+
+# Initialize directories and paths
+setd "ROOT_DIR" "${SCRIPT_DIR}/../"
+setd "COLLECTOR_CHART_DIR" "${ROOT_DIR}/helm-charts/splunk-otel-collector"
+setd "CRD_CHART_DIR" "${COLLECTOR_CHART_DIR}/charts/opentelemetry-operator-crds"
+setd "CRD_DIR" "${CRD_CHART_DIR}/crds"
+setd "CRD_CHART_FILE" "${CRD_CHART_DIR}/Chart.yaml"
+setd "OTEL_OPERATOR_REPO" "https://github.com/open-telemetry/opentelemetry-operator.git"
+setd "TEMP_DIR" "$(mktemp -d)"
+
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Function: get_operator_app_version
+# Description: Retrieves the app version of the OpenTelemetry operator dependency
+get_operator_app_version() {
+    debug "Retrieving OpenTelemetry operator version"
+
+    local operator_version
+    local operator_repo
+
+    operator_version=$(yq eval '.dependencies[] | select(.name == "opentelemetry-operator") | .version' "${COLLECTOR_CHART_DIR}/Chart.yaml")
+    operator_repo=$(yq eval '.dependencies[] | select(.name == "opentelemetry-operator") | .repository' "${COLLECTOR_CHART_DIR}/Chart.yaml")
+
+    debug "Pulling OpenTelemetry operator Helm chart version ${operator_version}"
+    helm pull opentelemetry-operator --version "$operator_version" --repo "$operator_repo" --untar --untardir "$TEMP_DIR/chart"
+
+    local app_version
+    app_version=$(yq eval '.appVersion' "$TEMP_DIR/chart/opentelemetry-operator/Chart.yaml")
+
+    echo "$app_version"
+}
+
+# Function: bump_patch_version
+# Description: Bumps the patch version of the CRDs chart and updates the dependency in the collector chart.
+bump_patch_version() {
+    local current_version
+    current_version=$(yq eval '.version' "$CRD_CHART_FILE")
+    debug "Current CRDs chart version: $current_version"
+
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$current_version"
+    patch=$((patch + 1))
+    local new_version="${major}.${minor}.${patch}"
+
+    yq eval ".version = \"$new_version\"" -i "$CRD_CHART_FILE"
+    echo "CRDs chart version bumped to $new_version"
+
+    yq eval "(.dependencies[] | select(.name == \"opentelemetry-operator-crds\") | .version) = \"$new_version\"" -i "${COLLECTOR_CHART_DIR}/Chart.yaml"
+    echo "Updated CRDs chart version in chart dependencies to $new_version"
+}
+
+# Function: update_crds
+# Description: Updates the OpenTelemetry CRDs if there are changes
+update_crds() {
+    local latest_version
+    latest_version=$(get_operator_app_version)
+    setd "LATEST_VERSION" "$latest_version"
+    echo "OpenTelemetry operator app version: $latest_version"
+
+    debug "Cloning OpenTelemetry Operator repository..."
+    git config --global advice.detachedHead false  # Suppress detached HEAD warnings
+    git clone --quiet --depth 1 --branch "v${latest_version}" ${OTEL_OPERATOR_REPO} ${TEMP_DIR}/opentelemetry-operator || {
+        echo "Error: Failed to clone OpenTelemetry Operator repository."
+        exit 1
+    }
+
+    mkdir -p "${CRD_DIR}"
+    cp ${TEMP_DIR}/opentelemetry-operator/config/crd/bases/*.yaml "${CRD_DIR}/" 2>/dev/null
+
+    if git diff --quiet -- "${CRD_DIR}"; then
+        echo "No CRD updates detected. CRDs are already up to date."
+        setd "CRDS_NEED_UPDATE" 0
+    else
+        echo "CRD updates detected for OpenTelemetry Operator."
+        setd "CRDS_NEED_UPDATE" 1
+        bump_patch_version
+    fi
+
+    setd "CRDS_LATEST_VERSION" "$(yq eval '.version' "$CRD_CHART_FILE")"
+    emit_output "CRDS_NEED_UPDATE"
+    emit_output "CRDS_LATEST_VERSION"
+}
+
+update_crds


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The current workflow which updates the opentelemetry-operator version in our helm chart does not check for updates to CRDs. This PR introduces steps to check for CRD updates corresponding the operator app version we are pulling in during the opentelemetry-operator version update. This makes certain that our opentelemetry-operator-crds subchart is kept in sync.
The workflow will also bump up the patch version of the crds subchart when changes are made. The subchart CRD changes are NOT applied by helm on an upgrade. The explicit version bump is to improve visibility for users that CRDs have changed and they'd want to upgrade the same in their clusters outside of helm.  

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
