### PR TITLE
[chore] fail if the tag pulled from collector is not valid version

### DIFF
--- a/ci_scripts/prepare-release.sh
+++ b/ci_scripts/prepare-release.sh
@@ -62,6 +62,12 @@ if [[ "$APP_VERSION_OVERRIDDEN" = true ]]; then
     LATEST_APP_VERSION=$APP_VERSION
     debug "Using override collector app version value $LATEST_APP_VERSION"
 fi
+
+if [[ -z "$LATEST_APP_VERSION" || "$LATEST_APP_VERSION" == "null" || ! "$LATEST_APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "[ERROR] LATEST_APP_VERSION $LATEST_APP_VERSION is invalid. Aborting release."
+    exit 1
+fi
+
 LATEST_CHART_VERSION_PATCH=$(get_major_version "v$LATEST_APP_VERSION")
 LATEST_CHART_VERSION_MINOR=$(get_minor_version "v$LATEST_APP_VERSION")
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Quick check in the script to avoid PRs like https://github.com/signalfx/splunk-otel-collector-chart/pull/1932 (with null). I haven't been able to locate where the null is detected from the docs for releases/latest, so adding an explicit check in the script for more visibility
