### PR TITLE
Enable discovery on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ bin/
 **__snapshot__**
 
 .tools/
+
+# dotnet related files created when opening the repository in VSCode (if dotnet related extensions are installed)
+functional_tests/functional/testdata/dotnet/obj
+chart.sln

--- a/examples/kubernetes-windows-nodes/README.md
+++ b/examples/kubernetes-windows-nodes/README.md
@@ -3,5 +3,5 @@
 ## How to install the collector on a Kubernetes cluster with Windows nodes
 
 In this example, we show how you can deploy the collector agent and cluster receiver to Kubernetes Windows nodes. See the
-[Windows Worker Nodes Support](https://docs.splunk.com/Observability/gdi/opentelemetry/kubernetes-config.html#configure-windows-worker-nodes)
+[Windows Worker Nodes Support](https://help.splunk.com/en/splunk-observability-cloud/manage-data/splunk-distribution-of-the-opentelemetry-collector/get-started-with-the-splunk-distribution-of-the-opentelemetry-collector/collector-for-kubernetes/configure-with-helm#configure-windows-worker-nodes-0)
 documentation for more details.

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -253,7 +253,7 @@ spec:
         {{- if .Values.agent.featureGates }}
         - --feature-gates={{ .Values.agent.featureGates }}
         {{- end }}
-        {{- if and .Values.agent.discovery.enabled (not .Values.isWindows) }}
+        {{- if and .Values.agent.discovery.enabled }}
         - --discovery
         {{- end }}
         ports:
@@ -340,7 +340,7 @@ spec:
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
-      {{- if and .Values.agent.discovery.enabled (not .Values.isWindows) }}
+      {{- if and .Values.agent.discovery.enabled }}
         - mountPath: /etc/otel/collector/config.d
           name: otel-discovery-properties-configmap
         {{- end }}
@@ -550,7 +550,7 @@ spec:
           items:
             - key: relay
               path: relay.yaml
-      {{- if and .Values.agent.discovery.enabled (not .Values.isWindows) }}
+      {{- if and .Values.agent.discovery.enabled }}
       - name: otel-discovery-properties-configmap
         configMap:
           name: {{ template "splunk-otel-collector.fullname" . }}-otel-agent

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -249,11 +249,7 @@ spec:
         {{- else }}
         args:
         {{- end }}
-        {{- if .Values.isWindows }}
-        - --config=C:\\conf\relay.yaml
-        {{- else }}
         - --config=/conf/relay.yaml
-        {{- end }}
         {{- if .Values.agent.featureGates }}
         - --feature-gates={{ .Values.agent.featureGates }}
         {{- end }}
@@ -342,7 +338,7 @@ spec:
         resources:
           {{- toYaml $agent.resources | nindent 10 }}
         volumeMounts:
-        - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
+        - mountPath: /conf
           name: otel-configmap
       {{- if and .Values.agent.discovery.enabled (not .Values.isWindows) }}
         - mountPath: /etc/otel/collector/config.d
@@ -350,7 +346,7 @@ spec:
         {{- end }}
         {{- if eq (include "splunk-otel-collector.metricsEnabled" $) "true" }}
         {{- if .Values.isWindows }}
-        - mountPath: "C:\\hostfs"
+        - mountPath: C:\hostfs
           name: hostfs
           readOnly: true
         {{- else }}
@@ -516,7 +512,7 @@ spec:
       {{- if .Values.isWindows }}
       - name: hostfs
         hostPath:
-          path: "C:\\"
+          path: C:\
       {{- else }}
       - name: host-dev
         hostPath:

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -112,9 +112,7 @@ spec:
       containers:
       - name: otel-collector
         args:
-        {{- if .Values.isWindows }}
-        - --config=C:\\conf\relay.yaml
-        {{- else if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+        {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
         - --config=/splunk-messages/config.yaml
         {{- else }}
         - --config=/conf/relay.yaml
@@ -201,7 +199,7 @@ spec:
           mountPath: /otel/etc
           readOnly: true
         {{- end }}
-        - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
+        - mountPath: /conf
           name: collector-configmap
         {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
         - mountPath: /splunk-messages

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -69,11 +69,7 @@ spec:
       containers:
       - name: otel-collector
         args:
-        {{- if .Values.isWindows }}
-        - --config=C:\\conf\relay.yaml
-        {{- else }}
         - --config=/conf/relay.yaml
-        {{- end }}
         {{- if .Values.gateway.featureGates }}
         - --feature-gates={{ .Values.gateway.featureGates }}
         {{- end }}
@@ -163,7 +159,7 @@ spec:
           mountPath: /otel/etc
           readOnly: true
         {{- end }}
-        - mountPath: {{ .Values.isWindows | ternary "C:\\conf" "/conf" }}
+        - mountPath: /conf
           name: collector-configmap
         {{- if $gateway.extraVolumeMounts }}
         {{- toYaml $gateway.extraVolumeMounts | nindent 8 }}


### PR DESCRIPTION
There is no need for special paths or similar when enabling discovery on Windows. Obs.: Windows images have only a `C:` drive* so any root path without drive letter it is just fine.

Note: in principle one could create another driver letter either with `VOLUME` on the Dockerfile or using the `subst` command. However, I didn't find any successful example of using `VOLUME` and using `subst` is just to map a letter to the existing volume. In the end we can consider that there is just the `C:` volume and all root paths are fine.
