### PR TITLE
[chore] add logic to update our tests k8s versions

### DIFF
--- a/.github/workflows/update_k8s_versions.yaml
+++ b/.github/workflows/update_k8s_versions.yaml
@@ -1,0 +1,47 @@
+name: Check for new matrix versions and update tests if needed
+
+on:
+  schedule:
+    # Run every Monday at noon.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+    inputs:
+      DEBUG_ARGUMENT:
+        description: 'Enable debug by setting -debug to true'
+        required: false
+        default: '-debug=false'
+
+jobs:
+  check_and_update:
+    runs-on: ubuntu-latest
+    env:
+      DEBUG: ${{ github.event.inputs.DEBUG_ARGUMENT }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for new matrix versions
+        id: check_for_update
+        run: |
+          echo "Checking for new matrix versions"
+          make update-matrix-versions DEBUG=$DEBUG
+
+      - name: check for changes
+        id: git-check
+        run: |
+          if git diff --quiet; then
+            echo "No changes detected, exiting workflow successfully"
+            exit 0
+          fi
+          echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Open PR for matrix version update
+        if: steps.git-check.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Update matrix test versions
+          title: Update matrix versions used for testing
+          body: Use latest supported matrix versions
+          branch: update-matrix-test-versions
+          base: main
+          delete-branch: true

--- a/Makefile
+++ b/Makefile
@@ -257,3 +257,7 @@ gogci-all:
 .PHONY: gomoddownload
 gomoddownload:
 	@$(MAKE) for-all-target TARGET="moddownload"
+
+.PHONY: update-matrix-versions
+update-matrix-versions: ## Update matrix, ex: K8s cluster versions used for testing. Set DEBUG=-debug to enable debug logs.
+	go run ./tools/k8s_versions/update_k8s_versions.go $(DEBUG)

--- a/tools/k8s_versions/Makefile
+++ b/tools/k8s_versions/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.common

--- a/tools/k8s_versions/go.mod
+++ b/tools/k8s_versions/go.mod
@@ -1,0 +1,11 @@
+module k8sVersions
+
+go 1.24.1
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/tools/k8s_versions/go.sum
+++ b/tools/k8s_versions/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tools/k8s_versions/update_k8s_versions.go
+++ b/tools/k8s_versions/update_k8s_versions.go
@@ -1,0 +1,288 @@
+// Copyright Splunk Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var debug bool
+
+const (
+	EndOfLifeURL        string = "https://endoflife.date/api/kubernetes.json"
+	KindDockerHubURL    string = "https://hub.docker.com/v2/repositories/kindest/node/tags?page_size=1&page=1&ordering=last_updated&name="
+	MiniKubeURL         string = "https://raw.githubusercontent.com/kubernetes/minikube/master/pkg/minikube/constants/constants_kubernetes_versions.go"
+	KubeKindVersion     string = "k8s-kind-version"
+	KubeMinikubeVersion string = "k8s-minikube-version"
+)
+
+type KubernetesVersion struct {
+	Cycle       string `json:"cycle"`
+	ReleaseDate string `json:"releaseDate"`
+	EOLDate     string `json:"eol"`
+	Latest      string `json:"latest"`
+}
+
+type DockerImage struct {
+	Count int `json:"count"`
+}
+
+// getSupportedKubernetesVersions returns the supported Kubernetes versions
+// by checking the EOL date of the collected versions.
+func getSupportedKubernetesVersions(url string) ([]KubernetesVersion, error) {
+	body, err := getRequestBody(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get k8s versions: %w", err)
+	}
+	var kubernetesVersions, supportedKubernetesVersions []KubernetesVersion
+	if err = json.Unmarshal(body, &kubernetesVersions); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	now := time.Now()
+	for _, kubernetesVersion := range kubernetesVersions {
+		eolDate, parseErr := time.Parse(time.DateOnly, kubernetesVersion.EOLDate)
+		if parseErr != nil {
+			return nil, fmt.Errorf("error parsing date: %w", parseErr)
+		}
+		if eolDate.After(now) {
+			supportedKubernetesVersions = append(supportedKubernetesVersions, kubernetesVersion)
+		} else {
+			logDebug("Skipping version %s, EOL date %s", kubernetesVersion.Cycle, kubernetesVersion.EOLDate)
+		}
+	}
+	return supportedKubernetesVersions, nil
+}
+
+// getLatestSupportedMinikubeVersions iterates through the K8s supported versions and find the latest minikube after parsing
+// the sorted ValidKubernetesVersions slice from constants_kubernetes_versions.go
+func getLatestSupportedMinikubeVersions(url string, k8sVersions []KubernetesVersion) ([]string, error) {
+	body, err := getRequestBody(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get minikube versions: %w", err)
+	}
+
+	// Extract the slice using a regular expression
+	re := regexp.MustCompile(`ValidKubernetesVersions = \[\]string{([^}]*)}`)
+	matches := re.FindStringSubmatch(string(body))
+	if len(matches) < 2 {
+		return nil, errors.New("minikube, failed to find the Kubernetes versions slice")
+	}
+
+	// Parse and cleanup the slice values
+	minikubeVersions := strings.Split(strings.NewReplacer("\n", "", `"`, "", "\t", "", " ", "").Replace(matches[1]), ",")
+
+	logDebug("Found minikube versions: %s", minikubeVersions)
+
+	var latestMinikubeVersions []string
+	// the minikube version slice is sorted, break when first cycle match is found
+	for _, k8sVersion := range k8sVersions {
+		for _, minikubeVersion := range minikubeVersions {
+			if strings.Contains(minikubeVersion, k8sVersion.Cycle) {
+				latestMinikubeVersions = append(latestMinikubeVersions, minikubeVersion)
+				break
+			}
+		}
+	}
+
+	return latestMinikubeVersions, nil
+}
+
+// getLatestSupportedKindImages iterates through the K8s supported versions and find the latest kind
+// tag that supports that version
+func getLatestSupportedKindImages(url string, k8sVersions []KubernetesVersion) ([]string, error) {
+	var supportedKindVersions []string
+	for _, k8sVersion := range k8sVersions {
+		tag := k8sVersion.Latest
+		for {
+			exists, err := imageTagExists(url, tag)
+			if err != nil {
+				return supportedKindVersions, fmt.Errorf("failed to check image tag existence: %w", err)
+			}
+			if exists {
+				supportedKindVersions = append(supportedKindVersions, "v"+tag)
+				break
+			}
+			tag, err = decrementMinorMinorVersion(tag)
+			if err != nil {
+				// It's possible that kind still does not have a tag for new versions, break the loop and
+				// process other k8s versions
+				if strings.Contains(err.Error(), "minor version cannot be decremented below 0") {
+					logDebug("No kind image found for k8s version %s", k8sVersion.Cycle)
+					break
+				}
+				return supportedKindVersions, fmt.Errorf("failed to decrement k8sVersion: %w", err)
+			}
+		}
+	}
+	return supportedKindVersions, nil
+}
+
+func imageTagExists(url string, tag string) (bool, error) {
+	body, err := getRequestBody(url + tag)
+	if err != nil {
+		return false, fmt.Errorf("failed to get image tag: %w", err)
+	}
+
+	var kindImage DockerImage
+	if err = json.Unmarshal(body, &kindImage); err != nil {
+		return false, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	if kindImage.Count > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func decrementMinorMinorVersion(version string) (string, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) < 3 {
+		return "", fmt.Errorf("version does not have a minor version: %s", version)
+	}
+
+	minor, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return "", fmt.Errorf("invalid minor version: %s", parts[1])
+	}
+
+	if minor == 0 {
+		return "", errors.New("minor version cannot be decremented below 0")
+	}
+
+	parts[2] = strconv.Itoa(minor - 1)
+	return strings.Join(parts, "."), nil
+}
+
+func updateMatrixFile(filePath string, kindVersions []string, minikubeVersions []string) error {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var testMatrix map[string]map[string][]string
+	if err = json.Unmarshal(content, &testMatrix); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	for _, value := range testMatrix {
+		if len(kindVersions) > 0 && value[KubeKindVersion] != nil {
+			value[KubeKindVersion] = kindVersions
+		} else if len(minikubeVersions) > 0 && value[KubeMinikubeVersion] != nil {
+			value[KubeMinikubeVersion] = minikubeVersions
+		}
+	}
+	// Marshal the updated test matrix back to JSON
+	updatedContent, err := json.MarshalIndent(testMatrix, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated JSON: %w", err)
+	}
+
+	// Ensure the file ends with a new line to make the pre-commit check happy
+	updatedContent = append(updatedContent, '\n')
+
+	if err = os.WriteFile(filePath, updatedContent, 0o644); err != nil {
+		return fmt.Errorf("failed to write updated file: %w", err)
+	}
+	return nil
+}
+
+func sortVersions(versions []string) {
+	sort.Slice(versions, func(i, j int) bool {
+		vi := strings.Split(versions[i][1:], ".") // Remove "v" and split by "."
+		vj := strings.Split(versions[j][1:], ".")
+
+		for k := 0; k < len(vi) && k < len(vj); k++ {
+			if vi[k] != vj[k] {
+				return vi[k] > vj[k] // Sort in descending order
+			}
+		}
+		return len(vi) > len(vj)
+	})
+}
+
+func getRequestBody(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	return body, nil
+}
+
+func logDebug(format string, v ...any) {
+	if debug {
+		log.Printf(format, v...)
+	}
+}
+
+func main() {
+	// setup logging
+	flag.BoolVar(&debug, "debug", false, "Enable debug logging")
+	flag.Parse()
+	log.SetOutput(os.Stdout)
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	k8sVersions, err := getSupportedKubernetesVersions(EndOfLifeURL)
+	if err != nil || len(k8sVersions) == 0 {
+		log.Fatalf("Failed to get k8s versions: %v", err)
+	}
+	logDebug("Found supported k8s versions %v", k8sVersions)
+
+	kindVersions, err := getLatestSupportedKindImages(KindDockerHubURL, k8sVersions)
+	if err != nil {
+		log.Printf("failed to get all kind versions: %v", err)
+	}
+	if len(kindVersions) > 0 {
+		// needs to be sorted so we don't end up with false positive diff in the json matrix file
+		sortVersions(kindVersions)
+		logDebug("Found supported kind images: %v", kindVersions)
+	}
+
+	minikubeVersions, err := getLatestSupportedMinikubeVersions(MiniKubeURL, k8sVersions)
+	if err != nil {
+		log.Printf("failed to get minikube versions: %v", err)
+	}
+	if len(minikubeVersions) > 0 {
+		logDebug("Found supported minikube versions: %v", minikubeVersions)
+	}
+
+	if len(kindVersions) == 0 && len(minikubeVersions) == 0 {
+		log.Fatalf("No supported versions found. Run with -debug=true for more info.")
+	}
+
+	path := "ci-matrix.json"
+	currentDir, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("Failed to get current directory: %v ", err)
+	}
+	path = filepath.Join(currentDir, filepath.Clean(path))
+	err = updateMatrixFile(path, kindVersions, minikubeVersions)
+	if err != nil {
+		log.Fatalf("Failed to update matrix file: %v", err)
+	}
+	os.Exit(0)
+}

--- a/tools/k8s_versions/update_k8s_versions_test.go
+++ b/tools/k8s_versions/update_k8s_versions_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockResponse struct {
+	responseBody       []byte
+	responseStatusCode int
+	responseError      string
+	responseErrorCode  int
+}
+
+func (mResponse mockResponse) setupMockServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(mResponse.responseStatusCode)
+		if _, err := w.Write(mResponse.responseBody); err != nil {
+			http.Error(w, mResponse.responseError, mResponse.responseErrorCode)
+		}
+	}))
+}
+
+func Test_FetchKubernetesVersions_ValidURL_ReturnsSupportedVersions(t *testing.T) {
+	mResponse := mockResponse{
+		responseBody: []byte(`	[{"cycle":"1.24","releaseDate":"2022-05-03","eol":"2023-10-03","latest":"1.24.8"},
+								{"cycle":"1.34","releaseDate":"2025-05-03","eol":"2034-10-03","latest":"1.34.9"}]`),
+		responseError:      "failed to write response",
+		responseStatusCode: http.StatusOK,
+		responseErrorCode:  http.StatusInternalServerError,
+	}
+	mockServer := mResponse.setupMockServer()
+	defer mockServer.Close()
+
+	versions, err := getSupportedKubernetesVersions(mockServer.URL)
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "1.34", versions[0].Cycle)
+}
+
+func Test_FetchKubernetesVersions_InvalidURL_ReturnsError(t *testing.T) {
+	_, err := getSupportedKubernetesVersions("http:/12.168.1.2:2025/invalid")
+	assert.Error(t, err)
+}
+
+func Test_GetSupportedKubernetesVersions_EmptyResponse_ReturnsNoVersions(t *testing.T) {
+	mResponse := mockResponse{
+		responseBody:       []byte(`[]`),
+		responseStatusCode: http.StatusOK,
+		responseError:      "failed to write response",
+		responseErrorCode:  http.StatusInternalServerError,
+	}
+	mockServer := mResponse.setupMockServer()
+	defer mockServer.Close()
+
+	versions, err := getSupportedKubernetesVersions(mockServer.URL)
+	require.NoError(t, err)
+	assert.Empty(t, versions)
+}
+
+func Test_GetSupportedKubernetesVersions_InvalidEOL_ReturnsError(t *testing.T) {
+	mResponse := mockResponse{
+		responseBody:       []byte(`[{"cycle":"1.24","releaseDate":"2022-05-03","eol":"202001-01","latest":"1.24.0"}]`),
+		responseStatusCode: http.StatusOK,
+		responseError:      "failed to write response",
+		responseErrorCode:  http.StatusInternalServerError,
+	}
+	mockServer := mResponse.setupMockServer()
+	defer mockServer.Close()
+
+	versions, err := getSupportedKubernetesVersions(mockServer.URL)
+	require.Error(t, err)
+	assert.Nil(t, versions)
+}
+
+func Test_GetLatestSupportedMinikubeVersions_ValidResponse_ReturnsMatchingVersions(t *testing.T) {
+	mResponse := mockResponse{
+		responseBody:       []byte(`ValidKubernetesVersions = []string{"v1.24.3-alpha1", "v1.24.2", "v1.23.5", "v1.22.1"}`),
+		responseStatusCode: http.StatusOK,
+		responseError:      "failed to write response",
+		responseErrorCode:  http.StatusInternalServerError,
+	}
+	mockServer := mResponse.setupMockServer()
+	defer mockServer.Close()
+
+	k8sVersions := []KubernetesVersion{
+		{Cycle: "1.24"},
+		{Cycle: "1.23"},
+		{Cycle: "1.25"},
+	}
+
+	versions, err := getLatestSupportedMinikubeVersions(mockServer.URL, k8sVersions)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v1.24.3-alpha1", "v1.23.5"}, versions)
+}
+
+func Test_GetLatestSupportedMinikubeVersions_InvalidResponseFormat_ReturnsError(t *testing.T) {
+	mResponse := mockResponse{
+		responseBody:       []byte(`InvalidFormat`),
+		responseStatusCode: http.StatusOK,
+		responseError:      "failed to write response",
+		responseErrorCode:  http.StatusInternalServerError,
+	}
+	mockServer := mResponse.setupMockServer()
+	defer mockServer.Close()
+
+	k8sVersions := []KubernetesVersion{
+		{Cycle: "1.24"},
+	}
+
+	versions, err := getLatestSupportedMinikubeVersions(mockServer.URL, k8sVersions)
+	assert.Error(t, err)
+	assert.Nil(t, versions)
+}
+
+func Test_GetLatestSupportedKindImages_ValidResponse_ReturnsMatchingImages(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/image&name=1.24.2" {
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write([]byte(`{"count": 1}`)); err != nil {
+				http.Error(w, "failed to write response", http.StatusInternalServerError)
+			}
+		} else {
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write([]byte(`{"count": 0}`)); err != nil {
+				http.Error(w, "failed to write response", http.StatusInternalServerError)
+			}
+		}
+	}))
+	defer mockServer.Close()
+
+	k8sVersions := []KubernetesVersion{
+		{Cycle: "1.24", Latest: "1.24.3"},
+		{Cycle: "1.23", Latest: "1.23.5"},
+	}
+
+	images, err := getLatestSupportedKindImages(mockServer.URL+"/image&name=", k8sVersions)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v1.24.2"}, images)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Added a utility to get a list of supported vanilla k8s clusters, compare it to our test k8s versions and update when necessary.

I added a make target, which we can keep or remove, but the end goal is to add a gh action that uses this logic to create a PR with the changes if detected.

We currently have a bunch of EOL k8s versions that we use, it's a way to check compatibility with cloud providers that extend the support. 
This is not ideal as we keep increasing our test matrix and the vanilla cluster is not identical to the one used by the cloud provider. To test for schema compatibility, we should start using `kubeconform`

To Do (sperate PRs):
- Add a gh action
- track EKS, AKS and GKE

**Testing:** <Describe what testing was performed and which tests were added.>
unit test

