### PR TITLE
Keep kubeletstats CPU usage metrics disabled by default

### DIFF
--- a/.chloggen/disable-kubelet-cpu-usage-metrics-by-default.yaml
+++ b/.chloggen/disable-kubelet-cpu-usage-metrics-by-default.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Keep the kubelet CPU usage metrics disabled by default for Splunk Observability users
+# One or more tracking issues related to the change
+issues: [1822]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `k8s.node.cpu.usage`, `k8s.pod.cpu.usage` and `container.cpu.usage` metrics are enabled by default in the kubeletstats
+  receiver upstream, but we disable them for Splunk Observability users because they are not included in the default
+  metrics set. If enabled, they will be charged as custom metrics. For now, `container_cpu_utilization` should still be
+  used. Later, it will be replaced with one of the CPU metrics from the kubelet receiver once they are fully stabilized
+  (e.g., `container.cpu.usage` or `container.cpu.time`).

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -339,6 +339,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 06450de50425c909d846c742e7544cf35d93c54a8af41dce186452da9041e90b
+        checksum/config: d26b0d586f4d3211bdf8f2661cb9ed388eace611064b6031ad8b01564fccf6b7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -295,6 +295,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 71c532ae7e57d02884df5b06da43db9d375fe3d532c5d7d8d79523858c7c6746
+        checksum/config: 2fd632edb91bde6432e819b1c109de4c8a19391c9947f4fad15efa06f466156c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7c41e99b608fe8e5860a51894fa33f9b51bd226cb8a940190c3c06271fbd98c5
+        checksum/config: ef0a3205e5092b5636829d97bc7a38bc95a423505ef02ae10d84670bcfbfb51c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -173,6 +173,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a220b82fd0a7d0e7189304aa83d356ff94cafa550b2990f9a172e9f3518985f3
+        checksum/config: fcaec49973c2959f3f1b44874ca826f3a8c467519cb22380066720267812bf13
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -323,6 +323,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6bc80121da57b5eeea99a0b9fa285c9bb977d81e751d3c72feb2663410a0bf09
+        checksum/config: e13a1175e2f22ab967db545c6e0c70806fc7e0b6e78a67f97d9c28ba866652ee
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cdb4b3f808634878c1a5d6f52c5789c863046e6eaff62199b3b1497297d1681b
+        checksum/config: 10253913c3032ae9bb670379ac59850c3f46ad9d13f0eb0365c969357b838069
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -152,6 +152,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 14b1643facfac30f937fce4d7a168f22521a410b268b7f29fd5893ef0eef9555
+        checksum/config: c36c2624dea028dc7762ece0395f99b2cbfc253b2b620f1c631658391f80bcdd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -175,6 +175,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 20d0cdbfdf8d0c1038dcd95b884e3144976a8b2b870776c7cad2d601e89e6046
+        checksum/config: b520400ef0137600e8e25e9b9aea2534b61b700c809f6e1e9589b01968a88bdb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cdb4b3f808634878c1a5d6f52c5789c863046e6eaff62199b3b1497297d1681b
+        checksum/config: 10253913c3032ae9bb670379ac59850c3f46ad9d13f0eb0365c969357b838069
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cdb4b3f808634878c1a5d6f52c5789c863046e6eaff62199b3b1497297d1681b
+        checksum/config: 10253913c3032ae9bb670379ac59850c3f46ad9d13f0eb0365c969357b838069
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6552b5f5d20895b121196750edd9ffe6d9df58c2162469ff5b17bfe7f660fb9e
+        checksum/config: 44c1cf6d8a131f6a48602305105f85ff4fdfcd78497756c16f85d7fac9ae9afa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -173,6 +173,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f00119ec35381b3bc87ee74eda5d6b4e148f5a066069181062fd3ed0c28cc4bd
+        checksum/config: 48a922d4a2d062b8f87c6accb589cd09f0c804d29ada09c6ffd858056e4f4189
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -172,6 +172,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 42e8937348fd76361e5e2c7988d1301194bd7b1f473bfcac997b6e874be49365
+        checksum/config: 206ef7cb1cbd9927238aa54e80a44d8fe82ee85c754b12d267a7792f83351dfe
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -171,6 +171,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 677837eea1b37e348118bb10338f7b2cc479f83c59c265edd42505f8f2fbb8e6
+        checksum/config: a82ddc1a76b0769c6cb7dadc0013f68704acc4f4f70a3ecf4ca48adfc23e4052
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -171,6 +171,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 38c1adbd733796f1f4abf925dbc198ed8cc0afdbf88829163cc8f2ccd872a473
+        checksum/config: f2588d9569587cf382b9236bb5d6e5d674b9e730e73c7e143b7b323b671b7cd7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 21e9b8fd9ec1c9e4cc44dd23d7b9615b2e119bb896bb79c90a4dd82c8905753a
+        checksum/config: 8612137f053383188ea9074d8811d74bad9e7c029f63601d354f61e703ceaa83
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -293,6 +293,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 483cfbf0e2a9efc50f53f953eecd8b72c1e7f2697f3b37d3f56e3551162093e2
+        checksum/config: 363e3fbc54011294150e7543af4e81aa50731fbd797a2e7888557376d8c293cb
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -171,6 +171,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 18c3906c08ea0180c98251dc6c84398a372b134c59b12d8bfdf2f1ac881244e7
+        checksum/config: 35d9310762d525066e748cd635a34232ce4cf4515942416833285d390ac947e6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -188,6 +188,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5481070cc5d55c59a4dc315a0d7abf084a4b87e355cb2dd182be7c97f6c74e69
+        checksum/config: c1223dcd05c79929545219993c29141ed98ee7ec1541b46dd8acf13da3ae1ca4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -188,6 +188,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 14db228efc92816af803f8588335db3bafa5a6d30080c4e6e1d557e223aa62e3
+        checksum/config: c24e86df063cc272d76676c2b73f62f5d30b5cd33d00d277623f016d9e63fe95
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -292,6 +292,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f73ebe760acf13cdadcde13db7df152cf83359c90dc960cc4d7e7f8586c0a5a6
+        checksum/config: 9b099dd195dc532ff1b4f0a696d385b2f2e4a6ad92ba0797ab4fe17cba6e2034
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -159,6 +159,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1686a24922efd459f23e546ab338d41b64ebd2915c397fbb72e121049a7cb6b2
+        checksum/config: 5b4f0a97da490c71159e4df897cac4d4984c5e93bfb26957d5763dae142ba5a6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -174,6 +174,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 554db3cd8819c59d32e333c0304893202532ce11e9040726a0a823e8b89bad2d
+        checksum/config: f7262c75457c33a2965e57636cae82ab874c4ab1f8e43b0a6352754c33c86b26
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5dc0428d64af47838cc4bc5db17e2dc384cf06c763eb902a1b3f6acee5aef2ef
+        checksum/config: 7bc36d47733bb3d0aa5600b6c21e9143e35cce2e02b0432798d2d18121988374
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cdb4b3f808634878c1a5d6f52c5789c863046e6eaff62199b3b1497297d1681b
+        checksum/config: 10253913c3032ae9bb670379ac59850c3f46ad9d13f0eb0365c969357b838069
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -170,6 +170,13 @@ data:
         - container
         - pod
         - node
+        metrics:
+          container.cpu.usage:
+            enabled: false
+          k8s.node.cpu.usage:
+            enabled: false
+          k8s.pod.cpu.usage:
+            enabled: false
       nop: null
       otlp:
         protocols:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9b12833a007e66dec8abbe0aa8312cf1f487b88047427b6e8e3d9d58dd8b62b7
+        checksum/config: d548d105808a0b15e6edb867781f54fc207fbb99976c0c10998dec3f7c1c2374
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -402,6 +402,16 @@ receivers:
     extra_metadata_labels:
       - container.id
       # - k8s.volume.type
+    {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
+    # Disable CPU usage metrics as they are not categorized as bundled in Splunk Observability
+    metrics:
+      container.cpu.usage:
+        enabled: false
+      k8s.pod.cpu.usage:
+        enabled: false
+      k8s.node.cpu.usage:
+        enabled: false
+    {{- end }}
 
   signalfx:
     endpoint: 0.0.0.0:9943


### PR DESCRIPTION
They are turned to enabled in 0.125.0, but we shouldn't send them to Splunk Observability yet.
