### PR TITLE
Remove deprecated `splunkRealm` and `splunkAccessToken` options

### DIFF
--- a/.chloggen/remove-deprecated-params.yaml
+++ b/.chloggen/remove-deprecated-params.yaml
@@ -1,0 +1,14 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove support of deprecated `splunkRealm` and `splunkAccessToken` values.yaml options.
+# One or more tracking issues related to the change
+issues: [1985]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  These parameters were deprecated in favor of the structured `splunkObservability` configuration.
+  Users must migrate to using `splunkObservability.realm` and `splunkObservability.accessToken` respectively.

--- a/helm-charts/splunk-otel-collector/ci/use-custom-gateway-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/use-custom-gateway-values.yaml
@@ -1,7 +1,8 @@
 clusterName: my-cluster
 # Validate backward compatible parameters
-splunkRealm: us0
-splunkAccessToken: my-access-token
+splunkObservability:
+  realm: us0
+  accessToken: my-access-token
 
 logsEnabled: false
 

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -1,13 +1,8 @@
-{{/* Current jsonschema doesn't enforce below requirement while `splunkRealm` not provided as (an undesired) default value. */}}
-{{- if and (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "false") (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "false") -}}
-{{ fail "[ERROR] Please set at least one of required `splunkObservability.realm` or `splunkPlatform.endpoint` and corresponding token values to specify the platform(s) to send data." }}
-{{- end -}}
-
 {{- if eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true" }}
 Splunk OpenTelemetry Collector is installed and configured to send data to Splunk Platform endpoint "{{ .Values.splunkPlatform.endpoint }}".
 {{ end }}
 {{- if eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true" }}
-Splunk OpenTelemetry Collector is installed and configured to send data to Splunk Observability realm {{ include "splunk-otel-collector.o11yRealm" . }}.
+Splunk OpenTelemetry Collector is installed and configured to send data to Splunk Observability realm {{ .Values.splunkObservability.realm }}.
 {{ end }}
 
 {{- if and (eq (include "splunk-otel-collector.distribution" .) "eks/auto-mode") (or (eq (include "splunk-otel-collector.clusterReceiverHostNetworkEnabled" .) "false") (eq (toString .Values.agent.hostNetwork) "false")) }}
@@ -20,17 +15,9 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
           For more information about deploying Splunk Opentelemetry in EKS Auto Mode cluster, see guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#eks-auto-mode
 {{- end }}
 
-{{- if .Values.splunkRealm }}
-[WARNING] "splunkRealm" parameter is deprecated, please use "splunkObservability.realm" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360
-{{ end }}
 {{- if not (eq (toString .Values.service) "<nil>") }}
 [WARNING] The ".Values.service" config is deprecated. Please use ".Values.agent.service" and ".Values.gateway.service" for configuring services for the agent and gateway, respectively.
           This field will be removed in a future release.
-{{ end }}
-{{- if .Values.splunkAccessToken }}
-[WARNING] "splunkAccessToken" parameter is deprecated, please use "splunkObservability.accessToken" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360
 {{ end }}
 {{- if .Values.ingestUrl }}
 [WARNING] "ingestUrl" parameter is deprecated, please use "splunkObservability.ingestUrl" instead.

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -43,7 +43,7 @@ Whether to send data to Splunk Platform endpoint
 Whether to send data to Splunk Observability endpoint
 */}}
 {{- define "splunk-otel-collector.splunkO11yEnabled" -}}
-{{- not (eq (include "splunk-otel-collector.o11yRealm" .) "") }}
+{{- not (eq .Values.splunkObservability.realm "") }}
 {{- end -}}
 
 {{/*
@@ -169,18 +169,10 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Get Splunk Observability Realm.
-*/}}
-{{- define "splunk-otel-collector.o11yRealm" -}}
-{{- .Values.splunkObservability.realm | default .Values.splunkRealm | default "" }}
-{{- end -}}
-
-
-{{/*
 Get Splunk ingest URL
 */}}
 {{- define "splunk-otel-collector.o11yIngestUrl" -}}
-{{- $realm := (include "splunk-otel-collector.o11yRealm" .) }}
+{{- $realm := .Values.splunkObservability.realm }}
 {{- .Values.splunkObservability.ingestUrl | default .Values.ingestUrl | default (printf "https://ingest.%s.signalfx.com" $realm) }}
 {{- end -}}
 
@@ -188,15 +180,8 @@ Get Splunk ingest URL
 Get Splunk API URL.
 */}}
 {{- define "splunk-otel-collector.o11yApiUrl" -}}
-{{- $realm := (include "splunk-otel-collector.o11yRealm" .) }}
+{{- $realm := .Values.splunkObservability.realm }}
 {{- .Values.splunkObservability.apiUrl | default .Values.apiUrl | default (printf "https://api.%s.signalfx.com" $realm) }}
-{{- end -}}
-
-{{/*
-Get Splunk Observability Access Token.
-*/}}
-{{- define "splunk-otel-collector.o11yAccessToken" -}}
-{{- .Values.splunkObservability.accessToken | default .Values.splunkAccessToken | default "" -}}
 {{- end -}}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
+++ b/helm-charts/splunk-otel-collector/templates/secret-splunk.yaml
@@ -17,7 +17,7 @@ metadata:
 type: Opaque
 data:
   {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}
-  splunk_observability_access_token: {{ include "splunk-otel-collector.o11yAccessToken" . | b64enc }}
+  splunk_observability_access_token: {{ .Values.splunkObservability.accessToken | b64enc }}
   {{- end }}
   {{- if (eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true") }}
   splunk_platform_hec_token: {{ .Values.splunkPlatform.token | b64enc }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1495,16 +1495,6 @@
         }
       }
     },
-    "splunkRealm": {
-      "description": "[DEPRECATED] Splunk Observability Realm",
-      "type": "string",
-      "deprecated": true
-    },
-    "splunkAccessToken": {
-      "description": "[DEPRECATED] Splunk Observability Access Token",
-      "type": "string",
-      "deprecated": true
-    },
     "ingestUrl": {
       "description": "[DEPRECATED] Splunk Observability ingest URL.",
       "type": "string",
@@ -1638,16 +1628,6 @@
                   "minLength": 1
                 }
               }
-            }
-          }
-        },
-        {
-          "properties": {
-            "splunkRealm": {
-              "description": "[DEPRECATED] Splunk Observability Realm",
-              "type": "string",
-              "deprecated": true,
-              "minLength": 1
             }
           }
         }


### PR DESCRIPTION
These parameters were deprecated in favor of the structured `splunkObservability` configuration. Users must migrate to using `splunkObservability.realm` and `splunkObservability.accessToken` respectively.
