### PR TITLE
EKS Auto Mode - Remove EC2 detector and expand EKS detector which supports fetching attributes through API (Part 2 - POD Identity) .

### DIFF
--- a/.chloggen/eksautomode2.yaml
+++ b/.chloggen/eksautomode2.yaml
@@ -1,0 +1,13 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: other
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove EC2 detector and expand EKS detector which, in addition to IMDS, supports fetching attributes through API (Part 2 - POD Identity) .
+# One or more tracking issues related to the change
+issues: [1903]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  For more information, see the [EKS Auto Mode documentation](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#eks-auto-mode)

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -142,8 +142,24 @@ data:
         detectors:
         - env
         - eks
-        - ec2
         - system
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+          resource_attributes:
+            cloud.account.id:
+              enabled: true
+            cloud.availability_zone:
+              enabled: true
+            cloud.region:
+              enabled: true
+            host.id:
+              enabled: true
+            host.image.id:
+              enabled: true
+            host.name:
+              enabled: true
+            host.type:
+              enabled: true
         override: true
         timeout: 15s
     receivers:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -76,8 +76,24 @@ data:
         detectors:
         - env
         - eks
-        - ec2
         - system
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+          resource_attributes:
+            cloud.account.id:
+              enabled: true
+            cloud.availability_zone:
+              enabled: true
+            cloud.region:
+              enabled: true
+            host.id:
+              enabled: true
+            host.image.id:
+              enabled: true
+            host.name:
+              enabled: true
+            host.type:
+              enabled: true
         override: true
         timeout: 15s
     receivers:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ab700a4b330471085ce917c0ca8dfdc971c77058ac201de2322f62791666fec4
+        checksum/config: 9537ac755378851bd5db953d45f34175c50a681b5c1c780d77f9b48444a53ab8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8ca129364d635ae110cbebeeb8713245bc62894ca5e705abdccdd7eb94df05ad
+        checksum/config: d42b87fa9eeb4836e4152225385cad4013f41f8112977593b324829f9e7fed81
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -532,6 +532,15 @@ Returns true if the distribution is eks but not eks/fargate.
 {{- end -}}
 
 {{/*
+Identifies K8s clutser running on AWS but they are not EKS.
+Returns true if the cloud provider is aws and distribution is not set.
+example: Vanilla K8s on AWS EC2
+*/}}
+{{- define "splunk-otel-collector.isNonEKSonAWS" -}}
+{{- and (eq (include "splunk-otel-collector.cloudProvider" .) "aws") (eq (include "splunk-otel-collector.distribution" .) "") -}}
+{{- end -}}
+
+{{/*
 Determine if hostNetwork should be enabled.
 If distribution is eks/auto-mode and hostNetwork is not explicitly set, it will be enabled.
 */}}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Remove EC2 detector and expand EKS detector which supports fetching attributes through API (Part 2 - POD Identity) .

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
