### PR TITLE
[chore][Makefile] Fix for-all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,13 +221,15 @@ prepare-release: ## Prepares for a new release of the helm chart. Optionally spe
 update-operator-crds: ## Update CRDs in the opentelemetry-operator-crds subchart
 	ci_scripts/update-crds.sh
 
-.PHONY: for-all
-for-all:
-	@set -e; for dir in $(ALL_MODS); do \
-		(cd "$${dir}" && \
-		echo "running $${CMD} in $${dir}" && \
-		$${CMD} ); \
-	done
+# Define a delegation target for each module
+.PHONY: $(ALL_MODS)
+$(ALL_MODS):
+	@echo "Running target '$(TARGET)' in module '$@' as part of group '$(GROUP)'"
+	$(MAKE) --no-print-directory -C $@ $(TARGET)
+
+# Trigger each module's delegation target
+.PHONY: for-all-target
+for-all-target: $(ALL_MODS)
 
 .PHONY: tidy-all
 tidy-all:
@@ -238,16 +240,16 @@ tidy-all:
 
 .PHONY: gofmt-all
 gofmt-all:
-	@$(MAKE) for-all gofmt
+	@$(MAKE) for-all-target TARGET='gofmt'
 
 .PHONY: govulncheck-all
 govulncheck-all:
-	@$(MAKE) for-all govulncheck
+	@$(MAKE) for-all-target TARGET='govulncheck'
 
 .PHONY: golint-all
 golint-all:
-	@$(MAKE) for-all golint
+	@$(MAKE) for-all-target TARGET='golint'
 
 .PHONY: gogci-all
 gogci-all:
-	@$(MAKE) for-all gogci
+	@$(MAKE) for-all-target TARGET='gogci'

--- a/Makefile.common
+++ b/Makefile.common
@@ -51,8 +51,7 @@ misspell-correction: $(TOOLS_BIN_DIR)/misspell
 	@$(MISSPELL_CORRECTION) $$($(ALL_SRC_AND_DOC_CMD))
 
 .PHONY: gofmt
-fmt: $(GOFUMPT) $(GOIMPORTS) misspell-correction
-	gofmt -w -s .
+fmt: $(GOFUMPT) $(GOIMPORTS)
 	$(GOFUMPT) -l -w .
 	$(GOIMPORTS) -w -local github.com/signalfx/splunk-otel-collector-chart ./
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -51,25 +51,18 @@ misspell-correction: $(TOOLS_BIN_DIR)/misspell
 	@$(MISSPELL_CORRECTION) $$($(ALL_SRC_AND_DOC_CMD))
 
 .PHONY: gofmt
-fmt: $(GOFUMPT) $(GOIMPORTS)
+fmt: $(GOFUMPT) $(GOIMPORTS) misspell-correction
+	gofmt -w -s .
 	$(GOFUMPT) -l -w .
 	$(GOIMPORTS) -w -local github.com/signalfx/splunk-otel-collector-chart ./
 
 .PHONY: golint
 golint: $(LINT) misspell
-	@if [ "$(SRC_ROOT)" != "$(PWD)" ]; then \
-		$(LINT) run --allow-parallel-runners -j$(NUM_CORES); \
-  else \
-    echo "top-level dir is not part of a go module, skipping golint"; \
-	fi
+		$(LINT) run --allow-parallel-runners -j$(NUM_CORES)
 
 .PHONY: govulncheck
 govulncheck: $(GOVULNCHECK)
-	@if [ "$(SRC_ROOT)" != "$(PWD)" ]; then \
-		$(GOVULNCHECK) ./...; \
-  else \
-    echo "top-level dir is not part of a go module, skipping govulncheck"; \
-	fi
+		$(GOVULNCHECK) ./...
 
 .PHONY: gogci
 gogci: $(TOOLS_BIN_DIR)/gci


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The original method of targeting all mods wasn't actually running the commands in each module, they're all being skipped because of the `Makefile.common` check `	@if [ "$(SRC_ROOT)" != "$(PWD)" ]; then \`. This was required as the top-level dir was being included when running the `for-all` target. To fix this, we can simply use the `for-all-target` functionality and the target won't be run in the top-level dir, so we can remove the `for-all` functionality and PWD checks.