### PR TITLE
Add trafficDistribution support to the gateway and agent services

### DIFF
--- a/.chloggen/trafficDistribution.yaml
+++ b/.chloggen/trafficDistribution.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: gateway
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add trafficDistribution support to the gateway services.
+# One or more tracking issues related to the change
+issues: [1874]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -20,6 +20,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}
   ports:
   {{- range $key, $port := $gateway.ports }}
   {{- $metricsEnabled   := and (eq (include "splunk-otel-collector.metricsEnabled"   $) "true") (has "metrics"   $port.enabled_for) }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1428,6 +1428,15 @@
             "ExternalName"
           ]
         },
+        "trafficDistribution": {
+          "type": "string",
+          "enum": [
+            "",
+            "PreferClose",
+            "PreferSameZone",
+            "PreferSameNode"
+          ]
+        },
         "annotations": {
           "type": "object"
         }

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1195,6 +1195,8 @@ gateway:
 service:
   # Service type
   type: ClusterIP
+  # Traffic distribution strategy for the service.  Only available for Kubernetes >= 1.33.
+  trafficDistribution: ""
   # Service annotations
   annotations: {}
 


### PR DESCRIPTION
Replaces https://github.com/signalfx/splunk-otel-collector-chart/pull/1772