### PR TITLE
[chore] Fix and improve functional-tests ghwf UPDATE_EXPECTED_RESULTS usage

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -6,14 +6,22 @@ on:
     branches: [ main ]
   workflow_dispatch:
     inputs:
-      UPLOAD_UPDATED_EXPECTED_RESULTS:
-        description: 'Set this to true to upload updated golden file expected results and upload these results as a Github workflow artifact.'
+      UPDATE_EXPECTED_RESULTS:
+        description: 'UPDATE_EXPECTED_RESULTS: Set this to true to update the golden file expected test results (if applicable) and upload them as a GitHub workflow run artifact.'
         required: false
         default: false
-      UPLOAD_KUBERNETES_DEBUG_INFO:
-        description: 'Set this to true to collect the debug info of the k8s cluster and upload this info as a Github workflow artifact.'
+        type: choice
+        options:
+          - false
+          - true
+      KUBERNETES_DEBUG_INFO:
+        description: 'KUBERNETES_DEBUG_INFO: Set this to true to collect the debug info of the k8s cluster and upload this info as a Github workflow artifact.'
         required: false
         default: false
+        type: choice
+        options:
+          - false
+          - true
 
 env:
   GO_VERSION: 1.24.4
@@ -40,8 +48,8 @@ jobs:
     env:
       KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing
       KUBE_TEST_ENV: kind
-      UPLOAD_UPDATED_EXPECTED_RESULTS: ${{ github.event.inputs.UPLOAD_UPDATED_EXPECTED_RESULTS || 'false' }}
-      UPLOAD_KUBERNETES_DEBUG_INFO: ${{ github.event.inputs.UPLOAD_KUBERNETES_DEBUG_INFO || 'false' }}
+      UPDATE_EXPECTED_RESULTS: ${{ github.event.inputs.UPDATE_EXPECTED_RESULTS || 'false' }}
+      KUBERNETES_DEBUG_INFO: ${{ github.event.inputs.KUBERNETES_DEBUG_INFO || 'false' }}
     needs: get-test-matrix
     strategy:
       fail-fast: false
@@ -72,27 +80,27 @@ jobs:
         env:
           K8S_VERSION: ${{ matrix.k8s-kind-version }}
         run: |
-          TEARDOWN_BEFORE_SETUP=true UPDATE_EXPECTED_RESULTS=${{ env.UPLOAD_UPDATED_EXPECTED_RESULTS }} SUITE=${{ matrix.test-job }} make functionaltest
+          TEARDOWN_BEFORE_SETUP=true UPDATE_EXPECTED_RESULTS=${{ env.UPDATE_EXPECTED_RESULTS }} SUITE=${{ matrix.test-job }} make functionaltest
       - name: Collect Kubernetes Cluster debug info on failure
-        if: always() && (steps.run-functional-tests.outcome == 'failure' || env.UPLOAD_KUBERNETES_DEBUG_INFO == 'true')
+        if: always() && (steps.run-functional-tests.outcome == 'failure' || env.KUBERNETES_DEBUG_INFO == 'true')
         id: collect-debug-info
         run: |
           echo "Functional tests failed. Collecting debug info for current state of the Kubernetes cluster..."
           cd tools
           ./splunk_kubernetes_debug_info.sh
       - name: Upload Kubernetes Cluster debug info
-        if: always() && (steps.run-functional-tests.outcome == 'failure' || env.UPLOAD_KUBERNETES_DEBUG_INFO == 'true')
+        if: always() && (steps.run-functional-tests.outcome == 'failure' || env.KUBERNETES_DEBUG_INFO == 'true')
         uses: actions/upload-artifact@v4
         with:
           name: k8s-debug-info-${{ matrix.test-job }}-${{ matrix.k8s-kind-version }}
           path: tools/splunk_kubernetes_debug_info_*
           retention-days: 5
-      - name: Upload test results
-        if: always() && env.UPLOAD_UPDATED_EXPECTED_RESULTS == 'true'
+      - name: Upload updated files artifact
+        if: always() && env.UPDATE_EXPECTED_RESULTS == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: functional_tests-${{ matrix.test-job }}-${{ matrix.k8s-kind-version }}
-          path: functional_tests/results
+          name: updated_expected_results-${{ matrix.test-job }}-${{ matrix.k8s-kind-version }}
+          path: ./functional_tests/**/*.yaml
           retention-days: 5
 
   eks-test:

--- a/functional_tests/README.md
+++ b/functional_tests/README.md
@@ -30,7 +30,10 @@ When running tests you can use the following env vars to help with local develop
 - `SKIP_TESTS`: Skip tests; only set up and tear down the cluster.
 - `TEARDOWN_BEFORE_SETUP`: Clean up deployments before setting up.
 - `SUITE`: Specify which test suite to run (e.g., `SUITE="functional"`).
-- `UPDATE_EXPECTED_RESULTS`: Generate new golden files for test results.
+- `UPDATE_EXPECTED_RESULTS`: Generate new golden files (expected test results) for the functional tests.
+  - The https://github.com/signalfx/splunk-otel-collector-chart/actions/workflows/functional_test_v2.yaml workflow can
+    be used with the dispatch trigger and input `UPLOAD_UPDATED_EXPECTED_RESULTS=true` to generate new results and upload
+    them as a github workflow run artifact.
 
 ## Run
 

--- a/functional_tests/README.md
+++ b/functional_tests/README.md
@@ -32,7 +32,7 @@ When running tests you can use the following env vars to help with local develop
 - `SUITE`: Specify which test suite to run (e.g., `SUITE="functional"`).
 - `UPDATE_EXPECTED_RESULTS`: Generate new golden files (expected test results) for the functional tests.
   - The https://github.com/signalfx/splunk-otel-collector-chart/actions/workflows/functional_test_v2.yaml workflow can
-    be used with the dispatch trigger and input `UPLOAD_UPDATED_EXPECTED_RESULTS=true` to generate new results and upload
+    be used with the dispatch trigger and input `UPDATE_EXPECTED_RESULTS=true` to generate new results and upload
     them as a github workflow run artifact.
 
 ## Run

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -549,6 +549,7 @@ func testNodeJSTraces(t *testing.T) {
 	maskScopeVersion(*selectedTrace)
 	maskScopeVersion(expectedTraces)
 
+	internal.MaybeWriteUpdateExpectedTracesResults(t, expectedTracesFile, selectedTrace)
 	err = ptracetest.CompareTraces(expectedTraces, *selectedTrace,
 		ptracetest.IgnoreResourceAttributeValue("container.id"),
 		ptracetest.IgnoreResourceAttributeValue("host.arch"),
@@ -582,9 +583,6 @@ func testNodeJSTraces(t *testing.T) {
 		ptracetest.IgnoreScopeSpansOrder(),
 		ptracetest.IgnoreScopeSpanInstrumentationScopeVersion(),
 	)
-	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-		internal.WriteNewExpectedTracesResult(t, expectedTracesFile, selectedTrace)
-	}
 	require.NoError(t, err)
 }
 
@@ -619,6 +617,7 @@ func testPythonTraces(t *testing.T) {
 	maskScopeVersion(*selectedTrace)
 	maskScopeVersion(expectedTraces)
 
+	internal.MaybeWriteUpdateExpectedTracesResults(t, expectedTracesFile, selectedTrace)
 	err = ptracetest.CompareTraces(expectedTraces, *selectedTrace,
 		ptracetest.IgnoreResourceAttributeValue("container.id"),
 		ptracetest.IgnoreResourceAttributeValue("host.arch"),
@@ -651,9 +650,6 @@ func testPythonTraces(t *testing.T) {
 		ptracetest.IgnoreResourceSpansOrder(),
 		ptracetest.IgnoreScopeSpansOrder(),
 	)
-	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-		internal.WriteNewExpectedTracesResult(t, expectedTracesFile, selectedTrace)
-	}
 	require.NoError(t, err)
 }
 
@@ -686,6 +682,7 @@ func testJavaTraces(t *testing.T) {
 	maskScopeVersion(*selectedTrace)
 	maskScopeVersion(expectedTraces)
 
+	internal.MaybeWriteUpdateExpectedTracesResults(t, expectedTracesFile, selectedTrace)
 	err = ptracetest.CompareTraces(expectedTraces, *selectedTrace,
 		ptracetest.IgnoreResourceAttributeValue("os.description"),
 		ptracetest.IgnoreResourceAttributeValue("process.pid"),
@@ -715,9 +712,6 @@ func testJavaTraces(t *testing.T) {
 		ptracetest.IgnoreResourceSpansOrder(),
 		ptracetest.IgnoreScopeSpansOrder(),
 	)
-	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-		internal.WriteNewExpectedTracesResult(t, expectedTracesFile, selectedTrace)
-	}
 	require.NoError(t, err)
 }
 
@@ -751,6 +745,7 @@ func testDotNetTraces(t *testing.T) {
 	maskSpanParentID(*selectedTrace)
 	maskSpanParentID(expectedTraces)
 
+	internal.MaybeWriteUpdateExpectedTracesResults(t, expectedTracesFile, selectedTrace)
 	err = ptracetest.CompareTraces(expectedTraces, *selectedTrace,
 		ptracetest.IgnoreResourceAttributeValue("os.description"),
 		ptracetest.IgnoreResourceAttributeValue("process.pid"),
@@ -780,9 +775,6 @@ func testDotNetTraces(t *testing.T) {
 		ptracetest.IgnoreResourceSpansOrder(),
 		ptracetest.IgnoreScopeSpansOrder(),
 	)
-	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-		internal.WriteNewExpectedTracesResult(t, expectedTracesFile, selectedTrace)
-	}
 	require.NoError(t, err)
 }
 
@@ -867,6 +859,7 @@ func testK8sClusterReceiverMetrics(t *testing.T) {
 
 	metricNames := []string{"k8s.node.condition_ready", "k8s.namespace.phase", "k8s.pod.phase", "k8s.replicaset.desired", "k8s.replicaset.available", "k8s.daemonset.ready_nodes", "k8s.daemonset.misscheduled_nodes", "k8s.daemonset.desired_scheduled_nodes", "k8s.daemonset.current_scheduled_nodes", "k8s.container.ready", "k8s.container.memory_request", "k8s.container.memory_limit", "k8s.container.cpu_request", "k8s.container.cpu_limit", "k8s.deployment.desired", "k8s.deployment.available", "k8s.container.restarts", "k8s.container.cpu_request", "k8s.container.memory_request", "k8s.container.memory_limit"}
 
+	internal.MaybeUpdateExpectedMetricsResults(t, expectedMetricsFile, selectedMetrics)
 	err = pmetrictest.CompareMetrics(expectedMetrics, *selectedMetrics,
 		pmetrictest.IgnoreTimestamp(),
 		pmetrictest.IgnoreStartTimestamp(),
@@ -904,9 +897,6 @@ func testK8sClusterReceiverMetrics(t *testing.T) {
 		pmetrictest.IgnoreMetricDataPointsOrder(),
 		pmetrictest.IgnoreSubsequentDataPoints("k8s.container.ready", "k8s.container.restarts", "k8s.pod.phase"),
 	)
-	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-		internal.WriteNewExpectedMetricsResult(t, expectedMetricsFile, selectedMetrics)
-	}
 	require.NoError(t, err)
 }
 
@@ -1135,6 +1125,7 @@ func testAgentMetrics(t *testing.T) {
 	}
 	require.NotNil(t, selectedInternalMetrics)
 
+	internal.MaybeUpdateExpectedMetricsResults(t, expectedInternalMetricsFile, selectedInternalMetrics)
 	err = pmetrictest.CompareMetrics(expectedInternalMetrics, *selectedInternalMetrics,
 		pmetrictest.IgnoreTimestamp(),
 		pmetrictest.IgnoreStartTimestamp(),
@@ -1177,9 +1168,6 @@ func testAgentMetrics(t *testing.T) {
 		pmetrictest.IgnoreMetricDataPointsOrder(),
 		pmetrictest.IgnoreSubsequentDataPoints("otelcol_receiver_accepted_log_records", "otelcol_receiver_refused_log_records"),
 	)
-	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-		internal.WriteNewExpectedMetricsResult(t, expectedInternalMetricsFile, selectedInternalMetrics)
-	}
 	assert.NoError(t, err)
 
 	expectedKubeletStatsMetricsFile := filepath.Join(testDir, expectedValuesDir, "expected_kubeletstats_metrics.yaml")
@@ -1192,6 +1180,7 @@ func testAgentMetrics(t *testing.T) {
 	}
 	require.NotNil(t, selectedKubeletstatsMetrics)
 
+	internal.MaybeUpdateExpectedMetricsResults(t, expectedKubeletStatsMetricsFile, selectedKubeletstatsMetrics)
 	err = pmetrictest.CompareMetrics(expectedKubeletStatsMetrics, *selectedKubeletstatsMetrics,
 		pmetrictest.IgnoreTimestamp(),
 		pmetrictest.IgnoreStartTimestamp(),
@@ -1231,9 +1220,6 @@ func testAgentMetrics(t *testing.T) {
 		pmetrictest.IgnoreScopeMetricsOrder(),
 		pmetrictest.IgnoreMetricDataPointsOrder(),
 	)
-	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-		internal.WriteNewExpectedMetricsResult(t, expectedKubeletStatsMetricsFile, selectedKubeletstatsMetrics)
-	}
 	assert.NoError(t, err)
 }
 

--- a/functional_tests/histogram/histogram_test.go
+++ b/functional_tests/histogram/histogram_test.go
@@ -148,12 +148,10 @@ func runMetricsTest(t *testing.T, isHistogram bool, metricsSink *consumertest.Me
 	}
 
 	assert.NotNil(t, actualMetrics, "Did not receive any metrics for component %s", input.ServiceName)
+	internal.MaybeUpdateExpectedMetricsResults(t, filepath.Join(testDir, fileName), actualMetrics)
 	err := checkMetrics(t, isHistogram, expectedMetrics, actualMetrics, input.ServiceName)
 	if err != nil {
 		t.Errorf("Error occurred while checking metrics for component %s: %v", input.ServiceName, err)
-		if os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-			internal.WriteNewExpectedMetricsResult(t, filepath.Join(testDir, fileName), actualMetrics)
-		}
 	}
 }
 

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -99,19 +99,29 @@ func ResetLogsSink(t *testing.T, lc *consumertest.LogsSink) {
 	t.Logf("Logs sink reset, current logs: %d", len(lc.AllLogs()))
 }
 
-func WriteNewExpectedTracesResult(t *testing.T, file string, trace *ptrace.Traces) {
-	require.NoError(t, os.MkdirAll("results", 0o755))
-	require.NoError(t, golden.WriteTraces(t, filepath.Join("results", filepath.Base(file)), *trace))
+var shouldUpdateExpectedResults = func() bool {
+	return os.Getenv("UPDATE_EXPECTED_RESULTS") == "true"
 }
 
-func WriteNewExpectedMetricsResult(t *testing.T, file string, metric *pmetric.Metrics) {
-	require.NoError(t, os.MkdirAll("results", 0o755))
-	require.NoError(t, golden.WriteMetrics(t, filepath.Join("results", filepath.Base(file)), *metric))
+func MaybeWriteUpdateExpectedTracesResults(t *testing.T, file string, traces *ptrace.Traces) {
+	if shouldUpdateExpectedResults() {
+		require.NoError(t, golden.WriteTraces(t, filepath.Base(file), *traces))
+		t.Logf("Wrote updated expected trace results to %s", filepath.Base(file))
+	}
 }
 
-func WriteNewExpectedLogsResult(t *testing.T, file string, log *plog.Logs) {
-	require.NoError(t, os.MkdirAll("results", 0o755))
-	require.NoError(t, golden.WriteLogs(t, filepath.Join("results", filepath.Base(file)), *log))
+func MaybeUpdateExpectedMetricsResults(t *testing.T, file string, metrics *pmetric.Metrics) {
+	if shouldUpdateExpectedResults() {
+		require.NoError(t, golden.WriteMetrics(t, filepath.Base(file), *metrics))
+		t.Logf("Wrote updated expected metric results to %s", filepath.Base(file))
+	}
+}
+
+func MaybeUpdateExpectedLogsResults(t *testing.T, file string, logs *plog.Logs) {
+	if shouldUpdateExpectedResults() {
+		require.NoError(t, golden.WriteLogs(t, filepath.Base(file), *logs))
+		t.Logf("Wrote updated expected log results to %s", filepath.Base(file))
+	}
 }
 
 func CheckPodsReady(t *testing.T, clientset *kubernetes.Clientset, namespace, labelSelector string,

--- a/functional_tests/istio/istio_test.go
+++ b/functional_tests/istio/istio_test.go
@@ -320,6 +320,7 @@ func testIstioMetrics(t *testing.T, expectedMetricsFile string, includeMetricNam
 		}
 	}
 
+	internal.MaybeUpdateExpectedMetricsResults(t, expectedMetricsFile, selectedMetrics)
 	err = pmetrictest.CompareMetrics(expectedMetrics, *selectedMetrics,
 		pmetrictest.IgnoreTimestamp(),
 		pmetrictest.IgnoreStartTimestamp(),
@@ -341,9 +342,6 @@ func testIstioMetrics(t *testing.T, expectedMetricsFile string, includeMetricNam
 		pmetrictest.IgnoreMetricAttributeValue("event"),
 		pmetrictest.IgnoreSubsequentDataPoints(metricNames...),
 	)
-	if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-		internal.WriteNewExpectedMetricsResult(t, expectedMetricsFile, selectedMetrics)
-	}
 	require.NoError(t, err)
 }
 

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -77,6 +77,7 @@ func Test_K8SEvents(t *testing.T) {
 		expectedEventsLogs, err := golden.ReadLogs(expectedEventsLogsFile)
 		require.NoError(t, err, "failed to read expected events logs from file")
 
+		internal.MaybeUpdateExpectedLogsResults(t, expectedEventsLogsFile, &k8sEventsLogs)
 		err = plogtest.CompareLogs(expectedEventsLogs, k8sEventsLogs,
 			plogtest.IgnoreTimestamp(),
 			plogtest.IgnoreObservedTimestamp(),
@@ -89,9 +90,6 @@ func Test_K8SEvents(t *testing.T) {
 			plogtest.IgnoreScopeLogsOrder(),
 			plogtest.IgnoreLogRecordsOrder(),
 		)
-		if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-			internal.WriteNewExpectedLogsResult(t, expectedEventsLogsFile, &k8sEventsLogs)
-		}
 		require.NoError(t, err)
 	})
 
@@ -114,6 +112,7 @@ func Test_K8SEvents(t *testing.T) {
 		expectedObjectsLogs, err := golden.ReadLogs(expectedObjectsLogsFile)
 		require.NoError(t, err, "failed to read expected objects logs from file")
 
+		internal.MaybeUpdateExpectedLogsResults(t, expectedObjectsLogsFile, &k8sObjectsLogs)
 		err = plogtest.CompareLogs(expectedObjectsLogs, k8sObjectsLogs,
 			plogtest.IgnoreTimestamp(),
 			plogtest.IgnoreObservedTimestamp(),
@@ -125,9 +124,6 @@ func Test_K8SEvents(t *testing.T) {
 			plogtest.IgnoreScopeLogsOrder(),
 			plogtest.IgnoreLogRecordsOrder(),
 		)
-		if err != nil && os.Getenv("UPDATE_EXPECTED_RESULTS") == "true" {
-			internal.WriteNewExpectedLogsResult(t, expectedObjectsLogsFile, &k8sObjectsLogs)
-		}
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
- The functional tests GitHub workflow previously supported uploading updated expected test results, allowing us to generate new results using GitHub Actions. However, this functionality appears to have broken due to recent refactors in the functional tests.
- This PR addresses the issue by restoring the ability to update functional test results via GitHub Actions, ensuring compatibility with Istio and other test cases. See README.md in changes for usage.
- Example of a workflow run from my fork that generated the artifacts.
  - https://github.com/jvoravong/splunk-otel-collector-chart/actions/runs/15836449587