### PR TITLE
Exclude AKS windows nodes from kubelet stats fix

### DIFF
--- a/.chloggen/kubeletAKS.yaml
+++ b/.chloggen/kubeletAKS.yaml
@@ -3,7 +3,7 @@ change_type: bug_fix
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: agent
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Configure AKS KubeletStats receiver to use the appropriate CA file. For more information, see the following link
+note: Configure AKS KubeletStats receiver on non-windows nodes to use the appropriate CA file. For more information, see the following link
   https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#aks-kubeletstats-receiver
 # One or more tracking issues related to the change
 issues: [1773]

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -71,7 +71,7 @@ and it only adds the node name in its certificate Subject Alternative Name.
 
 When `distribution` is set to `aks`, the chart automatically sets the custom `ca_file`
 option to `/hostfs/etc/kubernetes/certs/kubeletserver.crt` and uses the node name in
-its endpoint.
+its endpoint. Note: This is applicable solely to non-Windows nodes at this time.
 
 For custom setups (e.g., custom certificates, Windows nodes, or Linux nodes with virtual network using custom DNS),
 adjust `ca_file` and use the node IP instead.

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -381,7 +381,7 @@ receivers:
     # use the read-only endpoint instead.
     auth_type: none
     endpoint: ${K8S_NODE_IP}:10255
-    {{ else if eq .Values.distribution "aks" }}
+    {{ else if and (eq .Values.distribution "aks") (not .Values.isWindows) }}
     ca_file: "/hostfs/etc/kubernetes/certs/kubeletserver.crt"
     endpoint: ${K8S_NODE_NAME}:10250
     auth_type: serviceAccount


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Address this issue https://github.com/signalfx/splunk-otel-collector-chart/pull/1795#issuecomment-2828384975
We'll cover windows in next release

