### PR TITLE
[chore] Fix remaining linting errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,10 +54,6 @@ linters:
 
     # Excluding configuration per-path, per-linter, per-text and per-source
     rules:
-      - linters:
-          - unused
-        path: pagefile.go # This exclusion is required for Windows only
-        text: cachedBytes
 
     # Log a warning if an exclusion rule is unused.
     warn-unused: true

--- a/Makefile.common
+++ b/Makefile.common
@@ -54,6 +54,7 @@ misspell-correction: $(TOOLS_BIN_DIR)/misspell
 gofmt: $(GOFUMPT) $(GOIMPORTS) misspell-correction
 	gofmt -w -s .
 	$(GOFUMPT) -l -w .
+	$(MAKE) gogci
 	$(GOIMPORTS) -w -local github.com/signalfx/splunk-otel-collector-chart ./
 
 .PHONY: golint

--- a/functional_tests/discovery/discovery_test.go
+++ b/functional_tests/discovery/discovery_test.go
@@ -9,17 +9,16 @@ import (
 	"path/filepath"
 	"testing"
 
-	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/release"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"
+	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/signalfx/splunk-otel-collector-chart/functional_tests/internal"
 )

--- a/functional_tests/go.mod
+++ b/functional_tests/go.mod
@@ -25,7 +25,6 @@ require (
 	k8s.io/apimachinery v0.32.3
 	k8s.io/cli-runtime v0.32.2
 	k8s.io/client-go v0.32.3
-	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -212,6 +211,7 @@ require (
 	sigs.k8s.io/kustomize/api v0.18.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.18.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 // ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules

--- a/functional_tests/internal/api_server.go
+++ b/functional_tests/internal/api_server.go
@@ -4,7 +4,6 @@
 package internal
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,7 +21,6 @@ func SetupSignalFxAPIServer(t *testing.T) {
 		writer.WriteHeader(http.StatusOK)
 	})
 
-	_, cancelCtx := context.WithCancel(t.Context())
 	s := &http.Server{
 		Addr:              fmt.Sprintf("0.0.0.0:%d", SignalFxAPIPort),
 		Handler:           mux,
@@ -31,8 +29,9 @@ func SetupSignalFxAPIServer(t *testing.T) {
 
 	errCh := make(chan error)
 	t.Cleanup(func() {
-		cancelCtx()
-		err := <-errCh
+		err := s.Close()
+		require.NoError(t, err)
+		err = <-errCh
 		require.NoError(t, err)
 	})
 

--- a/functional_tests/internal/api_server.go
+++ b/functional_tests/internal/api_server.go
@@ -29,13 +29,17 @@ func SetupSignalFxAPIServer(t *testing.T) {
 		ReadHeaderTimeout: 60 * time.Minute,
 	}
 
+	errCh := make(chan error)
 	t.Cleanup(func() {
 		cancelCtx()
+		err := <-errCh
+		require.NoError(t, err)
 	})
 
 	go func() {
 		if err := s.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			require.NoError(t, err)
+			errCh <- err
 		}
+		errCh <- nil
 	}()
 }

--- a/functional_tests/internal/chart.go
+++ b/functional_tests/internal/chart.go
@@ -143,7 +143,8 @@ func getDependencyVersion(t *testing.T, dependency string, chartPath string) str
 	for _, dep := range dependencies {
 		depMap, _ := dep.(map[string]any)
 		if depMap["name"] == dependency {
-			version, ok := depMap["version"].(string)
+			var version string
+			version, ok = depMap["version"].(string)
 			require.True(t, ok, "Dependency version not found or invalid")
 			return version
 		}

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -207,6 +207,7 @@ func DeleteObject(t *testing.T, k8sClient *k8stest.K8sClient, objYAML string) {
 	require.NoError(t, yaml.Unmarshal([]byte(objYAML), obj))
 
 	if err := k8stest.DeleteObject(k8sClient, obj); err != nil {
+		// If an object that's being deleted is not found, it's considered successful deletion.
 		require.True(t, meta.IsNoMatchError(err) || strings.Contains(err.Error(), "not found"), "failed to delete object, err: %w", err)
 	}
 }

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -149,7 +149,7 @@ func CreateNamespace(t *testing.T, clientset *kubernetes.Clientset, name string)
 	require.NoError(t, err, "failed to create namespace %s", name)
 
 	require.Eventually(t, func() bool {
-		_, err := clientset.CoreV1().Namespaces().Get(t.Context(), name, metav1.GetOptions{})
+		_, err = clientset.CoreV1().Namespaces().Get(t.Context(), name, metav1.GetOptions{})
 		return err == nil
 	}, 1*time.Minute, 5*time.Second, "namespace %s is not available", name)
 }

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -208,6 +208,8 @@ func DeleteObject(t *testing.T, k8sClient *k8stest.K8sClient, objYAML string) {
 
 	if err := k8stest.DeleteObject(k8sClient, obj); err != nil {
 		// If an object that's being deleted is not found, it's considered successful deletion.
+		// Some tests delete all resources on setup to ensure a clean running environment,
+		// so it's a valid case to attempt to delete an object that doesn't exist.
 		require.True(t, meta.IsNoMatchError(err) || strings.Contains(err.Error(), "not found"), "failed to delete object, err: %w", err)
 	}
 }

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -12,20 +12,19 @@ import (
 	"testing"
 	"time"
 
-	k8stest "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
+	k8stest "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 )

--- a/functional_tests/istio/istio_test.go
+++ b/functional_tests/istio/istio_test.go
@@ -261,7 +261,7 @@ func sendWorkloadHTTPRequests(t *testing.T) {
 func deleteObject(t *testing.T, k8sClient *k8stest.K8sClient, objYAML string) {
 	obj := &unstructured.Unstructured{}
 	require.NoError(t, yaml.Unmarshal([]byte(objYAML), obj))
-	k8stest.DeleteObject(k8sClient, obj)
+	require.NoError(t, k8stest.DeleteObject(k8sClient, obj))
 }
 
 func Test_IstioMetrics(t *testing.T) {

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -19,8 +19,6 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -182,18 +180,12 @@ func teardown(t *testing.T, k8sClient *k8stest.K8sClient) {
 	testKubeConfig := os.Getenv("KUBECONFIG")
 	internal.ChartUninstall(t, testKubeConfig)
 
-	deleteObject(t, k8sClient, `
+	internal.DeleteObject(t, k8sClient, `
 apiVersion: v1
 kind: Namespace
 metadata:
   name: k8sevents-test
 `)
-}
-
-func deleteObject(t *testing.T, k8sClient *k8stest.K8sClient, objYAML string) {
-	obj := &unstructured.Unstructured{}
-	require.NoError(t, yaml.Unmarshal([]byte(objYAML), obj))
-	require.NoError(t, k8stest.DeleteObject(k8sClient, obj))
 }
 
 func selectResLogs(attributeName, attributeValue string, logSink *consumertest.LogsSink) plog.Logs {

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -193,7 +193,7 @@ metadata:
 func deleteObject(t *testing.T, k8sClient *k8stest.K8sClient, objYAML string) {
 	obj := &unstructured.Unstructured{}
 	require.NoError(t, yaml.Unmarshal([]byte(objYAML), obj))
-	k8stest.DeleteObject(k8sClient, obj)
+	require.NoError(t, k8stest.DeleteObject(k8sClient, obj))
 }
 
 func selectResLogs(attributeName, attributeValue string, logSink *consumertest.LogsSink) plog.Logs {

--- a/tools/empty_test.go
+++ b/tools/empty_test.go
@@ -1,0 +1,4 @@
+// Copyright Splunk Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package tools


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Linting errors being fixed (I've only included a single example of each kind of linting error):

1. ```functional_tests/istio/istio_test.go:263:22: Error return value of `k8stest.DeleteObject` is not checked (errcheck)```
2. ```functional_tests/functional/functional_test.go:300:26: shadow: declaration of "err" shadows declaration at line 92 (govet)```
3. ```functional_tests/functional/functional_test.go:350:29: context-as-argument: context.Context should be the first parameter of a function (revive)```
4. ```functional_tests/internal/api_server.go:38:4: go-require: require must only be used in the goroutine running the test function (testifylint)```