### PR TITLE
[chore] Avoid panic in histogram functional test

### DIFF
--- a/functional_tests/histogram/histogram_test.go
+++ b/functional_tests/histogram/histogram_test.go
@@ -172,8 +172,8 @@ func runMetricsTest(t *testing.T, isHistogram bool, metricsSink *consumertest.Me
 		require.NoError(t, err)
 	}
 
-	internal.MaybeUpdateExpectedMetricsResults(t, filepath.Join(testDir, fileName), actualMetrics)
 	require.NotNil(t, actualMetrics, "Did not receive any metrics for component %s", input.ServiceName)
+	internal.MaybeUpdateExpectedMetricsResults(t, filepath.Join(testDir, fileName), actualMetrics)
 	err := checkMetrics(t, isHistogram, expectedMetrics, actualMetrics, input.ServiceName)
 	if err != nil {
 		t.Errorf("Error occurred while checking metrics for component %s: %v", input.ServiceName, err)


### PR DESCRIPTION
Avoid panics like in https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/16151155691/job/45582516385?pr=1830#step:7:15

```terminal
=== RUN   Test_ControlPlaneMetrics
    chart.go:99: Running helm install
    client.go:142: creating 8 resource(s)
    wait.go:50: beginning wait for 8 resources with timeout of 10m0s
    ready.go:323: DaemonSet is not ready: default/sock-splunk-otel-collector-agent. 0 out of 1 expected pods have been scheduled
    common.go:153: [CheckPodsReady] Pod: sock-splunk-otel-collector-agent-drsml | Phase: Pending | Ready: false
    common.go:153: [CheckPodsReady] Pod: sock-splunk-otel-collector-agent-drsml | Phase: Running | Ready: true
    common.go:161: [CheckPodsReady] All pods ready at: 2025-07-08T18:18:32Z
    common.go:163: [CheckPodsReady] All pods have been ready for: 10.671µs (minReadyTime: 0s)
=== RUN   Test_ControlPlaneMetrics/kubernetes-scheduler_histograms=true
    histogram_test.go:115: checking for metrics matching component kubernetes-scheduler
--- FAIL: Test_ControlPlaneMetrics (81.60s)
    --- FAIL: Test_ControlPlaneMetrics/kubernetes-scheduler_histograms=true (57.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x3182417]

goroutine 120 [running]:
testing.tRunner.func1.2({0x3514bc0, 0x53888a0})
	/opt/hostedtoolcache/go/1.24.4/x64/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.24.4/x64/src/testing/testing.go:1737 +0x35e
panic({0x3514bc0?, 0x53888a0?})
	/opt/hostedtoolcache/go/1.24.4/x64/src/runtime/panic.go:792 +0x132
go.opentelemetry.io/collector/pdata/pmetric.Metrics.ResourceMetrics(...)
	/home/runner/go/pkg/mod/go.opentelemetry.io/collector/pdata@v1.33.0/pmetric/metrics.go:45
github.com/signalfx/splunk-otel-collector-chart/functional_tests/histogram.checkHistogramMetrics(0xc000a828c0, 0xc000505df0, 0xc0008b5ed0, {0x396ca78, 0x14}, 0xc000505b90)
	/home/runner/work/splunk-otel-collector-chart/splunk-otel-collector-chart/functional_tests/histogram/histogram_test.go:232 +0x57
github.com/signalfx/splunk-otel-collector-chart/functional_tests/histogram.checkMetrics(0xc000a828c0, 0x1, 0xc000505df0, 0xc0008b5ed0, {0x396ca78, 0x14})
	/home/runner/work/splunk-otel-collector-chart/splunk-otel-collector-chart/functional_tests/histogram/histogram_test.go:215 +0xafa
github.com/signalfx/splunk-otel-collector-chart/functional_tests/histogram.runMetricsTest(0xc000a828c0, 0x1, 0xc000154f00, {{0x396ca78, 0x14}, {0x3992d89, 0x23}, {0x39af72e, 0x2d}})
	/home/runner/work/splunk-otel-collector-chart/splunk-otel-collector-chart/functional_tests/histogram/histogram_test.go:152 +0x671
github.com/signalfx/splunk-otel-collector-chart/functional_tests/histogram.Test_ControlPlaneMetrics.func1(0xc000a828c0?)
	/home/runner/work/splunk-otel-collector-chart/splunk-otel-collector-chart/functional_tests/histogram/histogram_test.go:92 +0x38
testing.tRunner(0xc000a828c0, 0xc000d3c320)
	/opt/hostedtoolcache/go/1.24.4/x64/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 22
	/opt/hostedtoolcache/go/1.24.4/x64/src/testing/testing.go:1851 +0x413
FAIL	github.com/signalfx/splunk-otel-collector-chart/functional_tests/histogram	81.627s
FAIL
make: *** [Makefile:115: functionaltest] Error 1
```