### PR TITLE
[chore] increase timeout for functional_tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ unittest: ## Run unittests on the Helm chart
 .PHONY: functionaltest
 functionaltest: ## Run functional tests for this Helm chart with optional tags and environment variables
 	@echo "Running functional tests for this helm chart..."
-	cd functional_tests && go test -v -timeout 20m ./$(SUITE)/... || exit 1
+	cd functional_tests && go test -v -timeout 30m ./$(SUITE)/... || exit 1
 
 ##@ Changelog
 # Tasks related to changelog management


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Increase timeout for functional_tests from 20mins to 30mins since we are seeing more failures on EKS cluster tests recently due to the test timing out before lease can be acquired