### PR TITLE
[chore][misspell] Add linter to help catch typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ bin/
 
 # helm unittests - remove when ready to snapshots for unittest
 **__snapshot__**
+
+.tools/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,7 +471,7 @@ This Splunk OpenTelemetry Collector for Kubernetes release adopts the [Splunk Op
 
 - `clusterReceiver`: Bring back the default translations for kubelet metrics in EKS Fargate ([#1174](https://github.com/signalfx/splunk-otel-collector-chart/pull/1174))
 - `agent`: Remove a post-delete hook which targeted one a single node for reverting file ACLs. ([#1175](https://github.com/signalfx/splunk-otel-collector-chart/pull/1175))
-  The removed hook was intended to undo the ACLs set on log directores when
+  The removed hook was intended to undo the ACLs set on log directories when
   runAsUser and runAsGroup are provided. An initContainer run as root-user updates
   the permissions of log directories to allow read access to the provided uid/gid.
   But there is no graceful way to revert these ACLs on each node as part of the

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
+include ./Makefile.common
 ##@ General
 # The general settings and variables for the project
-SHELL := /bin/bash
 
 # TODO: Move CHART_FILE_PATH and VALUES_FILE_PATH here, currently set in multiple places
 # The version of the splunk-otel-collector chart
@@ -36,6 +36,7 @@ help: ## Display Makefile help information for all actions
 .PHONY: install-tools
 install-tools: ## Install tools (macOS/Linux)
 	LOCALBIN=$(LOCALBIN) GOBIN=$(LOCALBIN) ci_scripts/install-tools.sh || exit 1
+	$(MAKE) goinstall-tools
 
 ##@ Build
 # Tasks related to building the Helm chart
@@ -221,3 +222,8 @@ tidy-all:
 .PHONY: update-operator-crds
 update-operator-crds: ## Update CRDs in the opentelemetry-operator-crds subchart
 	ci_scripts/update-crds.sh
+
+.PHONY: misspell
+misspell: $(TOOLS_BIN_DIR)/misspell
+	@echo "running $(MISSPELL)"
+	@$(MISSPELL) $$($(ALL_SRC_AND_DOC_CMD))

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,29 @@
+SHELL=/bin/bash
+.SHELLFLAGS = -o pipefail -c
+
+
+# SRC_ROOT is the top of the source tree.
+ALL_SRC_AND_DOC_CMD := find . -type f \( \( -name "*.md" -o -name "*.go" -o -name "*.yaml" \) \) | sort
+
+SRC_ROOT := $(shell git rev-parse --show-toplevel)
+
+GOCMD?= go
+GOOS=$(shell $(GOCMD) env GOOS)
+GOARCH=$(shell $(GOCMD) env GOARCH)
+
+TOOLS_MOD_DIR    := $(SRC_ROOT)/tools
+TOOLS_MOD_REGEX  := "\s+_\s+\".*\""
+TOOLS_PKG_NAMES  := $(shell grep -E $(TOOLS_MOD_REGEX) < $(TOOLS_MOD_DIR)/tools.go | tr -d " _\"")
+TOOLS_BIN_DIR    := $(SRC_ROOT)/.tools
+TOOLS_BIN_NAMES  := $(addprefix $(TOOLS_BIN_DIR)/, $(notdir $(TOOLS_PKG_NAMES)))
+
+MISSPELL            := $(TOOLS_BIN_DIR)/misspell -error
+
+.PHONY: goinstall-tools
+goinstall-tools: $(TOOLS_BIN_NAMES)
+
+$(TOOLS_BIN_DIR):
+	mkdir -p $@
+
+$(TOOLS_BIN_NAMES): $(TOOLS_BIN_DIR) $(TOOLS_MOD_DIR)/go.mod
+	cd $(TOOLS_MOD_DIR) && GOOS="" GOARCH="" $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -764,7 +764,7 @@ Check [Data Persistence in the OpenTelemetry Collector
 
 Note: Data Persistence is only applicable for agent daemonset.
 
-Use following in values.yaml to disable data persistense for logs or metrics or traces:
+Use following in values.yaml to disable data persistence for logs or metrics or traces:
 
 ```yaml
 agent:
@@ -800,12 +800,12 @@ agent:
   * Persistent buffering is not supported for them, as directory needs to be mounted via `hostPath`.
   * Refer [aws/fargate](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) and [gke/autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security#built-in-security).
 * Gateway support
-  * The filestorage extention acquires an exclusive lock for the queue directory.
+  * The filestorage extension acquires an exclusive lock for the queue directory.
   * It is not possible to run the persistent buffering if there are multiple replicas of a pod and `gateway` runs 3 replicas by default.
   * Even if support is somehow provided, only one of the pods will be able to acquire the lock and run, while the others will be blocked and unable to operate.
 * Cluster Receiver support
   * Cluster receiver is a 1-replica deployment of OpenTelemetry collector.
-  * As any available node can be selected by the Kubernetes control plane to run the cluster receiver pod (unless we explicitly specify the `clusterReceiver.nodeSelector` to pin the pod to a specific node), `hostPath` or `local` volume mounts wouldn't work for such envrionments.
+  * As any available node can be selected by the Kubernetes control plane to run the cluster receiver pod (unless we explicitly specify the `clusterReceiver.nodeSelector` to pin the pod to a specific node), `hostPath` or `local` volume mounts wouldn't work for such environments.
   * Data Persistence is currently not applicable to the k8s cluster metrics and k8s events.
 
 ### Using OpenTelemetry eBPF helm chart with Splunk OpenTelemetry Collector for Kubernetes

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -393,7 +393,7 @@ with Splunk customer content.
 _The native OpenTelemetry instrumentation libraries are owned and maintained by the OpenTelemetry Community, Splunk
 provides best effort support with issues related to native OpenTelemetry instrumentation libraries._
 
-| Instrumentation Library | Distribution  | Status      | Supported        | Splunk Content Compatability | Code Repo                                                                            | Image Repo                                                                     |
+| Instrumentation Library | Distribution  | Status      | Supported        | Splunk Content Compatibility | Code Repo                                                                            | Image Repo                                                                     |
 |-------------------------|---------------|-------------|------------------|------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
 | java                    | Splunk        | Available   | Yes              | Completely                   | [Link](github.com/signalfx/splunk-otel-java)                                         | ghcr.io/signalfx/splunk-otel-java/splunk-otel-java                             |
 | dotnet                  | Splunk        | Coming Soon |                  |                              | [Link](github.com/signalfx/splunk-otel-dotnet)                                       |                                                                                |

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -452,7 +452,7 @@ agent:
   # Enable or disable features of the agent.
   featureGates: ""
 
-  # OpenTelemetry Collector configuration for otel-agent daemonset can be overriden in this field.
+  # OpenTelemetry Collector configuration for otel-agent daemonset can be overridden in this field.
   # Default configuration defined in templates/config/_otel-agent.tpl
   # Any additional fields will be merged into the defaults,
   # existing fields can be disabled by setting them to null value.
@@ -564,7 +564,7 @@ clusterReceiver:
   # k8s cluster receiver extra pod labels
   podLabels: {}
 
-  # Extra enviroment variables to be set in the OTel Cluster Receiver container
+  # Extra environment variables to be set in the OTel Cluster Receiver container
   extraEnvs: []
 
   # Extra volumes to be mounted to the k8s cluster receiver container.
@@ -574,7 +574,7 @@ clusterReceiver:
   # Enable or disable features of the cluster receiver.
   featureGates: ""
 
-  # OpenTelemetry Collector configuration for K8s Cluster Receiver deployment can be overriden in this field.
+  # OpenTelemetry Collector configuration for K8s Cluster Receiver deployment can be overridden in this field.
   # Default configuration defined in templates/config/_otel-k8s-cluster-receiver-config.tpl
   # Any additional fields will be merged into the defaults,
   # existing fields can be disabled by setting them to null value.
@@ -695,7 +695,7 @@ fluentd:
   securityContext:
     runAsUser: 0
 
-  # Extra enviroment variables to be set in the FluentD container
+  # Extra environment variables to be set in the FluentD container
   extraEnvs: []
 
   config:
@@ -1088,7 +1088,7 @@ isWindows: false
 securityContextConstraints:
   create: true
 
-# Openshift SecurityContextConstraints can be overriden in this field.
+# Openshift SecurityContextConstraints can be overridden in this field.
 # This fields will be merged into the default config that can be found at
 # https://github.com/signalfx/splunk-otel-collector-chart/blob/main/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
 # NOTE: This config will only be used when distribution=openshift
@@ -1173,7 +1173,7 @@ gateway:
   # OTel collector extra pod labels
   podLabels: {}
 
-  # Extra enviroment variables to be set in the standalone OTel collector container
+  # Extra environment variables to be set in the standalone OTel collector container
   extraEnvs: []
 
   # Extra volumes to be mounted to the OTel Collector container.
@@ -1183,7 +1183,7 @@ gateway:
   # Enable or disable features of the gateway.
   featureGates: ""
 
-  # OpenTelemetry Collector configuration for standalone otel-collector deployment can be overriden in this field.
+  # OpenTelemetry Collector configuration for standalone otel-collector deployment can be overridden in this field.
   # Default configuration defined in config/otel-collector-config.yaml
   # Any additional fields will be merged into the defaults,
   # existing fields can be disabled by setting them to `null`.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,5 @@
+module tools
+
+go 1.24.2
+
+require github.com/client9/misspell v0.3.4

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,0 +1,2 @@
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,23 @@
+// Copyright  Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build tools
+// +build tools
+
+package tools
+
+// based on https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/tools/tools.go
+import (
+	_ "github.com/client9/misspell/cmd/misspell"
+)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Adds the misspell tool to help catch typos in this repo. `Makefile` changes taken from the contrib and Splunk distributions of the Collector.

A future work item will be to add a workflow step that checks to make sure misspell is applied on all PRs.