### PR TITLE
[chore] Fix linting errors

### DIFF
--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -443,7 +443,8 @@ func teardown(t *testing.T, testKubeConfig string) {
 			GracePeriodSeconds: &waitTime,
 		})
 		require.Eventually(t, func() bool {
-			_, err := client.CoreV1().Namespaces().Get(t.Context(), nm.Name, metav1.GetOptions{})
+			_, err = client.CoreV1().Namespaces().Get(t.Context(), nm.Name, metav1.GetOptions{})
+			t.Logf("Getting Namespace: %s, Error: %v", nm.Name, err)
 			return k8serrors.IsNotFound(err)
 		}, 3*time.Minute, 3*time.Second, "namespace %s not removed in time", nm.Name)
 	}

--- a/functional_tests/histogram/histogram_test.go
+++ b/functional_tests/histogram/histogram_test.go
@@ -218,9 +218,8 @@ func checkMetrics(t *testing.T, isHistogram bool, expected, actual *pmetric.Metr
 
 	if isHistogram {
 		return checkHistogramMetrics(t, expected, actual, component, mergedAttrs)
-	} else {
-		return checkNonHistogramMetrics(t, expected, actual, component, mergedAttrs)
 	}
+	return checkNonHistogramMetrics(t, expected, actual, component, mergedAttrs)
 }
 
 func mergeMaps(map1, map2 map[string]string) map[string]string {

--- a/functional_tests/internal/api_server.go
+++ b/functional_tests/internal/api_server.go
@@ -26,7 +26,7 @@ func SetupSignalFxAPIServer(t *testing.T) {
 	s := &http.Server{
 		Addr:              fmt.Sprintf("0.0.0.0:%d", SignalFxAPIPort),
 		Handler:           mux,
-		ReadHeaderTimeout: 60 * time.Second,
+		ReadHeaderTimeout: 60 * time.Minute,
 	}
 
 	t.Cleanup(func() {

--- a/functional_tests/internal/api_server.go
+++ b/functional_tests/internal/api_server.go
@@ -9,22 +9,24 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
 const SignalFxAPIPort = 8881
 
-func SetupSignalFxApiServer(t *testing.T) {
+func SetupSignalFxAPIServer(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
-		writer.WriteHeader(200)
+	mux.HandleFunc("/", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
 	})
 
-	_, cancelCtx := context.WithCancel(context.Background())
+	_, cancelCtx := context.WithCancel(t.Context())
 	s := &http.Server{
-		Addr:    fmt.Sprintf("0.0.0.0:%d", SignalFxAPIPort),
-		Handler: mux,
+		Addr:              fmt.Sprintf("0.0.0.0:%d", SignalFxAPIPort),
+		Handler:           mux,
+		ReadHeaderTimeout: 60 * time.Second,
 	}
 
 	t.Cleanup(func() {

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -38,8 +38,8 @@ func HostEndpoint(t *testing.T) string {
 
 	client, err := docker.NewClientWithOpts(docker.FromEnv)
 	require.NoError(t, err)
-	client.NegotiateAPIVersion(context.Background())
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	client.NegotiateAPIVersion(t.Context())
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	network, err := client.NetworkInspect(ctx, "kind", network.InspectOptions{})
 	require.NoError(t, err)
@@ -77,13 +77,11 @@ func WaitForMetrics(t *testing.T, entriesNum int, mc *consumertest.MetricsSink) 
 }
 
 func CheckNoEventsReceived(t *testing.T, lc *consumertest.LogsSink) {
-	require.True(t, len(lc.AllLogs()) == 0,
-		"received %d logs, expected 0 logs", len(lc.AllLogs()))
+	require.Empty(t, lc.AllLogs(), "received %d logs, expected 0 logs", len(lc.AllLogs()))
 }
 
 func CheckNoMetricsReceived(t *testing.T, lc *consumertest.MetricsSink) {
-	require.True(t, len(lc.AllMetrics()) == 0,
-		"received %d metrics, expected 0 metrics", len(lc.AllMetrics()))
+	require.Empty(t, lc.AllMetrics(), "received %d metrics, expected 0 metrics", len(lc.AllMetrics()))
 }
 
 func ResetMetricsSink(t *testing.T, mc *consumertest.MetricsSink) {
@@ -115,7 +113,7 @@ func CheckPodsReady(t *testing.T, clientset *kubernetes.Clientset, namespace, la
 	timeout time.Duration,
 ) {
 	require.Eventually(t, func() bool {
-		pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		pods, err := clientset.CoreV1().Pods(namespace).List(t.Context(), metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
 		require.NoError(t, err)
@@ -147,40 +145,40 @@ func CreateNamespace(t *testing.T, clientset *kubernetes.Clientset, name string)
 			Name: name,
 		},
 	}
-	_, err := clientset.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Namespaces().Create(t.Context(), ns, metav1.CreateOptions{})
 	require.NoError(t, err, "failed to create namespace %s", name)
 
 	require.Eventually(t, func() bool {
-		_, err := clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+		_, err := clientset.CoreV1().Namespaces().Get(t.Context(), name, metav1.GetOptions{})
 		return err == nil
 	}, 1*time.Minute, 5*time.Second, "namespace %s is not available", name)
 }
 
 func LabelNamespace(t *testing.T, clientset *kubernetes.Clientset, name, key, value string) {
-	ns, err := clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	ns, err := clientset.CoreV1().Namespaces().Get(t.Context(), name, metav1.GetOptions{})
 	require.NoError(t, err)
 	if ns.Labels == nil {
 		ns.Labels = make(map[string]string)
 	}
 	ns.Labels[key] = value
-	_, err = clientset.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+	_, err = clientset.CoreV1().Namespaces().Update(t.Context(), ns, metav1.UpdateOptions{})
 	require.NoError(t, err)
 }
 
 func AnnotateNamespace(t *testing.T, clientset *kubernetes.Clientset, name, key, value string) {
-	ns, err := clientset.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	ns, err := clientset.CoreV1().Namespaces().Get(t.Context(), name, metav1.GetOptions{})
 	require.NoError(t, err)
 	if ns.Annotations == nil {
 		ns.Annotations = make(map[string]string)
 	}
 	ns.Annotations[key] = value
-	_, err = clientset.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+	_, err = clientset.CoreV1().Namespaces().Update(t.Context(), ns, metav1.UpdateOptions{})
 	require.NoError(t, err)
 }
 
 func WaitForTerminatingPods(t *testing.T, clientset *kubernetes.Clientset, namespace string) {
 	require.Eventually(t, func() bool {
-		pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+		pods, err := clientset.CoreV1().Pods(namespace).List(t.Context(), metav1.ListOptions{})
 		require.NoError(t, err)
 
 		terminatingPods := 0

--- a/functional_tests/internal/concurrency.go
+++ b/functional_tests/internal/concurrency.go
@@ -66,7 +66,7 @@ func AcquireLeaseForTest(t *testing.T, testKubeConfig string) {
 			OnNewLeader: func(identity string) {
 				t.Logf("The lease is currently held by another test %s. Waiting...", identity)
 			},
-			OnStartedLeading: func(c context.Context) {
+			OnStartedLeading: func(_ context.Context) {
 				// Signal that we've acquired the lease
 				close(becameLeader)
 			},
@@ -81,7 +81,7 @@ func AcquireLeaseForTest(t *testing.T, testKubeConfig string) {
 	}
 
 	// Run the leader election in a goroutine, so we can block until acquiring the lease
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	go elector.Run(ctx)
 
 	// Wait until we become leader OR the test context ends

--- a/functional_tests/internal/sinks.go
+++ b/functional_tests/internal/sinks.go
@@ -4,7 +4,6 @@
 package internal
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -40,13 +39,13 @@ func setupHECLogsSink(t *testing.T, port int) *consumertest.LogsSink {
 	cfg.Endpoint = fmt.Sprintf("0.0.0.0:%d", port)
 
 	lc := new(consumertest.LogsSink)
-	rcvr, err := f.CreateLogs(context.Background(), receivertest.NewNopSettings(f.Type()), cfg, lc)
+	rcvr, err := f.CreateLogs(t.Context(), receivertest.NewNopSettings(f.Type()), cfg, lc)
 	require.NoError(t, err)
 
-	require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, err, "failed creating logs receiver")
 	t.Cleanup(func() {
-		require.NoError(t, rcvr.Shutdown(context.Background()))
+		require.NoError(t, rcvr.Shutdown(t.Context()))
 	})
 
 	return lc
@@ -59,13 +58,13 @@ func SetupHECMetricsSink(t *testing.T) *consumertest.MetricsSink {
 	mCfg.Endpoint = fmt.Sprintf("0.0.0.0:%d", HECMetricsReceiverPort)
 
 	mc := new(consumertest.MetricsSink)
-	mrcvr, err := f.CreateMetrics(context.Background(), receivertest.NewNopSettings(f.Type()), mCfg, mc)
+	mrcvr, err := f.CreateMetrics(t.Context(), receivertest.NewNopSettings(f.Type()), mCfg, mc)
 	require.NoError(t, err)
 
-	require.NoError(t, mrcvr.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, mrcvr.Start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, err, "failed creating metrics receiver")
 	t.Cleanup(func() {
-		require.NoError(t, mrcvr.Shutdown(context.Background()))
+		require.NoError(t, mrcvr.Shutdown(t.Context()))
 	})
 
 	return mc
@@ -75,16 +74,16 @@ func SetupOTLPTracesSink(t *testing.T) *consumertest.TracesSink {
 	tc := new(consumertest.TracesSink)
 	f := otlpreceiver.NewFactory()
 	cfg := f.CreateDefaultConfig().(*otlpreceiver.Config)
-	cfg.Protocols.GRPC.NetAddr.Endpoint = fmt.Sprintf("0.0.0.0:%d", OTLPGRPCReceiverPort)
-	cfg.Protocols.HTTP.Endpoint = fmt.Sprintf("0.0.0.0:%d", OTLPHTTPReceiverPort)
+	cfg.GRPC.NetAddr.Endpoint = fmt.Sprintf("0.0.0.0:%d", OTLPGRPCReceiverPort)
+	cfg.HTTP.Endpoint = fmt.Sprintf("0.0.0.0:%d", OTLPHTTPReceiverPort)
 
-	rcvr, err := f.CreateTraces(context.Background(), receivertest.NewNopSettings(f.Type()), cfg, tc)
+	rcvr, err := f.CreateTraces(t.Context(), receivertest.NewNopSettings(f.Type()), cfg, tc)
 	require.NoError(t, err)
 
-	require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, err, "failed creating traces receiver")
 	t.Cleanup(func() {
-		require.NoError(t, rcvr.Shutdown(context.Background()))
+		require.NoError(t, rcvr.Shutdown(t.Context()))
 	})
 
 	return tc
@@ -94,16 +93,16 @@ func SetupOTLPLogsSink(t *testing.T) *consumertest.LogsSink {
 	ls := new(consumertest.LogsSink)
 	f := otlpreceiver.NewFactory()
 	cfg := f.CreateDefaultConfig().(*otlpreceiver.Config)
-	cfg.Protocols.GRPC.NetAddr.Endpoint = fmt.Sprintf("0.0.0.0:%d", OTLPGRPCReceiverPort)
-	cfg.Protocols.HTTP.Endpoint = fmt.Sprintf("0.0.0.0:%d", OTLPHTTPReceiverPort)
+	cfg.GRPC.NetAddr.Endpoint = fmt.Sprintf("0.0.0.0:%d", OTLPGRPCReceiverPort)
+	cfg.HTTP.Endpoint = fmt.Sprintf("0.0.0.0:%d", OTLPHTTPReceiverPort)
 
-	rcvr, err := f.CreateLogs(context.Background(), receivertest.NewNopSettings(f.Type()), cfg, ls)
+	rcvr, err := f.CreateLogs(t.Context(), receivertest.NewNopSettings(f.Type()), cfg, ls)
 	require.NoError(t, err)
 
-	require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, err, "failed creating logs receiver")
 	t.Cleanup(func() {
-		require.NoError(t, rcvr.Shutdown(context.Background()))
+		require.NoError(t, rcvr.Shutdown(t.Context()))
 	})
 
 	return ls
@@ -115,13 +114,13 @@ func SetupSignalfxReceiver(t *testing.T, port int) *consumertest.MetricsSink {
 	cfg := f.CreateDefaultConfig().(*signalfxreceiver.Config)
 	cfg.Endpoint = fmt.Sprintf("0.0.0.0:%d", port)
 
-	rcvr, err := f.CreateMetrics(context.Background(), receivertest.NewNopSettings(f.Type()), cfg, mc)
+	rcvr, err := f.CreateMetrics(t.Context(), receivertest.NewNopSettings(f.Type()), cfg, mc)
 	require.NoError(t, err)
 
-	require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, rcvr.Start(t.Context(), componenttest.NewNopHost()))
 	require.NoError(t, err, "failed creating metrics receiver")
 	t.Cleanup(func() {
-		require.NoError(t, rcvr.Shutdown(context.Background()))
+		require.NoError(t, rcvr.Shutdown(t.Context()))
 	})
 
 	return mc

--- a/functional_tests/istio/istio_test.go
+++ b/functional_tests/istio/istio_test.go
@@ -260,7 +260,7 @@ func sendWorkloadHTTPRequests(t *testing.T) {
 func deleteObject(t *testing.T, k8sClient *k8stest.K8sClient, objYAML string) {
 	obj := &unstructured.Unstructured{}
 	require.NoError(t, yaml.Unmarshal([]byte(objYAML), obj))
-	require.NoError(t, k8stest.DeleteObject(k8sClient, obj))
+	k8stest.DeleteObject(k8sClient, obj)
 }
 
 func Test_IstioMetrics(t *testing.T) {

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -46,7 +46,7 @@ func Test_K8SEvents(t *testing.T) {
 		teardown(t, k8sClient)
 	}
 
-	internal.SetupSignalFxApiServer(t)
+	internal.SetupSignalFxAPIServer(t)
 
 	eventsLogsConsumer = internal.SetupHECLogsSink(t)
 
@@ -65,7 +65,7 @@ func Test_K8SEvents(t *testing.T) {
 
 	t.Run("CheckK8SEventsLogs", func(t *testing.T) {
 		actualLogs := selectResLogs("com.splunk.sourcetype", "kube:events", eventsLogsConsumer)
-		k8sEventsLogs := selectLogs(t, "k8s.namespace.name", "k8sevents-test", &actualLogs, func(body string) string {
+		k8sEventsLogs := selectLogs("k8s.namespace.name", "k8sevents-test", &actualLogs, func(body string) string {
 			re := regexp.MustCompile(`Successfully pulled image "(busybox|alpine):latest" in .* \(.* including waiting\).*`)
 			return re.ReplaceAllString(body, `Successfully pulled image "$1:latest" in <time> (<time> including waiting)`)
 		})
@@ -192,9 +192,8 @@ metadata:
 
 func deleteObject(t *testing.T, k8sClient *k8stest.K8sClient, objYAML string) {
 	obj := &unstructured.Unstructured{}
-	err := yaml.Unmarshal([]byte(objYAML), obj)
-	require.NoError(t, err)
-	k8stest.DeleteObject(k8sClient, obj)
+	require.NoError(t, yaml.Unmarshal([]byte(objYAML), obj))
+	require.NoError(t, k8stest.DeleteObject(k8sClient, obj))
 }
 
 func selectResLogs(attributeName, attributeValue string, logSink *consumertest.LogsSink) plog.Logs {
@@ -213,7 +212,7 @@ func selectResLogs(attributeName, attributeValue string, logSink *consumertest.L
 	return selectedLogs
 }
 
-func selectLogs(t *testing.T, attributeName, attributeValue string, inLogs *plog.Logs, modifyBodyFunc func(string) string) plog.Logs {
+func selectLogs(attributeName, attributeValue string, inLogs *plog.Logs, modifyBodyFunc func(string) string) plog.Logs {
 	selectedLogs := plog.NewLogs()
 	// collapse logs across resource logs into a single one to reduce flakiness in test runs
 	for h := 0; h < inLogs.ResourceLogs().Len(); h++ {

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -193,7 +193,7 @@ metadata:
 func deleteObject(t *testing.T, k8sClient *k8stest.K8sClient, objYAML string) {
 	obj := &unstructured.Unstructured{}
 	require.NoError(t, yaml.Unmarshal([]byte(objYAML), obj))
-	require.NoError(t, k8stest.DeleteObject(k8sClient, obj))
+	k8stest.DeleteObject(k8sClient, obj)
 }
 
 func selectResLogs(attributeName, attributeValue string, logSink *consumertest.LogsSink) plog.Logs {

--- a/test/config.go
+++ b/test/config.go
@@ -10,7 +10,7 @@ import (
 const (
 	HostEnvVar           = "CI_SPLUNK_HOST"
 	UserEnvVar           = "CI_SPLUNK_USERNAME"
-	PasswordEnvVar       = "CI_SPLUNK_PASSWORD"
+	PasswordEnvVar       = "CI_SPLUNK_PASSWORD" //nolint:gosec
 	ManagementPortEnvVar = "CI_SPLUNK_PORT"
 )
 

--- a/test/splunk_search.go
+++ b/test/splunk_search.go
@@ -47,7 +47,7 @@ func getSplunkSearchResults(user string, password string, baseURL string, jobID 
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	eventURL := fmt.Sprintf("%s/services/search/jobs/%s/events?output_mode=json", baseURL, jobID)
 	logger.Println("URL: " + eventURL)
-	reqEvents, err := http.NewRequest("GET", eventURL, nil)
+	reqEvents, err := http.NewRequest(http.MethodGet, eventURL, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -88,7 +88,7 @@ func checkSearchJobStatusCode(user string, password string, baseURL string, jobI
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
-	checkReqEvents, err := http.NewRequest("GET", checkEventURL, nil)
+	checkReqEvents, err := http.NewRequest(http.MethodGet, checkEventURL, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -118,7 +118,6 @@ func checkSearchJobStatusCode(user string, password string, baseURL string, jobI
 func postSearchRequest(user string, password string, baseURL string, searchQuery string, startTime string, endTime string) string {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	searchURL := fmt.Sprintf("%s/services/search/jobs?output_mode=json", baseURL)
-	// query := "search " + searchQuery
 	query := searchQuery
 	logger.Println("Search query: " + query)
 	data := url.Values{}
@@ -130,7 +129,7 @@ func postSearchRequest(user string, password string, baseURL string, searchQuery
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
-	req, err := http.NewRequest("POST", searchURL, strings.NewReader(data.Encode()))
+	req, err := http.NewRequest(http.MethodPost, searchURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		logger.Printf("Error while preparing POST request")
 		panic(err)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Errors fixed:

1. `unused-parameter`
2. `var-naming: don't use an underscore in package name`
3. `var-declaration: should drop = 0 from declaration of var ...; it is the zero value`
4. `indent-error-flow: if block ends with a return statement, so drop this else and outdent its block`
5. `func `createObjectFromURL` is unused`
6. `ifElseChain: rewrite if-else to switch statement`
7. `shadow: declaration of "err" shadows declaration at line`
8. `should merge variable declaration with assignment on next line`
9. ` ineffectual assignment to err` (Means `err` wasn't used after being assigned, I added checks to tests to ensure it was empty for these cases)
10. `SA4010: this result of append is never used, except maybe in other appends`
11. `crdsInstallEnabled - result 1 (error) is always nil (unparam)`
12. `use-any: since Go 1.18 'interface{}' can be replaced by 'any'`
13. `comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error`
14. `Error return value of `k8stest.DeleteObject` is not checked`
15. Some `gosec` warnings, resolved some and ignored others.
16. `could remove embedded field "ChartPathOptions" from selector`
17. `ST1017: don't use Yoda conditions (staticcheck)`
18. ` compares: use assert.GreaterOrEqual`
19. `regexp: remove unnecessary regexp.MustCompile`
20. `compares: use require.Equal`
21. `"200" can be replaced by http.StatusOK (usestdlibvars)`
22. `"GET" can be replaced by http.MethodGet (usestdlibvars)`
23. `context.Background() could be replaced by t.Context() in listPodsInNamespace (usetesting)`
24. ` unnecessary trailing newline (whitespace)`
25. `commentFormatting: put a space between `//` and comment text (gocritic)`

Note: There are still a couple linting errors left, but they may require a bit more logic to resolve so I didn't want to include them here.