### PR TITLE
[chore][CICD] Upgrade GO_VERSION to 1.24.4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION:1.24.4
+  GO_VERSION: 1.24.4
 jobs:
   setup-environment:
     timeout-minutes: 30

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.24.2
+  GO_VERSION:1.24.4
 jobs:
   setup-environment:
     timeout-minutes: 30

--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.24.1
+  GO_VERSION:1.24.4
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION:1.24.4
+  GO_VERSION: 1.24.4
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -16,7 +16,7 @@ on:
         default: false
 
 env:
-  GO_VERSION: 1.23.6
+  GO_VERSION: 1.24.4
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Checks are currently failing detecting vulnerabilities in `go 1.24.2`. This upgrades the golang version used in testing to resolve vulns.