### PR TITLE
Change health check and prom internal metrics ports to a unique value

### DIFF
--- a/.chloggen/clusterreceiveruniqueports.yaml
+++ b/.chloggen/clusterreceiveruniqueports.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the cluster receiver internal metrics ports and healthcheck port to be unique, needed to avoid conflicts when running in host network namespace.
+# One or more tracking issues related to the change
+issues: [1859]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector
@@ -75,11 +75,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -32,7 +32,7 @@ data:
         token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -137,7 +137,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -183,7 +183,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1443ca5116860d6c85d3c192d973cfe6c265ba8728ed5a75b6a07b267727072e
+        checksum/config: 9372d43841c4ad5f94219f4b2d22673d501223fbdfcbec4694477f1662f47d70
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,7 +43,7 @@ data:
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -140,7 +140,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -176,7 +176,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d99d3e6e310b298b3592db1ec527775eaaba96e50f4eabe8cd518511a94a53b4
+        checksum/config: adc2618771734435c1d5a21fabe862a810a9481f63c00cad98b17d2bde652f47
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -94,7 +94,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -128,7 +128,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8cd7865c273329c823278ec93b6cae87c30917b96b8229321db6928d158cbe5e
+        checksum/config: 0fdc03066fc607984021e38cf9e6ad15c19a55801d6d2d64e9eeced63a095850
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -25,7 +25,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
       k8s_observer:
         auth_type: serviceAccount
         observe_nodes: true
@@ -97,7 +97,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
       receiver_creator:
         receivers:
           kubeletstats:
@@ -157,7 +157,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: af25314f28ad3b24ca8e712c16845d1d2d3abe038441542725d90ec3a5635649
+        checksum/config: 7c42a2b336e4cac40276a093826ef2500156c0a85962966bc0554a9cfacb4f67
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -107,11 +107,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -33,7 +33,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -101,7 +101,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
       prometheus/kubernetes-apiserver:
         config:
           scrape_configs:
@@ -161,7 +161,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c0c99650907decb8643ca6de5eeb310cca79df147e6db64e3862069df32c2bc7
+        checksum/config: cc247708dbe5f35e3d4728bbe5693f894aa2b9cf7a79f8b9b9c459c87bab33fa
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -93,7 +93,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -127,7 +127,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bf16c08d58401ae6f20470ff5926b2cd1bc1ba8ba1c69f6fb1fdc8b2622acd66
+        checksum/config: 3c2d0d605085e32d71122b127b8fc38ba1a07e50bd0969829640c02092d0b673
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -93,7 +93,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -127,7 +127,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bf16c08d58401ae6f20470ff5926b2cd1bc1ba8ba1c69f6fb1fdc8b2622acd66
+        checksum/config: 3c2d0d605085e32d71122b127b8fc38ba1a07e50bd0969829640c02092d0b673
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -93,7 +93,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -127,7 +127,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4a34b085d0beb5d0edc0471d77ead359687581a80c9242dda6c79c444c1aeba6
+        checksum/config: aa87519cdcf4edc24385c8d062e673687e9eebe804642293efc608dd102bb4ee
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fbc03846bf084d07c73b7fac591fe896ce5c81f39ae7396b2ab2d2c4003bd72a
+        checksum/config: 1d865a4b170b3be5a7c02629e79f59671084f40d1a73eb3f023a4583231b730b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,7 +43,7 @@ data:
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -140,7 +140,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -176,7 +176,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d99d3e6e310b298b3592db1ec527775eaaba96e50f4eabe8cd518511a94a53b4
+        checksum/config: adc2618771734435c1d5a21fabe862a810a9481f63c00cad98b17d2bde652f47
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -75,12 +75,12 @@ spec:
           initialDelaySeconds: 60
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           initialDelaySeconds: 60
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,7 +43,7 @@ data:
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -140,7 +140,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -176,7 +176,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d99d3e6e310b298b3592db1ec527775eaaba96e50f4eabe8cd518511a94a53b4
+        checksum/config: adc2618771734435c1d5a21fabe862a810a9481f63c00cad98b17d2bde652f47
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -43,7 +43,7 @@ data:
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -140,7 +140,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -176,7 +176,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d99d3e6e310b298b3592db1ec527775eaaba96e50f4eabe8cd518511a94a53b4
+        checksum/config: adc2618771734435c1d5a21fabe862a810a9481f63c00cad98b17d2bde652f47
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 32770aebb92fbcc5326aed5dd918326720202e95b176e74801da0f3882ac5e29
+        checksum/config: 7ea7bb417d191cb6268ec23e656fabdc98a0b80ec8e1a79e3b78e8363a9735d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -76,11 +76,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -26,7 +26,7 @@ data:
         timeout: 10s
     extensions:
       health_check:
-        endpoint: 0.0.0.0:13133
+        endpoint: 0.0.0.0:13134
     processors:
       batch:
         send_batch_max_size: 32768
@@ -92,7 +92,7 @@ data:
             scrape_interval: 10s
             static_configs:
             - targets:
-              - localhost:8889
+              - localhost:8899
     service:
       extensions:
       - health_check
@@ -126,7 +126,7 @@ data:
               exporter:
                 prometheus:
                   host: localhost
-                  port: 8889
+                  port: 8899
                   without_scope_info: true
                   without_type_suffix: true
                   without_units: true

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c52f76690cf9d3fa19576c63e81053bd92dd408933fefb8366b22a6fc4feabd
+        checksum/config: 9b3e23be59d5817ef8f8280f8c83220d34333c90130776341e87e6cf9e8fa5fd
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -74,11 +74,11 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           limits:
             cpu: 200m

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -559,8 +559,9 @@ Generates prometheus receiver config for internal metrics.
 Provide the component name as the input.
 */}}
 {{- define "splunk-otel-collector.prometheusInternalMetrics" -}}
-{{- $receiver := . | lower | replace "-" "_" }}
-{{- $job := . | lower }}
+{{- $receiver := .receiver | lower | replace "-" "_" }}
+{{- $job := .receiver | lower }}
+{{- $port := .port | default "8889" }}
 prometheus/{{ $receiver }}:
   config:
     scrape_configs:
@@ -576,5 +577,5 @@ prometheus/{{ $receiver }}:
         - __name__
       scrape_interval: 10s
       static_configs:
-      - targets: [localhost:8889]
+      - targets: [localhost:{{ $port }}]
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -46,7 +46,7 @@ receivers:
   {{- end }}
 
   # Prometheus receiver scraping metrics from the pod itself
-  {{- include "splunk-otel-collector.prometheusInternalMetrics" "agent" | nindent 2}}
+  {{- include "splunk-otel-collector.prometheusInternalMetrics" (dict "receiver" "agent") | nindent 2}}
 
   {{- if (eq (include "splunk-otel-collector.metricsEnabled" .) "true") }}
   hostmetrics:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -19,7 +19,7 @@ receivers:
   {{- include "splunk-otel-collector.otelReceivers" . | nindent 2 }}
 
   # Prometheus receiver scraping metrics from the pod itself
-  {{- include "splunk-otel-collector.prometheusInternalMetrics" "collector" | nindent 2}}
+  {{- include "splunk-otel-collector.prometheusInternalMetrics" (dict "receiver" "collector") | nindent 2}}
 
   signalfx:
     endpoint: 0.0.0.0:9943

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -6,7 +6,7 @@ The values can be overridden in .Values.clusterReceiver.config
 {{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) -}}
 extensions:
   health_check:
-    endpoint: 0.0.0.0:13133
+    endpoint: 0.0.0.0:13134
 
   {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
   # k8s_observer w/ pod and node detection for eks/fargate deployment
@@ -18,7 +18,7 @@ extensions:
 
 receivers:
   # Prometheus receiver scraping metrics from the pod itself
-  {{- include "splunk-otel-collector.prometheusInternalMetrics" "k8s-cluster-receiver" | nindent 2}}
+  {{- include "splunk-otel-collector.prometheusInternalMetrics" (dict "receiver" "k8s-cluster-receiver" "port" "8899") | nindent 2}}
 
   k8s_cluster:
     auth_type: serviceAccount
@@ -292,7 +292,7 @@ service:
             exporter:
               prometheus:
                 host: localhost
-                port: 8889
+                port: 8899
                 without_scope_info: true
                 without_units: true
                 without_type_suffix: true

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -180,14 +180,14 @@ spec:
           {{- end }}
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         livenessProbe:
           {{- if .Values.livenessProbe.initialDelaySeconds }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           {{- end }}
           httpGet:
             path: /
-            port: 13133
+            port: 13134
         resources:
           {{- toYaml $clusterReceiver.resources | nindent 10 }}
         volumeMounts:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Breaking down https://github.com/signalfx/splunk-otel-collector-chart/pull/1856 into multiple PR.
This is needed in preparation to allow running Cluster Receiver in host network namespace without conflicting with the agent
This PR does NOT depend on other upstream changes

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
