### PR TITLE
update apiserver metrics collected from EKS

### DIFF
--- a/.chloggen/update-eks-apiserver-metrics.yaml
+++ b/.chloggen/update-eks-apiserver-metrics.yaml
@@ -1,0 +1,13 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Updates scrape config for EKS apiserver prometheus receiver. The change reflects metrics used in out-of-the-box dashboards in Splunk Observability."
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - This change is only relevant for users who have enabled the `enableEKSApiServerMetrics` featuregate in their Helm chart configuration.

--- a/.chloggen/update-eks-apiserver-metrics.yaml
+++ b/.chloggen/update-eks-apiserver-metrics.yaml
@@ -5,7 +5,7 @@ component: clusterReceiver
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Updates scrape config for EKS apiserver prometheus receiver. The change reflects metrics used in out-of-the-box dashboards in Splunk Observability."
 # One or more tracking issues related to the change
-issues: []
+issues: [1893]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -110,7 +110,7 @@ data:
             job_name: kubernetes-apiserver
             metric_relabel_configs:
             - action: keep
-              regex: (apiserver_longrunning_requests|apiserver_request_duration_seconds|apiserver_request_total|apiserver_response_sizes|apiserver_storage_objects|rest_client_request_duration_seconds|rest_client_requests_total|workqueue_depth|workqueue_longest_running_processor_seconds|workqueue_queue_duration_seconds|workqueue_retries_total|workqueue_unfinished_work_seconds|)(?:_sum|_count|_bucket)?
+              regex: (apiserver_longrunning_requests|apiserver_request_duration_seconds|apiserver_storage_objects|apiserver_response_sizes|apiserver_request_total|rest_client_requests_total|rest_client_request_duration_seconds)(?:_sum|_count|_bucket)?
               source_labels:
               - __name__
             scheme: https

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 70635308f43f721f368ffc8d3c38d8d423e270f21281b5346969ccd107762a9b
+        checksum/config: 8ca129364d635ae110cbebeeb8713245bc62894ca5e705abdccdd7eb94df05ad
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -89,18 +89,12 @@ receivers:
             - source_labels: [__name__]
               action: keep
               regex: "(apiserver_longrunning_requests|\
-              apiserver_request_duration_seconds|\
-              apiserver_request_total|\
-              apiserver_response_sizes|\
-              apiserver_storage_objects|\
-              rest_client_request_duration_seconds|\
-              rest_client_requests_total|\
-              workqueue_depth|\
-              workqueue_longest_running_processor_seconds|\
-              workqueue_queue_duration_seconds|\
-              workqueue_retries_total|\
-              workqueue_unfinished_work_seconds|\
-              )(?:_sum|_count|_bucket)?"
+                apiserver_request_duration_seconds|\
+                apiserver_storage_objects|\
+                apiserver_response_sizes|\
+                apiserver_request_total|\
+                rest_client_requests_total|\
+                rest_client_request_duration_seconds)(?:_sum|_count|_bucket)?"
   {{- end }}
 
 processors:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This change updates the scrape rule for kubernetes-apiserver receiver used for EKS control plane. The metrics kept have been updated to the final list provided by the content team.
