### PR TITLE
Remove deprecated root-level options to enable/disable signals

### DIFF
--- a/.chloggen/remove-deprecated-params.yaml
+++ b/.chloggen/remove-deprecated-params.yaml
@@ -3,7 +3,7 @@ change_type: breaking
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: chart
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Remove support of deprecated `splunkRealm`, `splunkAccessToken`, `ingestUrl` and `apiUrl` values.yaml options.
+note: Remove support of deprecated `splunkRealm`, `splunkAccessToken`, `ingestUrl`, `apiUrl`, `metricsEnabled`, `tracesEnabled`, and `logsEnabled` root-level values.yaml options.
 # One or more tracking issues related to the change
 issues: [1985, 1987]
 # (Optional) One or more lines of additional information to render under the primary note.
@@ -16,3 +16,6 @@ subtext: |
   - `splunkObservability.accessToken` instead of `splunkAccessToken`
   - `splunkObservability.ingestUrl` instead of `ingestUrl`
   - `splunkObservability.apiUrl` instead of `apiUrl`
+  - `splunkObservability.metricsEnabled` instead of `metricsEnabled`
+  - `splunkObservability.tracesEnabled` instead of `tracesEnabled`
+  - `splunkObservability.logsEnabled` instead of `logsEnabled`

--- a/helm-charts/splunk-otel-collector/ci/use-custom-gateway-values.yaml
+++ b/helm-charts/splunk-otel-collector/ci/use-custom-gateway-values.yaml
@@ -1,10 +1,7 @@
 clusterName: my-cluster
-# Validate backward compatible parameters
 splunkObservability:
   realm: us0
   accessToken: my-access-token
-
-logsEnabled: false
 
 agent:
   config:

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -19,18 +19,6 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
 [WARNING] The ".Values.service" config is deprecated. Please use ".Values.agent.service" and ".Values.gateway.service" for configuring services for the agent and gateway, respectively.
           This field will be removed in a future release.
 {{ end }}
-{{- if not (eq (toString .Values.metricsEnabled) "<nil>") }}
-[WARNING] "metricsEnabled" parameter is deprecated, please use "splunkObservability.metricsEnabled" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360
-{{ end }}
-{{- if not (eq (toString .Values.tracesEnabled) "<nil>") }}
-[WARNING] "tracesEnabled" parameter is deprecated, please use "splunkObservability.tracesEnabled" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360
-{{ end }}
-{{- if not (eq (toString .Values.logsEnabled) "<nil>") }}
-[WARNING] "logsEnabled" parameter is deprecated, please use "splunkObservability.logsEnabled" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0353-to-0360
-{{ end }}
 {{- if not (eq (toString .Values.distro) "<nil>") }}
 [WARNING] "distro" parameter is deprecated, please use "distribution" instead.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -50,33 +50,21 @@ Whether to send data to Splunk Observability endpoint
 Whether metrics enabled for Splunk Observability, backward compatible.
 */}}
 {{- define "splunk-otel-collector.o11yMetricsEnabled" -}}
-{{- if eq (toString .Values.metricsEnabled) "<nil>" }}
 {{- and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.splunkObservability.metricsEnabled }}
-{{- else }}
-{{- and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.metricsEnabled }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Whether traces enabled for Splunk Observability, backward compatible.
 */}}
 {{- define "splunk-otel-collector.o11yTracesEnabled" -}}
-{{- if eq (toString .Values.tracesEnabled) "<nil>" }}
 {{- and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.splunkObservability.tracesEnabled }}
-{{- else }}
-{{- and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.tracesEnabled }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Whether logs enabled for Splunk Observability, backward compatible.
 */}}
 {{- define "splunk-otel-collector.o11yLogsEnabled" -}}
-{{- if eq (toString .Values.logsEnabled) "<nil>" }}
 {{- and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.splunkObservability.logsEnabled }}
-{{- else }}
-{{- and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.logsEnabled }}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1495,21 +1495,6 @@
         }
       }
     },
-    "metricsEnabled": {
-      "description": "[DEPRECATED] Send Metrics to Splunk Observability",
-      "type": "boolean",
-      "deprecated": true
-    },
-    "tracesEnabled": {
-      "description": "[DEPRECATED] Send Traces to Splunk Observability",
-      "type": "boolean",
-      "deprecated": true
-    },
-    "logsEnabled": {
-      "description": "[DEPRECATED] Send Logs to Splunk Observability",
-      "type": "boolean",
-      "deprecated": true
-    },
     "operatorcrds": {
       "description": "Deploys Operator related CRDs from https://github.com/open-telemetry/opentelemetry-operator/tree/main/config/crd via a Helm subchart and using the chart crds/ directory.",
       "type": "object",


### PR DESCRIPTION
The following deprecated options are removed in favor of corresponding options under `splunkObservability`:
  - `metricsEnabled` -> `splunkObservability.metricsEnabled`
  - `tracesEnabled` -> `splunkObservability.tracesEnabled`
  - `logsEnabled` -> `splunkObservability.logsEnabled`