### PR TITLE
[agent] Enable container.cpu.usage metric by default

### DIFF
--- a/.chloggen/enablecontainercpuusage.yaml
+++ b/.chloggen/enablecontainercpuusage.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable `container.cpu.usage` metric by default
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -352,8 +352,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7fd73b1ea3cf40e79812bfaa9adbbf885f01199c535094ea50fe5ed55f9c0768
+        checksum/config: 418f9ad94158c26ddaa8e6fd89561ceda46c03e0a597e24048ee91287db6f088
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -308,8 +308,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4759d3861c48fcb8d860def101ee96603ed2ecbde372b21312ea6a421e128897
+        checksum/config: 32981df862e5cd97d5f1a54921df3584f9bc73fa99916d91cccefa185474b9e8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c374a2af954d53e649b0f52861ba973e0bf331d5f450d1cb6ba18f4ec0b18c49
+        checksum/config: 7a138bddacdb368ff14649cec1c5aa505c5b3b487bd1a5dbe91ccc3083c26741
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -186,8 +186,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d3413c0b27ab8b2edf54dbb5be18bfa9ef54610914524f5a32bbf72d9fb8b94b
+        checksum/config: cb3990db37d41fa26c5392b5b60c9c2da3d2b0abfcc2059b10ad7aae892326b9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -336,8 +336,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1a9f68694bba895bef1b094bf2098b547226009dbbdab9ca6fe1ab2f8c3ff4e4
+        checksum/config: 3503a604efa5c19cddf931d4b2268edfe92ce110a58cccfec9a8c3823cfc566b
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 38357969ce56b6d70094e54a0124fdb97575ee5499528c0be8164b1cd735cd41
+        checksum/config: e76d0ca24e2ef1c9e42d7aa8fb66f9ad969a9bb8710739edbca32e45db73bfe9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -169,8 +169,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 255ceeb74da01f60c733e116637c54621e57e030ba23d92dd6c70c6050b7c6bd
+        checksum/config: f645759b17dec5169dbeea68b02bb27b690c8bdd0518e6000ca571608a58c743
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 38357969ce56b6d70094e54a0124fdb97575ee5499528c0be8164b1cd735cd41
+        checksum/config: e76d0ca24e2ef1c9e42d7aa8fb66f9ad969a9bb8710739edbca32e45db73bfe9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/configmap-agent.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 38357969ce56b6d70094e54a0124fdb97575ee5499528c0be8164b1cd735cd41
+        checksum/config: e76d0ca24e2ef1c9e42d7aa8fb66f9ad969a9bb8710739edbca32e45db73bfe9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 38357969ce56b6d70094e54a0124fdb97575ee5499528c0be8164b1cd735cd41
+        checksum/config: e76d0ca24e2ef1c9e42d7aa8fb66f9ad969a9bb8710739edbca32e45db73bfe9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 839d5341690faf06309d3c3d02c1893f65cd18e6c5450df26d2596011d9f7549
+        checksum/config: 99d9dbb4c7ecce53b676d1826ad92a09c614b77269e8fe947523fd2ef090f277
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -185,8 +185,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 627954d417d8564058fa3039d18b9f3aba817fe9458ac030702ff877daf07e53
+        checksum/config: 344dad787d8cf046aeac7956e75aecd7e3f40b19e766e4365af29159cb13ff07
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-agent.yaml
@@ -200,8 +200,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 578ffb616ab694da1a0407b0654071c164735b4e6dd76e5ab4b0e0e3128941eb
+        checksum/config: fbe22e72422fc04a8559bffb4ab4ced91aa7762a10e946d897b1d297e64e316e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -201,8 +201,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9bc24df07d6846f61f373c47e18c8188425dd796a74cd6ab69a119b5f7bc297a
+        checksum/config: 6259587801e02c7558490539a97a0b1d72382b974fcb40dae2727a84d77a672b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -184,8 +184,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1dd205bef5a1e4e5b62c5824cf82ca755fef8376a769e532e6a94fd44f9e4b9b
+        checksum/config: 10edb30fc24defcbc80f9c8c35f0ffb091cf0ae7c20c31632950753ffd47f470
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -184,8 +184,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 816ebc127ec5700afe2f270a51a95e0dd674c6d3d82bfffecf57dbace6b9db8a
+        checksum/config: 7d45300245bf65066346d20bc27a61ea86dad7b7b4f576c9a70737c3e8499c89
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a727355f7b67e6ad62e73d446dfc76fec43512bc153405bfb5a7cc2e990f274e
+        checksum/config: 4169a22dc9b87fd2184a4ac207107a6a8e5165cd59ce88e6d625d85d32cefc38
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -306,8 +306,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0ed51bfc08816655d1bfad9932fa69eb1fe235f970b428d05cb03da96c62d7c1
+        checksum/config: 69e5835a5b37c6cbb35eb3b11db7fc8ad4eb7d0484ef72247bcb27c2702572e4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -184,8 +184,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: deaa07436e9f38b49d19153124246a854cbe76e0b7dd56b55a845b32a68d7057
+        checksum/config: 71eaf186ac3c77f9a1787a229fca71f368689e40b79ce8ea622c90bb49334cf1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-agent.yaml
@@ -201,8 +201,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bad24d12a21e18ccc2c652841981e23c72418d2a20c3edaca5839a98e11480d2
+        checksum/config: 76e840321d952649227eaf56f93cf725135da7a44f0769ee301fd7f03e47e0ce
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-agent.yaml
@@ -201,8 +201,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 87fdccb4e2883242107b25c66862567c4dac79bfde165bbadbe6491c102e47f5
+        checksum/config: 32b3394b3c06b4006045b98003766f3d8540c277f0105e4bfbe563531d10fa71
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -304,8 +304,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7208f76344fdfb9918e5d3f61586cf03047a28d55549f953570c06fc6a08102f
+        checksum/config: 4baceaef6fb4ffec2a473cfef4bc15710ea0fd25d38dbab0b517d35eef7a4860
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -172,8 +172,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7bc0ee298a3ded69f365e7bdbcb49499839aa76865b2053874c1b0b0442bea3d
+        checksum/config: ce223b2bcbdc01d8b6b607a69c693f254453f91184f414f7b2a40d487c0988ba
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-agent.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-agent.yaml
@@ -169,8 +169,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/otlp-token-passthrough/rendered_manifests/daemonset.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 432de6d2bd1c52c3fddd5ee69b29783b06e2a919225a060fb49a477110bfb838
+        checksum/config: c05a44050ba13e942e0229e83b1afd993b261ebcf37cd74c1f8f096d9e464608
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -187,8 +187,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9195c1ebacaf2c090e56065fcc6562fc607da20d85ee3fb2bd1357cb47570783
+        checksum/config: d87020930c0da093016aa2dde641272d7e1dcd80bb0f35ab31342efd252065da
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e15c0835c33b2cfe10ec3c7fce4c30f08a88e202b717e893320bd5d65778fd03
+        checksum/config: 1ee85ce944e8a97b77af3683eb62efda189c631b01d55a502b67c4a2bb06d5b0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 38357969ce56b6d70094e54a0124fdb97575ee5499528c0be8164b1cd735cd41
+        checksum/config: e76d0ca24e2ef1c9e42d7aa8fb66f9ad969a9bb8710739edbca32e45db73bfe9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -183,8 +183,6 @@ data:
         - pod
         - node
         metrics:
-          container.cpu.usage:
-            enabled: false
           k8s.node.cpu.usage:
             enabled: false
           k8s.pod.cpu.usage:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 64c3d08efbf4f5ad419cd969ad49941f7f33d4310bc38665412079614f62cc30
+        checksum/config: 98006ee70f432b3bbe8fa2ab82ef4c472ff85515cef831610f17e0c649b9e214
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -466,8 +466,6 @@ receivers:
     {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
     # Disable CPU usage metrics as they are not categorized as bundled in Splunk Observability
     metrics:
-      container.cpu.usage:
-        enabled: false
       k8s.pod.cpu.usage:
         enabled: false
       k8s.node.cpu.usage:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This [metric is enabled by default](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kubeletstatsreceiver/documentation.md#containercpuusage) upstream and is a bundled metric, so it can be enabled by default in the chart.