### PR TITLE
WIP: fix metrics annotations

### DIFF
--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -288,7 +288,8 @@ k8sattributes/metrics:
       - from: resource_attribute
         name: k8s.pod.ip
     - sources:
-      - from: connection
+      - from: resource_attribute
+        name: ip
   extract:
     metadata: []
     annotations:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -286,9 +286,6 @@ k8sattributes/metrics:
         name: k8s.namespace.name
     - sources:
       - from: resource_attribute
-        name: k8s.pod.ip
-    - sources:
-      - from: resource_attribute
         name: ip
     - sources:
       - from: connection

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -286,7 +286,7 @@ k8sattributes/metrics:
         name: k8s.namespace.name
     - sources:
       - from: resource_attribute
-        name: ip
+        name: k8s.pod.ip
     - sources:
       - from: connection
   extract:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -277,13 +277,13 @@ k8sattributes/metrics:
   pod_association:
     - sources:
       - from: resource_attribute
-        name: k8s.node.name
-    - sources:
-      - from: resource_attribute
         name: k8s.pod.uid
     - sources:
       - from: resource_attribute
         name: k8s.namespace.name
+    - sources:
+      - from: resource_attribute
+        name: k8s.node.name
   extract:
     metadata: []
     annotations:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -283,6 +283,9 @@ k8sattributes/metrics:
         name: k8s.pod.uid
     - sources:
       - from: resource_attribute
+        name: k8s.namespace.name
+    - sources:
+      - from: resource_attribute
         name: k8s.pod.ip
     - sources:
       - from: resource_attribute

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -284,12 +284,6 @@ k8sattributes/metrics:
     - sources:
       - from: resource_attribute
         name: k8s.namespace.name
-    - sources:
-      - from: resource_attribute
-        name: k8s.pod.ip
-    - sources:
-      - from: resource_attribute
-        name: ip
   extract:
     metadata: []
     annotations:

--- a/test/splunk_integration_test.go
+++ b/test/splunk_integration_test.go
@@ -137,6 +137,51 @@ func testVerifyMetricNamespaceAnnotations(t *testing.T) {
 	}
 }
 
+func testVerifyMetricPodAnnotations(t *testing.T) {
+	podName := "pod-metrics-index"
+	namespace := "default"
+	defaultIndex := "ci_metrics"
+	defaultSourcetype := "httpevent"
+	annotationIndex := "test_metrics"
+	annotationSourcetype := "annotation_sourcetype"
+
+	client := createK8sClient(t)
+
+	tests := []struct {
+		name                      string
+		annotationIndexValue      string
+		annotationSourcetypeValue string
+	}{
+		{"default index and default sourcetype", "", ""},
+		{"annotation index and default sourcetype", annotationIndex, ""},
+		{"default index and annotation sourcetype", "", annotationSourcetype},
+		{"annotation index and annotation sourcetype", annotationIndex, annotationSourcetype},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addPodAnnotation(t, client, podName, tt.annotationIndexValue, tt.annotationSourcetypeValue)
+			time.Sleep(20 * time.Second)
+
+			index := defaultIndex
+			if tt.annotationIndexValue != "" {
+				index = tt.annotationIndexValue
+			}
+			sourcetype := defaultSourcetype
+			if tt.annotationSourcetypeValue != "" {
+				sourcetype = tt.annotationSourcetypeValue
+			}
+			searchQuery := METRIC_SEARCH_QUERY_STRING + "index=" + index + " filter=\"sourcetype=" + sourcetype + "\" | search \"k8s.pod.name\"=" + podName
+			fmt.Println("Search Query: ", searchQuery)
+			startTime := "-15s@s"
+			events := CheckEventsFromSplunk(searchQuery, startTime)
+			fmt.Println(" =========>  Events received: ", len(events))
+			assert.Greater(t, len(events), 1)
+
+			removeAllPodsAnnotations(t, client, podName)
+		})
+	}
+}
+
 func createK8sClient(t *testing.T) *kubernetes.Clientset {
 	testKubeConfig, setKubeConfig := os.LookupEnv("KUBECONFIG")
 	require.True(t, setKubeConfig, "the environment variable KUBECONFIG must be set")
@@ -157,6 +202,16 @@ func removeAllNamespaceAnnotations(t *testing.T, clientset *kubernetes.Clientset
 	fmt.Printf("All annotations removed from namespace_name %s\n", namespace_name)
 }
 
+func removeAllPodsAnnotations(t *testing.T, clientset *kubernetes.Clientset, pod_name string) {
+	pod, err := clientset.CoreV1().Pods().Get(context.TODO(), pod_name, metav1.GetOptions{})
+	require.NoError(t, err)
+	pod.Annotations = make(map[string]string)
+
+	_, err = clientset.CoreV1().Pods().Update(context.TODO(), pod_name, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	fmt.Printf("All annotations removed from pod_name %s\n", pod_name)
+}
+
 func addNamespaceAnnotation(t *testing.T, clientset *kubernetes.Clientset, namespace_name string, annotationIndex string, annotationSourcetype string) {
 	ns, err := clientset.CoreV1().Namespaces().Get(context.TODO(), namespace_name, metav1.GetOptions{})
 	require.NoError(t, err)
@@ -173,4 +228,22 @@ func addNamespaceAnnotation(t *testing.T, clientset *kubernetes.Clientset, names
 	_, err = clientset.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
 	require.NoError(t, err)
 	fmt.Printf("Annotation added to namespace_name %s\n", namespace_name)
+}
+
+func addPodAnnotation(t *testing.T, clientset *kubernetes.Clientset, pod_name string, annotationIndex string, annotationSourcetype string) {
+	pod, err := client.CoreV1().Pods("namespace").Get(context.TODO(), pod_name, metav1.GetOptions{})
+	require.NoError(t, err)
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	if annotationIndex != "" {
+		pod.Annotations["splunk.com/metricsIndex"] = annotationIndex
+	}
+	if annotationSourcetype != "" {
+		pod.Annotations["splunk.com/sourcetype"] = annotationSourcetype
+	}
+
+	_, err = clientset.CoreV1().Namespaces().Update(context.TODO(), pod, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	fmt.Printf("Annotation added to pod_name %s\n", pod_name)
 }

--- a/test/test_setup.yaml
+++ b/test/test_setup.yaml
@@ -176,3 +176,27 @@ spec:
           value: "256"
         - name: FREQ
           value: "0.1"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pod-metrics-index
+  namespace: default
+spec:
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: pod-metrics-index
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: pod-w-index-w-ns-index
+          image: docker.io/rock1017/log-generator:2.2.6
+          env:
+            - name: MESSAGE_COUNT
+              value: "10"
+            - name: SIZE
+              value: "256"
+            - name: FREQ
+              value: "1"


### PR DESCRIPTION
**Description:** 
Currently setting `splunk.com/metricsIndex` and `splunk.com/sourcetype` in `k8sattributes/metrics` processor doesn't work at all on a pod level.

This PR fixes this problem and adds integration tests for setting annotations on a pod level.


**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
