### PR TITLE
add option to set metrics sourcetype directly from values.yaml

### DIFF
--- a/.chloggen/make-metrics-sourcetype-configurable.yaml
+++ b/.chloggen/make-metrics-sourcetype-configurable.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add configuration option for Splunk Platform metrics sourcetype
+# One or more tracking issues related to the change
+issues: [1941]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/make-metrics-sourcetype-configurable.yaml
+++ b/.chloggen/make-metrics-sourcetype-configurable.yaml
@@ -3,10 +3,12 @@ change_type: enhancement
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: chart
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add configuration option for Splunk Platform metrics sourcetype
+note: Adds configuration option for Splunk Platform metrics sourcetype
 # One or more tracking issues related to the change
 issues: [1941]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  - Users can override the metrics sourcetype for Splunk Platform using the `splunk.com/sourcetypeMetrics` annotation or the `.Values.splunkPlatform.sourcetypeMetrics` Helm value.
+  - See `advanced-configuration.md` for detailed precedence and usage notes.

--- a/.chloggen/make-metrics-sourcetype-configurable.yaml
+++ b/.chloggen/make-metrics-sourcetype-configurable.yaml
@@ -10,5 +10,5 @@ issues: [1941]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  - Users can override the metrics sourcetype for Splunk Platform using the `splunk.com/sourcetypeMetrics` annotation or the `.Values.splunkPlatform.sourcetypeMetrics` Helm value.
+  - Users can override the metrics sourcetype for Splunk Platform using the `splunk.com/metricsSourcetype` annotation or the `.Values.splunkPlatform.metricsSourcetype` Helm value.
   - See `advanced-configuration.md` for detailed precedence and usage notes.

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -689,7 +689,17 @@ Manage Splunk OTel Collector Logging with these supported annotations.
   * If `logsCollection.containers.useSplunkIncludeAnnotation` is `false` (default: false), set `splunk.com/exclude` annotation to `true` on pod and/or namespace to exclude its logs from ingested.
   * If `logsCollection.containers.useSplunkIncludeAnnotation` is `true` (default: false), set `splunk.com/include` annotation to `true` on pod and/or namespace to only include its logs from ingested. All other logs will be ignored.
 * For logs, use `splunk.com/sourcetype` annotation on pod to overwrite `sourcetype` field. If not set, it is dynamically generated to be `kube:container:CONTAINER_NAME`.
-* For metrics, use the `splunk.com/sourcetype` annotation on the namespace to override the sourcetype field. If not set, it defaults to `httpevent`.
+* For metrics, use the `splunk.com/sourcetypeMetrics` annotation on the namespace to override the `sourcetypeMetrics` field. If not set, it defaults to `httpevent`.
+
+The sourcetype for metrics is selected based on the following precedence:
+
+1. The value of the `splunk.com/sourcetypeMetrics` annotation on the pod, if present.
+2. The value of the `splunk.com/sourcetype` annotation on the pod, if present, applies to all data types.
+3. The value of the `splunk.com/sourcetypeMetrics` annotation on the namespace, if present.
+4. The value of the `splunk.com/sourcetype` annotation on the namespace, if present, applies to all data types.
+5. The value of `.Values.splunkPlatform.sourcetypeMetrics` in the Helm values, if specified, is used for metrics.
+6. If only `.Values.splunkPlatform.sourcetype` is set, it applies to all data types.
+7. If none of the above are set, the default `sourcetype` is `httpevent`.
 
 ### Performance of native OpenTelemetry logs collection
 

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -689,15 +689,15 @@ Manage Splunk OTel Collector Logging with these supported annotations.
   * If `logsCollection.containers.useSplunkIncludeAnnotation` is `false` (default: false), set `splunk.com/exclude` annotation to `true` on pod and/or namespace to exclude its logs from ingested.
   * If `logsCollection.containers.useSplunkIncludeAnnotation` is `true` (default: false), set `splunk.com/include` annotation to `true` on pod and/or namespace to only include its logs from ingested. All other logs will be ignored.
 * For logs, use `splunk.com/sourcetype` annotation on pod to overwrite `sourcetype` field. If not set, it is dynamically generated to be `kube:container:CONTAINER_NAME`.
-* For metrics, use the `splunk.com/sourcetypeMetrics` annotation on the namespace to override the `sourcetypeMetrics` field. If not set, it defaults to `httpevent`.
+* For metrics, use the `splunk.com/metricsSourcetype` annotation on the namespace to override the `metricsSourcetype` field. If not set, it defaults to `httpevent`.
 
 The sourcetype for metrics is selected based on the following precedence:
 
-1. The value of the `splunk.com/sourcetypeMetrics` annotation on the pod, if present.
+1. The value of the `splunk.com/metricsSourcetype` annotation on the pod, if present.
 2. The value of the `splunk.com/sourcetype` annotation on the pod, if present, applies to all data types.
-3. The value of the `splunk.com/sourcetypeMetrics` annotation on the namespace, if present.
+3. The value of the `splunk.com/metricsSourcetype` annotation on the namespace, if present.
 4. The value of the `splunk.com/sourcetype` annotation on the namespace, if present, applies to all data types.
-5. The value of `.Values.splunkPlatform.sourcetypeMetrics` in the Helm values, if specified, is used for metrics.
+5. The value of `.Values.splunkPlatform.metricsSourcetype` in the Helm values, if specified, is used for metrics.
 6. If only `.Values.splunkPlatform.sourcetype` is set, it applies to all data types.
 7. If none of the above are set, the default `sourcetype` is `httpevent`.
 

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -173,10 +173,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -173,6 +173,12 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: pod
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: namespace
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
           - from: pod

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -122,10 +122,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a7fc326eabd79a76ef47903caa4a13234ae7fa70068bcc75cba0e9701e1e4aaa
+        checksum/config: 6836ff7b46e57c129323124f9e7626388967e8cfa06e52b31eaf740075c57ae7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0aede0b0f30b8f05a25203c8cc764410952ea60068d66f2200e41dd4a239370d
+        checksum/config: a7fc326eabd79a76ef47903caa4a13234ae7fa70068bcc75cba0e9701e1e4aaa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4e286e35ae91b607a67d264994d4d24c95f31f70d295b89249daf9833b1dcdef
+        checksum/config: df08cdd4852fe12260809f2fe6888471eb3b5edd090f7a65905559b8277af703
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: df08cdd4852fe12260809f2fe6888471eb3b5edd090f7a65905559b8277af703
+        checksum/config: de19dd84f223ca9233380cfff23ef13a6988dcd6c2300898967adb85585b5daa
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -173,10 +173,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -122,6 +122,12 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: pod
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: namespace
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
           - from: pod

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -122,10 +122,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 36a3199d2134209f5feda25d02b3e9de19df39164616b0f120cbe1eba6b99375
+        checksum/config: cc8642d2c5cf93a555753a2f6f60c8e664a87f2447ead9f64b579f80e5883a4e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e6b036e7dafb7c7951a4e80535d9032f1e6f22194187dcf2519df3890efc7144
+        checksum/config: 36a3199d2134209f5feda25d02b3e9de19df39164616b0f120cbe1eba6b99375
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4e286e35ae91b607a67d264994d4d24c95f31f70d295b89249daf9833b1dcdef
+        checksum/config: df08cdd4852fe12260809f2fe6888471eb3b5edd090f7a65905559b8277af703
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: df08cdd4852fe12260809f2fe6888471eb3b5edd090f7a65905559b8277af703
+        checksum/config: de19dd84f223ca9233380cfff23ef13a6988dcd6c2300898967adb85585b5daa
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -145,6 +145,12 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: pod
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: namespace
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
           - from: pod

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -145,10 +145,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -122,6 +122,12 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: pod
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: namespace
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
           - from: pod

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -122,10 +122,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bcbc787174ec87919990249bc2abd4c25588a5f13d95eb24b790ee4e967c1c74
+        checksum/config: ed8d9429564fbea94dd9272e489d23fb30baa08c50fb5e28ff2ae2f46a75b50a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 06cbfeb038ac64e94612e737feba37d3e8f9b51de678bf7d52c226351ef73f85
+        checksum/config: bcbc787174ec87919990249bc2abd4c25588a5f13d95eb24b790ee4e967c1c74
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 968bfd80bed7da3306050f72d53725b5fa0dba8672c7f1a62cbb3d14da57b6f5
+        checksum/config: c9ef800ff76a225b3ecaa490141ffb5c9908e84ab5e4545cf1e60f376a75fa02
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8645327f1786dd6a2931b4178f878424c9df4a1c2879ff42e841866493f3ed06
+        checksum/config: 968bfd80bed7da3306050f72d53725b5fa0dba8672c7f1a62cbb3d14da57b6f5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -118,10 +118,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -118,6 +118,12 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: pod
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: namespace
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
           - from: pod

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,6 +56,12 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: pod
+            key: splunk.com/sourcetypeMetrics
+            tag_name: com.splunk.sourcetype
+          - from: namespace
             key: splunk.com/metricsIndex
             tag_name: com.splunk.index
           - from: pod

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,10 +56,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a43cb045918a51c45b71fdfa05b42fbb6d522bf3990f889fd3de69245df6df52
+        checksum/config: 76514bf3bbc877d4a0ddf48f6d4d0bf69adc428b0727a4cd5a95d8d5fef23ffa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 623824a1d1b960a941462746b2a6221bf0dd6f81175b2e35ef199cc753f467c9
+        checksum/config: a43cb045918a51c45b71fdfa05b42fbb6d522bf3990f889fd3de69245df6df52
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 02a1dee0f791f05b505f13d6c45a478b6946b218dbaf994f3e308fb5dcdf921c
+        checksum/config: 735353b66f059445e9d3625dec7de7b971bf7d584d904893314ec9e47ad071a5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 02d27b947c166fde3e2b6a78b2f4759d2dcc09bee54251de181a05156f8230c7
+        checksum/config: 02a1dee0f791f05b505f13d6c45a478b6946b218dbaf994f3e308fb5dcdf921c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/README.md
+++ b/examples/splunk-platform-with-sourcetypes/README.md
@@ -1,0 +1,7 @@
+# Example of chart configuration
+
+## Set Splunk sourcetypes for logs metrics
+
+When sending logs and metrics to the Splunk platform, it is best practice to set explicit sourcetypes.
+This ensures that data is properly categorized and parsed in Splunk, improving searchability and enabling accurate
+field extractions.

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
@@ -6,14 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm
 rules:
 - apiGroups:
   - ""

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
@@ -1,0 +1,92 @@
+---
+# Source: splunk-otel-collector/templates/clusterRole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.132.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.132.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.132.0
+    release: default
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - nodes/stats
+  - nodes/proxy
+  - pods
+  - pods/status
+  - persistentvolumeclaims
+  - persistentvolumes
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRoleBinding.yaml
@@ -6,14 +6,13 @@ metadata:
   name: default-splunk-otel-collector
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRoleBinding.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRoleBinding.yaml
@@ -1,0 +1,24 @@
+---
+# Source: splunk-otel-collector/templates/clusterRoleBinding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: default-splunk-otel-collector
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.132.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.132.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.132.0
+    release: default
+    heritage: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-splunk-otel-collector
+subjects:
+- kind: ServiceAccount
+  name: default-splunk-otel-collector
+  namespace: default

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
@@ -7,14 +7,13 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm
 data:
   relay: |
     exporters:
@@ -37,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.132.0
+        splunk_app_version: 0.134.0
         timeout: 10s
         tls:
           insecure_skip_verify: false
@@ -60,7 +59,7 @@ data:
           queue_size: 1000
         source: kubernetes
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.132.0
+        splunk_app_version: 0.134.0
         timeout: 10s
         tls:
           insecure_skip_verify: false

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
@@ -144,10 +144,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
@@ -7,21 +7,22 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.134.0
+    helm.sh/chart: splunk-otel-collector-0.132.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.134.0"
+    app.kubernetes.io/version: "0.132.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.134.0
+    chart: splunk-otel-collector-0.132.0
     release: default
+    heritage: Helm
 data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
         disable_compression: true
-        endpoint: CHANGEME
+        endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
-        index: CHANGEME
+        index: main
         max_idle_conns: 200
         max_idle_conns_per_host: 200
         profiling_data_enabled: false
@@ -34,19 +35,18 @@ data:
           enabled: true
           num_consumers: 10
           queue_size: 1000
-          storage: file_storage/persistent_queue
         source: kubernetes
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.134.0
+        splunk_app_version: 0.132.0
         timeout: 10s
         tls:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
         disable_compression: true
-        endpoint: CHANGEME
+        endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
-        index: CHANGEME
+        index: metrics
         max_idle_conns: 200
         max_idle_conns_per_host: 200
         retry_on_failure:
@@ -58,34 +58,9 @@ data:
           enabled: true
           num_consumers: 10
           queue_size: 1000
-          storage: file_storage/persistent_queue
         source: kubernetes
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.134.0
-        timeout: 10s
-        tls:
-          insecure_skip_verify: false
-        token: ${SPLUNK_PLATFORM_HEC_TOKEN}
-      splunk_hec/platform_traces:
-        disable_compression: true
-        endpoint: CHANGEME
-        idle_conn_timeout: 10s
-        index: ""
-        max_idle_conns: 200
-        max_idle_conns_per_host: 200
-        retry_on_failure:
-          enabled: true
-          initial_interval: 5s
-          max_elapsed_time: 300s
-          max_interval: 30s
-        sending_queue:
-          enabled: true
-          num_consumers: 10
-          queue_size: 1000
-          storage: file_storage/persistent_queue
-        source: kubernetes
-        splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.134.0
+        splunk_app_version: 0.132.0
         timeout: 10s
         tls:
           insecure_skip_verify: false
@@ -93,9 +68,6 @@ data:
     extensions:
       file_storage:
         directory: /var/addon/splunk/otel_pos
-      file_storage/persistent_queue:
-        directory: /var/addon/splunk/exporter_queue/agent
-        timeout: 0
       headers_setter:
         headers:
         - action: upsert
@@ -231,12 +203,20 @@ data:
       resource/logs:
         attributes:
         - action: upsert
+          key: com.splunk.sourcetype
+          value: logs
+        - action: upsert
           from_attribute: k8s.pod.annotations.splunk.com/sourcetype
           key: com.splunk.sourcetype
         - action: delete
           key: k8s.pod.annotations.splunk.com/sourcetype
         - action: delete
           key: splunk.com/exclude
+      resource/metrics:
+        attributes:
+        - action: insert
+          key: com.splunk.sourcetype
+          value: metrics
       resourcedetection:
         detectors:
         - env
@@ -370,12 +350,6 @@ data:
           network: null
           paging: null
           processes: null
-      jaeger:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:14250
-          thrift_http:
-            endpoint: 0.0.0.0:14268
       kubeletstats:
         auth_type: serviceAccount
         collection_interval: 10s
@@ -415,12 +389,9 @@ data:
         - k8s_observer
       signalfx:
         endpoint: 0.0.0.0:9943
-      zipkin:
-        endpoint: 0.0.0.0:9411
     service:
       extensions:
       - file_storage
-      - file_storage/persistent_queue
       - health_check
       - headers_setter
       - k8s_observer
@@ -450,6 +421,7 @@ data:
           - resourcedetection
           - resource
           - k8sattributes/metrics
+          - resource/metrics
           receivers:
           - hostmetrics
           - kubeletstats
@@ -466,21 +438,9 @@ data:
           - resource
           - resource/add_mode
           - k8sattributes/metrics
+          - resource/metrics
           receivers:
           - prometheus/agent
-        traces:
-          exporters:
-          - splunk_hec/platform_traces
-          processors:
-          - memory_limiter
-          - k8sattributes
-          - batch
-          - resourcedetection
-          - resource
-          receivers:
-          - otlp
-          - jaeger
-          - zipkin
       telemetry:
         metrics:
           readers:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -7,21 +7,22 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.134.0
+    helm.sh/chart: splunk-otel-collector-0.132.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.134.0"
+    app.kubernetes.io/version: "0.132.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.134.0
+    chart: splunk-otel-collector-0.132.0
     release: default
+    heritage: Helm
 data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
         disable_compression: true
-        endpoint: CHANGEME
+        endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
-        index: CHANGEME
+        index: main
         max_idle_conns: 200
         max_idle_conns_per_host: 200
         profiling_data_enabled: false
@@ -37,16 +38,16 @@ data:
         source: kubernetes
         sourcetype: kube:events
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.134.0
+        splunk_app_version: 0.132.0
         timeout: 10s
         tls:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
         disable_compression: true
-        endpoint: CHANGEME
+        endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
-        index: CHANGEME
+        index: metrics
         max_idle_conns: 200
         max_idle_conns_per_host: 200
         retry_on_failure:
@@ -60,7 +61,7 @@ data:
           queue_size: 1000
         source: kubernetes
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.134.0
+        splunk_app_version: 0.132.0
         timeout: 10s
         tls:
           insecure_skip_verify: false
@@ -185,6 +186,11 @@ data:
         - action: insert
           key: receiver
           value: k8scluster
+      resource/metrics:
+        attributes:
+        - action: insert
+          key: com.splunk.sourcetype
+          value: metrics
       resourcedetection:
         detectors:
         - env
@@ -260,6 +266,7 @@ data:
           - batch
           - resource
           - k8sattributes/metrics
+          - resource/metrics
           - resource/k8s_cluster
           receivers:
           - k8s_cluster
@@ -274,6 +281,7 @@ data:
           - resource
           - resource/add_mode
           - k8sattributes/metrics
+          - resource/metrics
           receivers:
           - prometheus/k8s_cluster_receiver
       telemetry:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -7,14 +7,13 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm
 data:
   relay: |
     exporters:
@@ -38,7 +37,7 @@ data:
         source: kubernetes
         sourcetype: kube:events
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.132.0
+        splunk_app_version: 0.134.0
         timeout: 10s
         tls:
           insecure_skip_verify: false
@@ -61,7 +60,7 @@ data:
           queue_size: 1000
         source: kubernetes
         splunk_app_name: splunk-otel-collector
-        splunk_app_version: 0.132.0
+        splunk_app_version: 0.134.0
         timeout: 10s
         tls:
           insecure_skip_verify: false

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -122,10 +122,10 @@ data:
             key: splunk.com/sourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: pod
-            key: splunk.com/sourcetypeMetrics
+            key: splunk.com/metricsSourcetype
             tag_name: com.splunk.sourcetype
           - from: namespace
             key: splunk.com/metricsIndex

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
@@ -7,15 +7,14 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
     component: otel-collector-agent
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -32,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9b5a0baeb8dd7c21c6b1eff6bd7ec7748f4b14200f0a944512a8d234d463abb5
+        checksum/config: 03a9b51cda6472d846c5f082050bf705e5fa68846dbeb8963af9093825133b13
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true
@@ -74,7 +73,7 @@ spec:
           containerPort: 9943
           hostPort: 9943
           protocol: TCP
-        image: quay.io/signalfx/splunk-otel-collector:0.132.0
+        image: quay.io/signalfx/splunk-otel-collector:0.134.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
@@ -1,0 +1,204 @@
+---
+# Source: splunk-otel-collector/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.132.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.132.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.132.0
+    release: default
+    heritage: Helm
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        component: otel-collector-agent
+        release: default
+      annotations:
+        checksum/config: 9b5a0baeb8dd7c21c6b1eff6bd7ec7748f4b14200f0a944512a8d234d463abb5
+        kubectl.kubernetes.io/default-container: otel-collector
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: kubernetes.io/system-node
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+      initContainers:
+      containers:
+      - name: otel-collector
+        args:
+        - --config=/conf/relay.yaml
+        ports:
+        - name: fluentforward
+          containerPort: 8006
+          hostPort: 8006
+          protocol: TCP
+        - name: otlp
+          containerPort: 4317
+          hostPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          containerPort: 4318
+          protocol: TCP
+        - name: signalfx
+          containerPort: 9943
+          hostPort: 9943
+          protocol: TCP
+        image: quay.io/signalfx/splunk-otel-collector:0.132.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_NODE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_PLATFORM_HEC_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: default-splunk-otel-collector
+                key: splunk_platform_hec_token
+
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: otel-configmap
+        - mountPath: /hostfs/dev
+          name: host-dev
+          readOnly: true
+        - mountPath: /hostfs/etc
+          name: host-etc
+          readOnly: true
+        - mountPath: /hostfs/proc
+          name: host-proc
+          readOnly: true
+        - mountPath: /hostfs/run/udev/data
+          name: host-run-udev-data
+          readOnly: true
+        - mountPath: /hostfs/sys
+          name: host-sys
+          readOnly: true
+        - mountPath: /hostfs/var/run/utmp
+          name: host-var-run-utmp
+          readOnly: true
+        - mountPath: /hostfs/usr/lib/os-release
+          name: host-usr-lib-osrelease
+          readOnly: true
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: checkpoint
+          mountPath: /var/addon/splunk/otel_pos
+        - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+          name: run-collectd
+          readOnly: false
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: run-collectd
+        emptyDir:
+          sizeLimit: 25Mi
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: checkpoint
+        hostPath:
+          path: /var/addon/splunk/otel_pos
+          type: DirectoryOrCreate
+      - name: host-dev
+        hostPath:
+          path: /dev
+      - name: host-etc
+        hostPath:
+          path: /etc
+      - name: host-proc
+        hostPath:
+          path: /proc
+      - name: host-run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-var-run-utmp
+        hostPath:
+          path: /var/run/utmp
+      - name: host-usr-lib-osrelease
+        hostPath:
+          path: /usr/lib/os-release
+      - name: otel-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-agent
+          items:
+            - key: relay
+              path: relay.yaml

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 03a9b51cda6472d846c5f082050bf705e5fa68846dbeb8963af9093825133b13
+        checksum/config: 7e433e0b6578c4f3b9f677df68ac7896c37fde93c36fea62e3a09af0a3886992
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -7,15 +7,14 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
     component: otel-k8s-cluster-receiver
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm
     app.kubernetes.io/component: otel-k8s-cluster-receiver
 spec:
   replicas: 1
@@ -31,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 282f68528461edf31e7cede0526e85c329525cc002b9569541f213603ae327a9
+        checksum/config: aed55769a09b5be226087015063ccbb410df39d5159ae7a9a73f9d6e2c19cfce
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:
@@ -40,7 +39,7 @@ spec:
       - name: otel-collector
         args:
         - --config=/conf/relay.yaml
-        image: quay.io/signalfx/splunk-otel-collector:0.132.0
+        image: quay.io/signalfx/splunk-otel-collector:0.134.0
         imagePullPolicy: IfNotPresent
         env:
           - name: SPLUNK_MEMORY_TOTAL_MIB

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aed55769a09b5be226087015063ccbb410df39d5159ae7a9a73f9d6e2c19cfce
+        checksum/config: c0c937824346dfb157baa925f3ab97f3fdbded306a28b25a05866f38641d2096
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -1,0 +1,102 @@
+---
+# Source: splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: default-splunk-otel-collector-k8s-cluster-receiver
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.132.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.132.0"
+    app: splunk-otel-collector
+    component: otel-k8s-cluster-receiver
+    chart: splunk-otel-collector-0.132.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-k8s-cluster-receiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: splunk-otel-collector
+      component: otel-k8s-cluster-receiver
+      release: default
+  template:
+    metadata:
+      labels:
+        app: splunk-otel-collector
+        component: otel-k8s-cluster-receiver
+        release: default
+      annotations:
+        checksum/config: 282f68528461edf31e7cede0526e85c329525cc002b9569541f213603ae327a9
+    spec:
+      serviceAccountName: default-splunk-otel-collector
+      nodeSelector:
+          kubernetes.io/os: linux
+      containers:
+      - name: otel-collector
+        args:
+        - --config=/conf/relay.yaml
+        image: quay.io/signalfx/splunk-otel-collector:0.132.0
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: SPLUNK_MEMORY_TOTAL_MIB
+            value: "500"
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: K8S_POD_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: K8S_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: K8S_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+          - name: K8S_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SPLUNK_PLATFORM_HEC_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: default-splunk-otel-collector
+                key: splunk_platform_hec_token
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13134
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13134
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /conf
+          name: collector-configmap
+        - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
+          name: run-collectd
+          readOnly: false
+      terminationGracePeriodSeconds: 600
+      volumes:
+      - name: collector-configmap
+        configMap:
+          name: default-splunk-otel-collector-otel-k8s-cluster-receiver
+          items:
+            - key: relay
+              path: relay.yaml
+      - name: run-collectd
+        emptyDir:
+          sizeLimit: 25Mi

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/secret-splunk.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/secret-splunk.yaml
@@ -7,14 +7,13 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm
 type: Opaque
 data:
   splunk_platform_hec_token: Q0hBTkdFTUU=

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/secret-splunk.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/secret-splunk.yaml
@@ -1,0 +1,20 @@
+---
+# Source: splunk-otel-collector/templates/secret-splunk.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-splunk-otel-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.132.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.132.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.132.0
+    release: default
+    heritage: Helm
+type: Opaque
+data:
+  splunk_platform_hec_token: Q0hBTkdFTUU=

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/service-agent.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/service-agent.yaml
@@ -7,15 +7,14 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
     component: otel-collector-agent
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm
     app.kubernetes.io/component: otel-collector-agent
 spec:
   type: ClusterIP

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/service-agent.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/service-agent.yaml
@@ -1,0 +1,43 @@
+---
+# Source: splunk-otel-collector/templates/service-agent.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-splunk-otel-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.132.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.132.0"
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    chart: splunk-otel-collector-0.132.0
+    release: default
+    heritage: Helm
+    app.kubernetes.io/component: otel-collector-agent
+spec:
+  type: ClusterIP
+  ports:
+  - name: fluentforward
+    port: 8006
+    targetPort: fluentforward
+    protocol: TCP
+  - name: otlp
+    port: 4317
+    targetPort: otlp
+    protocol: TCP
+  - name: otlp-http
+    port: 4318
+    targetPort: otlp-http
+    protocol: TCP
+  - name: signalfx
+    port: 9943
+    targetPort: signalfx
+    protocol: TCP
+  selector:
+    app: splunk-otel-collector
+    component: otel-collector-agent
+    release: default
+  internalTrafficPolicy: Local

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/serviceAccount.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/serviceAccount.yaml
@@ -8,11 +8,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: splunk-otel-collector
-    helm.sh/chart: splunk-otel-collector-0.132.0
+    helm.sh/chart: splunk-otel-collector-0.134.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "0.132.0"
+    app.kubernetes.io/version: "0.134.0"
     app: splunk-otel-collector
-    chart: splunk-otel-collector-0.132.0
+    chart: splunk-otel-collector-0.134.0
     release: default
-    heritage: Helm

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/serviceAccount.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/serviceAccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: splunk-otel-collector/templates/serviceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: default-splunk-otel-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: splunk-otel-collector
+    helm.sh/chart: splunk-otel-collector-0.132.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: "0.132.0"
+    app: splunk-otel-collector
+    chart: splunk-otel-collector-0.132.0
+    release: default
+    heritage: Helm

--- a/examples/splunk-platform-with-sourcetypes/splunk-platform-with-sourcetypes-values.yaml
+++ b/examples/splunk-platform-with-sourcetypes/splunk-platform-with-sourcetypes-values.yaml
@@ -1,0 +1,8 @@
+clusterName: CHANGEME
+splunkPlatform:
+  token: CHANGEME
+  endpoint: http://localhost:8088/services/collector
+  sourcetype: "logs"
+  sourcetypeMetrics: "metrics"
+  metricsEnabled: true
+  metricsIndex: "metrics"

--- a/examples/splunk-platform-with-sourcetypes/splunk-platform-with-sourcetypes-values.yaml
+++ b/examples/splunk-platform-with-sourcetypes/splunk-platform-with-sourcetypes-values.yaml
@@ -3,6 +3,6 @@ splunkPlatform:
   token: CHANGEME
   endpoint: http://localhost:8088/services/collector
   sourcetype: "logs"
-  sourcetypeMetrics: "metrics"
+  metricsSourcetype: "metrics"
   metricsEnabled: true
   metricsIndex: "metrics"

--- a/functional_tests/configuration_switching/testdata/values/values_indexes_switching.yaml.tmpl
+++ b/functional_tests/configuration_switching/testdata/values/values_indexes_switching.yaml.tmpl
@@ -7,7 +7,12 @@ splunkPlatform:
   metricsIndex: {{ .MetricsIndex }}
   index: {{ .LogsIndex }}
   {{ if .NonDefaultSourcetype }}
+  {{ if .Sourcetype }}
   sourcetype: {{ .Sourcetype }}
+  {{ end }}
+  {{ if .SourcetypeMetrics }}
+  sourcetypeMetrics: {{ .SourcetypeMetrics }}
+  {{ end }}
   {{ end }}
 
 agent:

--- a/functional_tests/configuration_switching/testdata/values/values_indexes_switching.yaml.tmpl
+++ b/functional_tests/configuration_switching/testdata/values/values_indexes_switching.yaml.tmpl
@@ -11,7 +11,7 @@ splunkPlatform:
   sourcetype: {{ .Sourcetype }}
   {{ end }}
   {{ if .SourcetypeMetrics }}
-  sourcetypeMetrics: {{ .SourcetypeMetrics }}
+  metricsSourcetype: {{ .SourcetypeMetrics }}
   {{ end }}
   {{ end }}
 

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -373,7 +373,7 @@ resource/metrics:
       {{- if .Values.splunkPlatform.metricsSourcetype }}
       value: {{.Values.splunkPlatform.metricsSourcetype | quote }}
       {{- else }}
-      value: "{{.Values.splunkPlatform.sourcetype }}"
+      value: {{.Values.splunkPlatform.sourcetype | quote }}
       {{- end }}
       action: insert
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -294,6 +294,12 @@ k8sattributes/metrics:
       - key: splunk.com/sourcetype
         tag_name: com.splunk.sourcetype
         from: pod
+      - key: splunk.com/sourcetypeMetrics
+        tag_name: com.splunk.sourcetype
+        from: namespace
+      - key: splunk.com/sourcetypeMetrics
+        tag_name: com.splunk.sourcetype
+        from: pod
       - key: splunk.com/metricsIndex
         tag_name: com.splunk.index
         from: namespace
@@ -364,7 +370,11 @@ resource/metrics:
   attributes:
     # Insert the sourcetype value from values.yaml if it has not already been set through annotations.
     - key: com.splunk.sourcetype
+      {{- if .Values.splunkPlatform.sourcetypeMetrics }}
+      value: {{.Values.splunkPlatform.sourcetypeMetrics | quote }}
+      {{- else }}
       value: "{{.Values.splunkPlatform.sourcetype }}"
+      {{- end }}
       action: insert
 {{- end }}
 

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -294,10 +294,10 @@ k8sattributes/metrics:
       - key: splunk.com/sourcetype
         tag_name: com.splunk.sourcetype
         from: pod
-      - key: splunk.com/sourcetypeMetrics
+      - key: splunk.com/metricsSourcetype
         tag_name: com.splunk.sourcetype
         from: namespace
-      - key: splunk.com/sourcetypeMetrics
+      - key: splunk.com/metricsSourcetype
         tag_name: com.splunk.sourcetype
         from: pod
       - key: splunk.com/metricsIndex
@@ -370,8 +370,8 @@ resource/metrics:
   attributes:
     # Insert the sourcetype value from values.yaml if it has not already been set through annotations.
     - key: com.splunk.sourcetype
-      {{- if .Values.splunkPlatform.sourcetypeMetrics }}
-      value: {{.Values.splunkPlatform.sourcetypeMetrics | quote }}
+      {{- if .Values.splunkPlatform.metricsSourcetype }}
+      value: {{.Values.splunkPlatform.metricsSourcetype | quote }}
       {{- else }}
       value: "{{.Values.splunkPlatform.sourcetype }}"
       {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -759,7 +759,7 @@ processors:
   {{- include "splunk-otel-collector.k8sAttributesSplunkPlatformMetrics" . | nindent 2 }}
     filter:
       node_from_env_var: K8S_NODE_NAME
-  {{- if .Values.splunkPlatform.sourcetype }}
+  {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
   {{- include "splunk-otel-collector.resourceMetricsProcessor" . | nindent 2 }}
   {{- end }}
   {{- end }}
@@ -1159,7 +1159,7 @@ service:
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}
@@ -1189,7 +1189,7 @@ service:
         - resource/add_mode
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -759,7 +759,7 @@ processors:
   {{- include "splunk-otel-collector.k8sAttributesSplunkPlatformMetrics" . | nindent 2 }}
     filter:
       node_from_env_var: K8S_NODE_NAME
-  {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+  {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
   {{- include "splunk-otel-collector.resourceMetricsProcessor" . | nindent 2 }}
   {{- end }}
   {{- end }}
@@ -1159,7 +1159,7 @@ service:
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}
@@ -1189,7 +1189,7 @@ service:
         - resource/add_mode
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -40,7 +40,7 @@ processors:
   {{- include "splunk-otel-collector.k8sAttributesSplunkPlatformMetrics" . | nindent 2 }}
     filter:
       node_from_env_var: K8S_NODE_NAME
-  {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+  {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
   {{- include "splunk-otel-collector.resourceMetricsProcessor" . | nindent 2 }}
   {{- end }}
   {{- end }}
@@ -251,7 +251,7 @@ service:
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}
@@ -331,7 +331,7 @@ service:
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -40,7 +40,7 @@ processors:
   {{- include "splunk-otel-collector.k8sAttributesSplunkPlatformMetrics" . | nindent 2 }}
     filter:
       node_from_env_var: K8S_NODE_NAME
-  {{- if .Values.splunkPlatform.sourcetype }}
+  {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
   {{- include "splunk-otel-collector.resourceMetricsProcessor" . | nindent 2 }}
   {{- end }}
   {{- end }}
@@ -251,7 +251,7 @@ service:
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}
@@ -331,7 +331,7 @@ service:
         {{- end }}
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -106,7 +106,7 @@ processors:
   {{- include "splunk-otel-collector.k8sAttributesSplunkPlatformMetrics" . | nindent 2 }}
     filter:
       node_from_env_var: K8S_NODE_NAME
-  {{- if .Values.splunkPlatform.sourcetype }}
+  {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
   {{- include "splunk-otel-collector.resourceMetricsProcessor" . | nindent 2 }}
   {{- end }}
   {{- end }}
@@ -319,7 +319,7 @@ service:
         - resource
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}
@@ -344,7 +344,7 @@ service:
         - resource
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}
@@ -369,7 +369,7 @@ service:
         - resource/add_mode
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -106,7 +106,7 @@ processors:
   {{- include "splunk-otel-collector.k8sAttributesSplunkPlatformMetrics" . | nindent 2 }}
     filter:
       node_from_env_var: K8S_NODE_NAME
-  {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+  {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
   {{- include "splunk-otel-collector.resourceMetricsProcessor" . | nindent 2 }}
   {{- end }}
   {{- end }}
@@ -319,7 +319,7 @@ service:
         - resource
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}
@@ -344,7 +344,7 @@ service:
         - resource
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}
@@ -369,7 +369,7 @@ service:
         - resource/add_mode
         {{- if (eq (include "splunk-otel-collector.platformMetricsEnabled" $) "true") }}
         - k8sattributes/metrics
-        {{- if or .Values.splunkPlatform.sourcetypeMetrics .Values.splunkPlatform.sourcetype }}
+        {{- if or .Values.splunkPlatform.metricsSourcetype .Values.splunkPlatform.sourcetype }}
         - resource/metrics
         {{- end }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -61,6 +61,9 @@
         "sourcetype": {
           "type": "string"
         },
+        "sourcetypeMetrics": {
+          "type": "string"
+        },
         "maxConnections": {
           "type": "integer"
         },

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -61,7 +61,7 @@
         "sourcetype": {
           "type": "string"
         },
-        "sourcetypeMetrics": {
+        "metricsSourcetype": {
           "type": "string"
         },
         "maxConnections": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -56,6 +56,8 @@ splunkPlatform:
   # Optional. Default value for `sourcetype` field. For container logs, it will
   # be container name. For metrics and traces it will default to "httpevent".
   sourcetype: ""
+  # Optional. Default value for metrics `sourcetype` field. If not set it will follow the logic of the "sourcetype" field.
+  sourcetypeMetrics: ""
   # Maximum HTTP connections to use simultaneously when sending data.
   maxConnections: 200
   # Whether to disable gzip compression over HTTP. Defaults to true.

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -57,7 +57,7 @@ splunkPlatform:
   # be container name. For metrics and traces it will default to "httpevent".
   sourcetype: ""
   # Optional. Default value for metrics `sourcetype` field. If not set it will follow the logic of the "sourcetype" field.
-  sourcetypeMetrics: ""
+  metricsSourcetype: ""
   # Maximum HTTP connections to use simultaneously when sending data.
   maxConnections: 200
   # Whether to disable gzip compression over HTTP. Defaults to true.

--- a/test/splunk_integration_test.go
+++ b/test/splunk_integration_test.go
@@ -243,7 +243,7 @@ func addNamespaceAnnotation(t *testing.T, clientset *kubernetes.Clientset, names
 		ns.Annotations["splunk.com/sourcetype"] = annotationSourcetype
 	}
 	if annotationSourcetypeMetrics != "" {
-		ns.Annotations["splunk.com/sourcetypeMetrics"] = annotationSourcetypeMetrics
+		ns.Annotations["splunk.com/metricsSourcetype"] = annotationSourcetypeMetrics
 	}
 
 	_, err = clientset.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
@@ -264,7 +264,7 @@ func addPodAnnotation(t *testing.T, clientset *kubernetes.Clientset, pod_name st
 		pod.Annotations["splunk.com/sourcetype"] = annotationSourcetype
 	}
 	if annotationSourcetypeMetrics != "" {
-		pod.Annotations["splunk.com/sourcetypeMetrics"] = annotationSourcetypeMetrics
+		pod.Annotations["splunk.com/metricsSourcetype"] = annotationSourcetypeMetrics
 	}
 	_, err = clientset.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
 	require.NoError(t, err)

--- a/test/splunk_integration_test.go
+++ b/test/splunk_integration_test.go
@@ -170,6 +170,7 @@ func testVerifyMetricPodAnnotations(t *testing.T) {
 		{"default index and default sourcetype", "", "", ""},
 		{"annotation index and default sourcetype", annotationIndex, "", ""},
 		{"default index and annotation sourcetype", "", annotationSourcetype, ""},
+		{"default index, default sourcetype and annotation metric sourcetype", "", "", annotationMetricSourcetype},
 		{"default index, annotation sourcetype and annotation metric sourcetype", "", annotationSourcetype, annotationMetricSourcetype},
 		{"annotation index and annotation sourcetype", annotationIndex, annotationSourcetype, ""},
 	}


### PR DESCRIPTION
**Description:** 
This PR introduces support for the `sourcetypeMetrics` field in the Splunk Platform configuration within the Helm chart. The new field allows users to specify a custom sourcetype value for metrics ingested into Splunk Platform, providing greater flexibility and alignment with Splunk data models.

**Purpose**: 
Introduce `sourcetypeMetrics` for granular control over metrics sourcetypes, while ensuring backward compatibility.

**Current Behavior**: 
`sourcetype` applies to all data types (logs, traces, and metrics).

**New Behavior**:
`sourcetype` will now primarily define the sourcetype for logs and traces.
For metrics, the sourcetype is determined by the following hierarchy:
`sourcetypeMetrics`: If specified, it takes precedence.
`sourcetype`: If `sourcetypeMetrics` is not specified, the value from `sourcetype` is used (to avoid a breaking change for existing configurations).
`httpevent`: If neither `sourcetypeMetrics` nor s`ourcetype` is specified, `httpevent` is used as the default.

**Testing:** functional tests, manual tests

**Documentation:** <Describe the documentation added.>
