### PR TITLE
[chore][Makefile] Fix and update gofmt target

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -51,7 +51,7 @@ misspell-correction: $(TOOLS_BIN_DIR)/misspell
 	@$(MISSPELL_CORRECTION) $$($(ALL_SRC_AND_DOC_CMD))
 
 .PHONY: gofmt
-gofmt: $(GOFUMPT) $(GOIMPORTS)
+gofmt: $(GOFUMPT) $(GOIMPORTS) misspell-correction
 	gofmt -w -s .
 	$(GOFUMPT) -l -w .
 	$(GOIMPORTS) -w -local github.com/signalfx/splunk-otel-collector-chart ./


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
There was a naming mismatch with the `gofmt` phony alias and target name, causing the target to not actually get run. This also adds a gofmt call to the target, and misspell correction so that typos are fixed when `gofmt` is run.