### PR TITLE
Remove deprecated ingestUrl and apiUrl values.yaml params

### DIFF
--- a/.chloggen/remove-deprecated-params.yaml
+++ b/.chloggen/remove-deprecated-params.yaml
@@ -3,12 +3,16 @@ change_type: breaking
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: chart
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Remove support of deprecated `splunkRealm` and `splunkAccessToken` values.yaml options.
+note: Remove support of deprecated `splunkRealm`, `splunkAccessToken`, `ingestUrl` and `apiUrl` values.yaml options.
 # One or more tracking issues related to the change
-issues: [1985]
+issues: [1985, 1987]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
   These parameters were deprecated in favor of the structured `splunkObservability` configuration.
-  Users must migrate to using `splunkObservability.realm` and `splunkObservability.accessToken` respectively.
+  Users must migrate to using:
+  - `splunkObservability.realm` instead of `splunkRealm`
+  - `splunkObservability.accessToken` instead of `splunkAccessToken`
+  - `splunkObservability.ingestUrl` instead of `ingestUrl`
+  - `splunkObservability.apiUrl` instead of `apiUrl`

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -19,14 +19,6 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
 [WARNING] The ".Values.service" config is deprecated. Please use ".Values.agent.service" and ".Values.gateway.service" for configuring services for the agent and gateway, respectively.
           This field will be removed in a future release.
 {{ end }}
-{{- if .Values.ingestUrl }}
-[WARNING] "ingestUrl" parameter is deprecated, please use "splunkObservability.ingestUrl" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360
-{{ end }}
-{{- if .Values.apiUrl }}
-[WARNING] "apiUrl" parameter is deprecated, please use "splunkObservability.apiUrl" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360
-{{ end }}
 {{- if not (eq (toString .Values.metricsEnabled) "<nil>") }}
 [WARNING] "metricsEnabled" parameter is deprecated, please use "splunkObservability.metricsEnabled" instead.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -173,7 +173,7 @@ Get Splunk ingest URL
 */}}
 {{- define "splunk-otel-collector.o11yIngestUrl" -}}
 {{- $realm := .Values.splunkObservability.realm }}
-{{- .Values.splunkObservability.ingestUrl | default .Values.ingestUrl | default (printf "https://ingest.%s.signalfx.com" $realm) }}
+{{- .Values.splunkObservability.ingestUrl | default (printf "https://ingest.%s.signalfx.com" $realm) }}
 {{- end -}}
 
 {{/*
@@ -181,7 +181,7 @@ Get Splunk API URL.
 */}}
 {{- define "splunk-otel-collector.o11yApiUrl" -}}
 {{- $realm := .Values.splunkObservability.realm }}
-{{- .Values.splunkObservability.apiUrl | default .Values.apiUrl | default (printf "https://api.%s.signalfx.com" $realm) }}
+{{- .Values.splunkObservability.apiUrl | default (printf "https://api.%s.signalfx.com" $realm) }}
 {{- end -}}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1495,16 +1495,6 @@
         }
       }
     },
-    "ingestUrl": {
-      "description": "[DEPRECATED] Splunk Observability ingest URL.",
-      "type": "string",
-      "deprecated": true
-    },
-    "apiUrl": {
-      "description": "[DEPRECATED] Splunk Observability API URL.",
-      "type": "string",
-      "deprecated": true
-    },
     "metricsEnabled": {
       "description": "[DEPRECATED] Send Metrics to Splunk Observability",
       "type": "boolean",


### PR DESCRIPTION
Use `splunkObservability.ingestUrl` instead of `ingestUrl` and `splunkObservability.apiUrl` instead of `apiUrl`