### PR TITLE
[chore] debug chart tests in cloud provider clusters

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -441,44 +441,45 @@ jobs:
         run: |
           TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
 
-  eks-auto-mode-upgrade-test:
-    name: Test helm upgrade in EKS Auto Mode - credentials needed
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.ref == 'refs/heads/main')
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
-      KUBE_TEST_ENV: eks/auto-mode
-      SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
-    runs-on: ubuntu-latest
-    continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download the latest published release to use as a base for the upgrade
-        run: |
-          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
-          helm repo update
-          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-          aws-region: us-west-2
-      - name: Install kubeconfig
-        run: |
-          aws eks update-kubeconfig --name rotel-eks-autotest --region us-west-2
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          UPGRADE_FROM_VALUES: aws_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+  # TODO: Enable this once v0.129 is released
+  # eks-auto-mode-upgrade-test:
+  #   name: Test helm upgrade in EKS Auto Mode - credentials needed
+  #   if: |
+  #     (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+  #     (github.ref == 'refs/heads/main')
+  #   env:
+  #     KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
+  #     KUBE_TEST_ENV: eks/auto-mode
+  #     SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
+  #   runs-on: ubuntu-latest
+  #   continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Download the latest published release to use as a base for the upgrade
+  #       run: |
+  #         helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
+  #         helm repo update
+  #         helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
+  #     - uses: actions/setup-go@v5
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
+  #         cache-dependency-path: '**/go.sum'
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_KEY }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+  #         aws-region: us-west-2
+  #     - name: Install kubeconfig
+  #       run: |
+  #         aws eks update-kubeconfig --name rotel-eks-autotest --region us-west-2
+  #     - name: Update dependencies
+  #       run: |
+  #         make dep-update
+  #     - name: run functional tests
+  #       env:
+  #         HOST_ENDPOINT: 0.0.0.0
+  #         UPGRADE_FROM_VALUES: aws_upgrade_from_previous_release_values.yaml
+  #         UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
+  #       run: |
+  #         TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest

--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -240,9 +240,9 @@ func testClusterReceiverEnabledOrDisabled(t *testing.T) {
 			"LogObjectsHecEndpoint":  logsObjectsHecEndpoint,
 		}
 		deployChartsAndApps(t, valuesFileName, replacements)
-		internal.WaitForTerminatingPods(t, clientset, internal.Namespace)
+		internal.WaitForTerminatingPods(t, clientset, internal.DefaultNamespace)
 		internal.ResetLogsSink(t, logsObjectsConsumer)
-		pods := listPodsInNamespace(t, internal.Namespace)
+		pods := listPodsInNamespace(t, internal.DefaultNamespace)
 		assert.Len(t, pods.Items, 1)
 		assert.True(t, strings.HasPrefix(pods.Items[0].Name, "sock-splunk-otel-collector-agent"))
 		internal.CheckNoEventsReceived(t, logsObjectsConsumer)
@@ -254,9 +254,9 @@ func testClusterReceiverEnabledOrDisabled(t *testing.T) {
 			"LogObjectsHecEndpoint":  logsObjectsHecEndpoint,
 		}
 		deployChartsAndApps(t, valuesFileName, replacements)
-		internal.WaitForTerminatingPods(t, clientset, internal.Namespace)
+		internal.WaitForTerminatingPods(t, clientset, internal.DefaultNamespace)
 		internal.ResetLogsSink(t, logsObjectsConsumer)
-		pods := listPodsInNamespace(t, internal.Namespace)
+		pods := listPodsInNamespace(t, internal.DefaultNamespace)
 		assert.Len(t, pods.Items, 2)
 		assert.True(t, checkPodExists(pods, "sock-splunk-otel-collector-agent"))
 		assert.True(t, checkPodExists(pods, "sock-splunk-otel-collector-k8s-cluster-receiver"))

--- a/functional_tests/discovery/discovery_test.go
+++ b/functional_tests/discovery/discovery_test.go
@@ -100,7 +100,7 @@ func assertRedisEntities(t *testing.T, sink *consumertest.LogsSink) {
 	entityAttrsVal, ok := lrAttrs.Get("otel.entity.attributes")
 	assert.True(t, ok)
 	entityAttrs := entityAttrsVal.Map()
-	assertAttr(t, entityAttrs, "k8s.namespace.name", internal.Namespace)
+	assertAttr(t, entityAttrs, "k8s.namespace.name", internal.DefaultNamespace)
 	assertAttr(t, entityAttrs, "k8s.pod.name", "test-redis-master-0")
 	assertAttr(t, entityAttrs, "discovery.status", "successful")
 }
@@ -187,7 +187,7 @@ func installRedisChart(t *testing.T, kubeConfig string) {
 	require.NoError(t, err)
 	actionConfig.RegistryClient = rc
 	install := action.NewInstall(actionConfig)
-	install.Namespace = internal.Namespace
+	install.Namespace = internal.DefaultNamespace
 	install.ReleaseName = redisReleaseName
 	install.RepoURL = redisChartRepo
 	install.Wait = true

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -166,7 +166,7 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 		Version:  "v1",
 		Resource: "podmonitors",
 	}
-	_, err = dynamicClient.Resource(g).Namespace(internal.Namespace).Create(t.Context(),
+	_, err = dynamicClient.Resource(g).Namespace(internal.DefaultNamespace).Create(t.Context(),
 		podMonitor.(*unstructured.Unstructured), metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -181,13 +181,13 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 		addChartInfo("autopilot_test_values.yaml.tmpl", internal.GetDefaultChartOptions())
 	case aksTestKubeEnv:
 		addChartInfo("aks_test_win_values.yaml.tmpl", internal.ChartOptions{
-			ChartNamespace:   internal.Namespace,
+			ChartNamespace:   internal.DefaultNamespace,
 			ChartReleaseName: "aks-win",
 			ChartWait:        true,
 			ChartTimeout:     internal.HelmActionTimeout,
 		})
 		addChartInfo("aks_test_linux_values.yaml.tmpl", internal.ChartOptions{
-			ChartNamespace:   internal.Namespace,
+			ChartNamespace:   internal.DefaultNamespace,
 			ChartReleaseName: "aks-linux",
 			ChartWait:        true,
 			ChartTimeout:     internal.HelmActionTimeout,
@@ -222,7 +222,7 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 		internal.ChartInstallOrUpgrade(t, testKubeConfig, valuesFile, replacements, 1*time.Minute, chartOption)
 	}
 
-	deployments := client.AppsV1().Deployments(internal.Namespace)
+	deployments := client.AppsV1().Deployments(internal.DefaultNamespace)
 
 	// NodeJS test app
 	stream, err = os.ReadFile(filepath.Join(testDir, "nodejs", "deployment.yaml"))
@@ -295,7 +295,7 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 	require.NoError(t, err)
 	service, _, err := decode(stream, nil, nil)
 	require.NoError(t, err)
-	_, err = client.CoreV1().Services(internal.Namespace).Create(t.Context(), service.(*corev1.Service),
+	_, err = client.CoreV1().Services(internal.DefaultNamespace).Create(t.Context(), service.(*corev1.Service),
 		metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -310,7 +310,7 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 		Version:  "v1",
 		Resource: "servicemonitors",
 	}
-	_, err = dynamicClient.Resource(g).Namespace(internal.Namespace).Create(t.Context(),
+	_, err = dynamicClient.Resource(g).Namespace(internal.DefaultNamespace).Create(t.Context(),
 		serviceMonitor.(*unstructured.Unstructured), metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -388,7 +388,7 @@ func teardown(ctx context.Context, t *testing.T, testKubeConfig string) {
 	extensionsClient, err := clientset.NewForConfig(kubeConfig)
 	require.NoError(t, err)
 	waitTime := int64(0)
-	deployments := client.AppsV1().Deployments(internal.Namespace)
+	deployments := client.AppsV1().Deployments(internal.DefaultNamespace)
 	require.NoError(t, err)
 	_ = deployments.Delete(ctx, "nodejs-test", metav1.DeleteOptions{
 		GracePeriodSeconds: &waitTime,
@@ -405,7 +405,7 @@ func teardown(ctx context.Context, t *testing.T, testKubeConfig string) {
 	_ = deployments.Delete(ctx, "prometheus-annotation-test", metav1.DeleteOptions{
 		GracePeriodSeconds: &waitTime,
 	})
-	_ = client.CoreV1().Services(internal.Namespace).Delete(ctx, "prometheus-annotation-service",
+	_ = client.CoreV1().Services(internal.DefaultNamespace).Delete(ctx, "prometheus-annotation-service",
 		metav1.DeleteOptions{
 			GracePeriodSeconds: &waitTime,
 		})

--- a/functional_tests/internal/chart.go
+++ b/functional_tests/internal/chart.go
@@ -18,16 +18,17 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
-	HelmActionTimeout = 10 * time.Minute
-	chartReleaseName  = "sock"
-	chartLabelKey     = "helm.sh/chart-name"
-	defaultChartPath  = "helm-charts/splunk-otel-collector"
+	HelmActionTimeout       = 15 * time.Minute
+	DefaultChartReleaseName = "sock"
+	chartLabelKey           = "helm.sh/chart-name"
+	defaultChartPath        = "helm-charts/splunk-otel-collector"
 )
 
 type ChartOptions struct {
@@ -39,8 +40,8 @@ type ChartOptions struct {
 
 func GetDefaultChartOptions() ChartOptions {
 	return ChartOptions{
-		ChartNamespace:   Namespace,
-		ChartReleaseName: chartReleaseName,
+		ChartNamespace:   DefaultNamespace,
+		ChartReleaseName: DefaultChartReleaseName,
 		ChartWait:        true,
 		ChartTimeout:     HelmActionTimeout,
 	}
@@ -64,7 +65,7 @@ func ChartInstallOrUpgrade(t *testing.T, testKubeConfig string, valuesFile strin
 	install.ReleaseName = options.ChartReleaseName
 	install.Wait = options.ChartWait
 	install.Timeout = options.ChartTimeout
-	install.Labels = map[string]string{chartLabelKey: chartReleaseName}
+	install.Labels = map[string]string{chartLabelKey: DefaultChartReleaseName}
 
 	// If UPGRADE_FROM_VALUES env var is set, we install the helm chart using the values. Otherwise, run helm install.
 	// UPGRADE_FROM_CHART_DIR is an optional env var that provides an alternative path for the initial helm chart.
@@ -120,25 +121,44 @@ func ChartUninstall(t *testing.T, testKubeConfig string) {
 	actionConfig := InitHelmActionConfig(t, testKubeConfig)
 	client := action.NewList(actionConfig)
 	client.AllNamespaces = true
-	client.Selector = fmt.Sprintf("%s==%s", chartLabelKey, chartReleaseName)
+	client.Selector = fmt.Sprintf("%s==%s", chartLabelKey, DefaultChartReleaseName)
+	client.StateMask = action.ListAll // Include releases in all states
 	releases, err := client.Run()
 	require.NoError(t, err)
+
+	if len(releases) == 0 {
+		t.Log("No Helm releases found for uninstall.")
+	}
 
 	uninstall := action.NewUninstall(actionConfig)
 	uninstall.IgnoreNotFound = true
 	uninstall.Wait = true
 	uninstall.Timeout = HelmActionTimeout
+	clientset, err := getKubeClient(testKubeConfig)
+	require.NoError(t, err)
 	for _, release := range releases {
+		t.Logf("Uninstalling release: %s (namespace: %s)", release.Name, release.Namespace)
 		_, _ = uninstall.Run(release.Name)
+		// delete the cert secret created with helm hooks when the operator is installed
+		secretName := release.Name + "-operator-controller-manager-service-cert"
+		t.Logf("Attempting to delete secret: %s in namespace: %s", secretName, release.Namespace)
+		_, getErr := clientset.CoreV1().Secrets(release.Namespace).Get(t.Context(), secretName, v1.GetOptions{})
+		if getErr == nil {
+			deleteErr := clientset.CoreV1().Secrets(release.Namespace).Delete(t.Context(), secretName, v1.DeleteOptions{})
+			require.NoError(t, deleteErr)
+			t.Logf("Deleted webhook secret: %s (namespace: %s)", secretName, release.Namespace)
+		} else {
+			t.Logf("Secret %s not found in namespace: %s, nothing to delete", secretName, release.Namespace)
+		}
 	}
 }
 
 func InitHelmActionConfig(t *testing.T, kubeConfig string) *action.Configuration {
 	actionConfig := new(action.Configuration)
 	cf := genericclioptions.NewConfigFlags(true)
-	cf.Namespace = &Namespace
+	cf.Namespace = &DefaultNamespace
 	cf.KubeConfig = &kubeConfig
-	require.NoError(t, actionConfig.Init(cf, Namespace, os.Getenv("HELM_DRIVER"), t.Logf))
+	require.NoError(t, actionConfig.Init(cf, DefaultNamespace, os.Getenv("HELM_DRIVER"), t.Logf))
 	return actionConfig
 }
 

--- a/functional_tests/internal/chart.go
+++ b/functional_tests/internal/chart.go
@@ -117,6 +117,19 @@ func getKubeClient(kubeConfig string) (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(config)
 }
 
+func deleteCertSecret(t *testing.T, clientset *kubernetes.Clientset, releaseName, namespace string) {
+	secretName := releaseName + "-operator-controller-manager-service-cert"
+	t.Logf("Attempting to delete secret: %s in namespace: %s", secretName, namespace)
+	_, getErr := clientset.CoreV1().Secrets(namespace).Get(t.Context(), secretName, v1.GetOptions{})
+	if getErr == nil {
+		deleteErr := clientset.CoreV1().Secrets(namespace).Delete(t.Context(), secretName, v1.DeleteOptions{})
+		require.NoError(t, deleteErr)
+		t.Logf("Deleted webhook secret: %s (namespace: %s)", secretName, namespace)
+	} else {
+		t.Logf("Secret %s not found in namespace: %s, nothing to delete", secretName, namespace)
+	}
+}
+
 func ChartUninstall(t *testing.T, testKubeConfig string) {
 	actionConfig := InitHelmActionConfig(t, testKubeConfig)
 	client := action.NewList(actionConfig)
@@ -125,31 +138,24 @@ func ChartUninstall(t *testing.T, testKubeConfig string) {
 	client.StateMask = action.ListAll // Include releases in all states
 	releases, err := client.Run()
 	require.NoError(t, err)
+	clientset, err := getKubeClient(testKubeConfig)
+	require.NoError(t, err)
 
 	if len(releases) == 0 {
 		t.Log("No Helm releases found for uninstall.")
+		// try to delete the cert secret for the default release name/namespace
+		deleteCertSecret(t, clientset, DefaultChartReleaseName, DefaultNamespace)
+		return
 	}
 
 	uninstall := action.NewUninstall(actionConfig)
 	uninstall.IgnoreNotFound = true
 	uninstall.Wait = true
 	uninstall.Timeout = HelmActionTimeout
-	clientset, err := getKubeClient(testKubeConfig)
-	require.NoError(t, err)
 	for _, release := range releases {
 		t.Logf("Uninstalling release: %s (namespace: %s)", release.Name, release.Namespace)
 		_, _ = uninstall.Run(release.Name)
-		// delete the cert secret created with helm hooks when the operator is installed
-		secretName := release.Name + "-operator-controller-manager-service-cert"
-		t.Logf("Attempting to delete secret: %s in namespace: %s", secretName, release.Namespace)
-		_, getErr := clientset.CoreV1().Secrets(release.Namespace).Get(t.Context(), secretName, v1.GetOptions{})
-		if getErr == nil {
-			deleteErr := clientset.CoreV1().Secrets(release.Namespace).Delete(t.Context(), secretName, v1.DeleteOptions{})
-			require.NoError(t, deleteErr)
-			t.Logf("Deleted webhook secret: %s (namespace: %s)", secretName, release.Namespace)
-		} else {
-			t.Logf("Secret %s not found in namespace: %s, nothing to delete", secretName, release.Namespace)
-		}
+		deleteCertSecret(t, clientset, release.Name, release.Namespace)
 	}
 }
 

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var Namespace = "default"
+var DefaultNamespace = "default"
 
 const waitTimeout = 3 * time.Minute
 

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -151,7 +151,7 @@ func deployWorkloadAndCollector(t *testing.T) {
 	clientset, err := kubernetes.NewForConfig(config)
 	require.NoError(t, err)
 
-	internal.CheckPodsReady(t, clientset, internal.Namespace, "component=otel-k8s-cluster-receiver", 3*time.Minute, 0)
+	internal.CheckPodsReady(t, clientset, internal.DefaultNamespace, "component=otel-k8s-cluster-receiver", 3*time.Minute, 0)
 	time.Sleep(30 * time.Second)
 
 	// Deploy the workload


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
PR fixes a couple of helm chart install/delete issues we have been seeing recently

- Explicitly delete cert secret we create as a hook object which sometimes helm uninstall does not clear
- Bumps the wait time on helm install and when running uninstall, get releases in all states (the default option does not get releases which never went past the pending-install/pending-upgrade phase) 
- eks/auto-mode upgrade tests have been disabled until we have at least 1 release of the new distro available

