### PR TITLE
fix scrape target for rule type == port

### DIFF
--- a/.chloggen/fixapiserverrule.yaml
+++ b/.chloggen/fixapiserverrule.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix scrape target in prometheus receivers added for k8s controlPlaneMetrics.
+# One or more tracking issues related to the change
+issues: [1865]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -245,7 +245,7 @@ data:
                   scheme: https
                   static_configs:
                   - targets:
-                    - '`endpoint`:`port`'
+                    - '`endpoint`'
                   tls_config:
                     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                     insecure_skip_verify: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4c68dc929cca0cc2217a2caaa0c028b9835633094e99697c0212e96ba38e8f59
+        checksum/config: 8b0b91b3c4aab87ca2913cc5d95e29d7127466be7bb7ca86222d289955a01e4c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -323,7 +323,7 @@ receivers:
                 ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
                 insecure_skip_verify: true
               static_configs:
-                - targets: ["`endpoint`:`port`"]
+                - targets: ["`endpoint`"]
       {{- end }}
       {{- if .Values.agent.controlPlaneMetrics.proxy.enabled }}
       prometheus/kubernetes-proxy:
@@ -345,7 +345,7 @@ receivers:
                 credentials_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
                 type: Bearer
               static_configs:
-                - targets: ["`endpoint`:`port`"]
+                - targets: ["`endpoint`"]
               {{- else }}
               static_configs:
                 - targets: ["`endpoint`:10249"]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Endpoint is of the form `ip:port` when rule type is `port` for k8sobserver. This PR updates 2 k8s control plane prometheus receiver configs to fix scrape targets which are incorrectly using an extra `:port`.

**Testing:** <Describe what testing was performed and which tests were added.>
Ran the kubernetes-apiserver receiver in a kops cluster.
