### PR TITLE
Mark `splunkObservability.logsEnabled` as deprecated

### DIFF
--- a/.chloggen/deprecate-o11y-lo.yaml
+++ b/.chloggen/deprecate-o11y-lo.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark `splunkObservability.logsEnabled` as deprecated.
+# One or more tracking issues related to the change
+issues: [1984]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Logs cannot be sent directly to Splunk Observability anymore.
+  Configure `splunkPlatform` to send logs to Splunk Platform and enable Log Observer Connect to view the logs in Splunk Observability.
+  See the following documentation for more details: https://help.splunk.com/en/splunk-observability-cloud/manage-data/view-splunk-platform-logs/accomplish-logs-pipeline-rules-in-splunk-platform

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -102,3 +102,8 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
 {{- fail (printf "ERROR: Deprecated instrumentation configuration detected, the following %s is no longer supported under instrumentation. Please migrate to instrumentation.spec.*. See https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#01280-to-01290 for details." $instrKeys) }}
 {{- end }}
 {{- end }}
+{{- if (eq (include "splunk-otel-collector.o11yLogsEnabled" .) "true") }}
+[WARNING] "splunkObservability.logsEnabled" parameter is deprecated. Logs cannot be sent directly to Splunk Observability anymore.
+          Use `splunkPlatform.logsEnabled` to send logs to Splunk Platform and enable Log Observer Connect.
+          See https://help.splunk.com/en/splunk-observability-cloud/manage-data/view-splunk-platform-logs/accomplish-logs-pipeline-rules-in-splunk-platform for more details.
+{{ end }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -160,6 +160,11 @@ splunkObservability:
   # Options to disable or enable particular telemetry data types.
   metricsEnabled: true
   tracesEnabled: true
+
+  # Deprecated: [v0.132.0] this setting will be removed in 2 versions
+  # Logs cannot be sent directly to Splunk Observability anymore.
+  # Configure `splunkPlatform` to send logs to Splunk Platform and enable Log Observer Connect to view the logs in Splunk Observability.
+  # See https://help.splunk.com/en/splunk-observability-cloud/manage-data/view-splunk-platform-logs/accomplish-logs-pipeline-rules-in-splunk-platform
   logsEnabled: false
 
   # Option to send Kubernetes events to Splunk Observability Infrastructure Monitoring in the old


### PR DESCRIPTION
Logs cannot be sent directly to Splunk Observability anymore. Configure `splunkPlatform` to send logs to Splunk Platform and enable Log Observer Connect to view the logs in Splunk Observability. See the following documentation for more details: https://help.splunk.com/en/splunk-observability-cloud/manage-data/view-splunk-platform-logs/accomplish-logs-pipeline-rules-in-splunk-platform
