### PR TITLE
Remove deprecated `distro` and `provider` values.yaml options

### DIFF
--- a/.chloggen/remove-deprecated-distro.yaml
+++ b/.chloggen/remove-deprecated-distro.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove support of deprecated `distro` and `provider` root-level values.yaml options.
+# One or more tracking issues related to the change
+issues: [1989]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use `distribution` instead of `distro` and `cloudProvider` instead of `provider`.

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -5,12 +5,12 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
 Splunk OpenTelemetry Collector is installed and configured to send data to Splunk Observability realm {{ .Values.splunkObservability.realm }}.
 {{ end }}
 
-{{- if and (eq (include "splunk-otel-collector.distribution" .) "eks/auto-mode") (or (eq (include "splunk-otel-collector.clusterReceiverHostNetworkEnabled" .) "false") (eq (toString .Values.agent.hostNetwork) "false")) }}
+{{- if and (eq .Values.distribution "eks/auto-mode") (or (eq (include "splunk-otel-collector.clusterReceiverHostNetworkEnabled" .) "false") (eq (toString .Values.agent.hostNetwork) "false")) }}
 [WARNING] Host networking is explicitly disabled. For resourcedetection to work correctly in EKS Auto Mode, ensure Pod Identity is enabled and configured or enable pod host networking.
           For more information about deploying Splunk Opentelemetry in EKS Auto Mode cluster, see guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#eks-auto-mode
 {{- end }}
 
-{{- if and (eq (include "splunk-otel-collector.distribution" .) "eks/auto-mode") (eq (include "splunk-otel-collector.gatewayEnabled" .) "true") }}
+{{- if and (eq .Values.distribution "eks/auto-mode") (eq (include "splunk-otel-collector.gatewayEnabled" .) "true") }}
 [WARNING] Deploying a Gateway in EKS Auto Mode requires Pod Identity to be enabled and configured, otherwise some functionalities will be missing.
           For more information about deploying Splunk Opentelemetry in EKS Auto Mode cluster, see guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#eks-auto-mode
 {{- end }}
@@ -18,14 +18,6 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
 {{- if not (eq (toString .Values.service) "<nil>") }}
 [WARNING] The ".Values.service" config is deprecated. Please use ".Values.agent.service" and ".Values.gateway.service" for configuring services for the agent and gateway, respectively.
           This field will be removed in a future release.
-{{ end }}
-{{- if not (eq (toString .Values.distro) "<nil>") }}
-[WARNING] "distro" parameter is deprecated, please use "distribution" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
-{{ end }}
-{{- if not (eq (toString .Values.provider) "<nil>") }}
-[WARNING] "provider" parameter is deprecated, please use "cloudProvider" instead.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
 {{ end }}
 {{- if not (eq (toString .Values.extraAttributes.podLabels) "<nil>") }}
 [WARNING] ".Values.extraAttributes.podLabels" parameter is deprecated, please use ".Values.extraAttributes.fromLabels" instead.

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -291,20 +291,6 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end -}}
 
 {{/*
-cloudProvider helper to support backward compatibility with the deprecated name.
-*/}}
-{{- define "splunk-otel-collector.cloudProvider" -}}
-{{- .Values.cloudProvider | default .Values.provider | default "" -}}
-{{- end -}}
-
-{{/*
-distribution helper to support backward compatibility with the deprecated name.
-*/}}
-{{- define "splunk-otel-collector.distribution" -}}
-{{- .Values.distribution | default .Values.distro | default "" -}}
-{{- end -}}
-
-{{/*
 Helper that returns "agent" parameter group yaml taking care of backward
 compatibility with the old config group name: "otelAgent".
 */}}
@@ -450,7 +436,7 @@ Build the securityContext for Linux and Windows
 Whether the clusterName configuration option is optional
 */}}
 {{- define "splunk-otel-collector.clusterNameOptional" -}}
-{{- or (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (eq (include "splunk-otel-collector.isNonFargateEKS" .) "true") }}
+{{- or (hasPrefix "gke" .Values.distribution) (eq (include "splunk-otel-collector.isNonFargateEKS" .) "true") }}
 {{- end -}}
 
 {{/*
@@ -501,7 +487,7 @@ Create the name of the target allocator cluster role binding to use
 Returns true if the distribution is eks but not eks/fargate.
 */}}
 {{- define "splunk-otel-collector.isNonFargateEKS" -}}
-{{- and (hasPrefix "eks" (include "splunk-otel-collector.distribution" .)) (ne (include "splunk-otel-collector.distribution" .) "eks/fargate") -}}
+{{- and (hasPrefix "eks" .Values.distribution) (ne .Values.distribution "eks/fargate") -}}
 {{- end -}}
 
 {{/*
@@ -510,7 +496,7 @@ Returns true if the cloud provider is aws and distribution is not set.
 example: Vanilla K8s on AWS EC2
 */}}
 {{- define "splunk-otel-collector.isNonEKSonAWS" -}}
-{{- and (eq (include "splunk-otel-collector.cloudProvider" .) "aws") (eq (include "splunk-otel-collector.distribution" .) "") -}}
+{{- and (eq .Values.cloudProvider "aws") (eq .Values.distribution "") -}}
 {{- end -}}
 
 {{/*
@@ -519,7 +505,7 @@ If distribution is eks/auto-mode and hostNetwork is not explicitly set, it will 
 */}}
 {{- define "splunk-otel-collector.clusterReceiverHostNetworkEnabled" -}}
 {{- if eq (toString .Values.clusterReceiver.hostNetwork) "<nil>" }}
-  {{- eq (include "splunk-otel-collector.distribution" .) "eks/auto-mode" }}
+  {{- eq .Values.distribution "eks/auto-mode" }}
 {{- else }}
   {{- .Values.clusterReceiver.hostNetwork }}
 {{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -10,7 +10,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-{{- if eq (include "splunk-otel-collector.distribution" .) "openshift" }}
+{{- if eq .Values.distribution "openshift" }}
 - apiGroups:
   - quota.openshift.io
   resources:
@@ -86,7 +86,7 @@ rules:
   - get
   - list
   - watch
-{{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+{{- if eq .Values.distribution "eks/fargate" }}
 - apiGroups:
     - ""
   resources:
@@ -94,7 +94,7 @@ rules:
   verbs:
     - patch
 {{- end }}
-{{- if hasPrefix "eks" (include "splunk-otel-collector.distribution" .) }}
+{{- if hasPrefix "eks" .Values.distribution }}
 - apiGroups:
   - ""
   resources:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -70,20 +70,20 @@ resourcedetection:
     # Note: Kubernetes distro detectors need to come first so they set the proper cloud.platform
     # before it gets set later by the cloud provider detector.
     - env
-    {{- if or (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (eq (include "splunk-otel-collector.cloudProvider" .) "gcp") }}
+    {{- if or (hasPrefix "gke" .Values.distribution) (eq .Values.cloudProvider "gcp") }}
     - gcp
     {{- else if or (eq (include "splunk-otel-collector.isNonEKSonAWS" .) "true") (eq (include "splunk-otel-collector.isNonFargateEKS" .) "true") }}
     - eks
-    {{- else if eq (include "splunk-otel-collector.distribution" .) "aks" }}
+    {{- else if eq .Values.distribution "aks" }}
     - aks
     {{- end }}
-    {{- if eq (include "splunk-otel-collector.cloudProvider" .) "azure" }}
+    {{- if eq .Values.cloudProvider "azure" }}
     - azure
     {{- end }}
     # The `system` detector goes last so it can't preclude cloud detectors from setting host/os info.
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#ordering
     - system
-  {{- if and (hasPrefix "gke" (include "splunk-otel-collector.distribution" .)) (not .Values.clusterName) }}
+  {{- if and (hasPrefix "gke" .Values.distribution) (not .Values.clusterName) }}
   gcp:
     resource_attributes:
       k8s.cluster.name:
@@ -121,12 +121,12 @@ Common config for adding k8s.cluster.name using the resourcedetection processor
 {{- define "splunk-otel-collector.resourceDetectionProcessorKubernetesClusterName" -}}
 resourcedetection/k8s_cluster_name:
   detectors:
-    {{- if hasPrefix "gke" (include "splunk-otel-collector.distribution" .) }}
+    {{- if hasPrefix "gke" .Values.distribution }}
     - gcp
     {{- else if eq (include "splunk-otel-collector.isNonFargateEKS" .) "true" }}
     - eks
     {{- end }}
-  {{- if hasPrefix "gke" (include "splunk-otel-collector.distribution" .) }}
+  {{- if hasPrefix "gke" .Values.distribution }}
   gcp:
     resource_attributes:
       k8s.cluster.name:

--- a/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
@@ -2,7 +2,7 @@
 {{/*
 Fargate doesn't support daemonsets so never use for that platform
 */}}
-{{- if and $agent.enabled (ne (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
+{{- if and $agent.enabled (ne .Values.distribution "eks/fargate") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver-node-discoverer-script.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" ) (eq (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
+{{ if and (eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" ) (eq .Values.distribution "eks/fargate") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -2,7 +2,7 @@
 {{/*
 Fargate doesn't support daemonsets so never use for that platform
 */}}
-{{- if and $agent.enabled (ne (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
+{{- if and $agent.enabled (ne .Values.distribution "eks/fargate") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -6,10 +6,10 @@ eks/fargate distributions use a two-replica StatefulSet instead of a single node
 The first replica monitors all fargate node kubelets (except its own) via k8s_observer and kubeletstats receiver.
 The second replica monitors the first replica's kubelet and the cluster.
 */}}
-kind: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }} StatefulSet {{- else }} Deployment {{- end }}
+kind: {{- if eq .Values.distribution "eks/fargate" }} StatefulSet {{- else }} Deployment {{- end }}
 metadata:
   {{- /* StatefulSet names must be truncated or the `statefulset.kubernetes.io/pod-name` label value will be too long */}}
-  name: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }} {{ template "splunk-otel-collector.clusterReceiverTruncatedName" . }} {{- else }} {{ template "splunk-otel-collector.fullname" . }}-k8s-cluster-receiver {{- end }}
+  name: {{- if eq .Values.distribution "eks/fargate" }} {{ template "splunk-otel-collector.clusterReceiverTruncatedName" . }} {{- else }} {{ template "splunk-otel-collector.fullname" . }}-k8s-cluster-receiver {{- end }}
   namespace: {{ template "splunk-otel-collector.namespace" . }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
@@ -24,8 +24,8 @@ metadata:
     {{- toYaml $clusterReceiver.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }} 2 {{- else }} 1 {{- end }}
-  {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+  replicas: {{- if eq .Values.distribution "eks/fargate" }} 2 {{- else }} 1 {{- end }}
+  {{- if eq .Values.distribution "eks/fargate" }}
   serviceName: {{ template "splunk-otel-collector.clusterReceiverServiceName" . }}
   podManagementPolicy: Parallel
   {{- end }}
@@ -70,7 +70,7 @@ spec:
       tolerations:
         {{ toYaml $clusterReceiver.tolerations | nindent 8 }}
       {{- end }}
-      {{- if or $clusterReceiver.affinity (eq (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
+      {{- if or $clusterReceiver.affinity (eq .Values.distribution "eks/fargate") }}
       affinity:
         {{- $clusterReceiverPodAntiAffinity := `
         podAntiAffinity:
@@ -90,7 +90,7 @@ spec:
       securityContext:
         {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $podSecurityContext) | nindent 8 }}
       {{- end }}
-      {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+      {{- if eq .Values.distribution "eks/fargate" }}
       initContainers:
         - name: cluster-receiver-node-discoverer
           image: public.ecr.aws/amazonlinux/amazonlinux:latest
@@ -116,7 +116,7 @@ spec:
       containers:
       - name: otel-collector
         args:
-        {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+        {{- if eq .Values.distribution "eks/fargate" }}
         - --config=/splunk-messages/config.yaml
         {{- else }}
         - --config=/conf/relay.yaml
@@ -205,7 +205,7 @@ spec:
         {{- end }}
         - mountPath: /conf
           name: collector-configmap
-        {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+        {{- if eq .Values.distribution "eks/fargate" }}
         - mountPath: /splunk-messages
           name: messages
         {{- end }}
@@ -250,7 +250,7 @@ spec:
         secret:
           secretName: {{ template "splunk-otel-collector.secret" . }}
       {{- end }}
-      {{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+      {{- if eq .Values.distribution "eks/fargate" }}
       - name: init-eks-fargate-cluster-receiver-script
         configMap:
           name: {{ template "splunk-otel-collector.clusterReceiverNodeDiscovererScript" . }}

--- a/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
+++ b/helm-charts/splunk-otel-collector/templates/securityContextConstraints.yaml
@@ -36,7 +36,7 @@ requiredDropCapabilities:
 - ALL
 {{- end -}}
 
-{{- if and (eq (include "splunk-otel-collector.distribution" .) "openshift") .Values.securityContextConstraints.create  }}
+{{- if and (eq .Values.distribution "openshift") .Values.securityContextConstraints.create  }}
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/service-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service-agent.yaml
@@ -4,7 +4,7 @@
 {{/*
 Fargate doesn't support daemonsets so never use for that platform
 */}}
-{{- if and $agent.enabled (ne (include "splunk-otel-collector.distribution" .) "eks/fargate") }}
+{{- if and $agent.enabled (ne .Values.distribution "eks/fargate") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/service-cluster-receiver-stateful-set.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service-cluster-receiver-stateful-set.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "splunk-otel-collector.distribution" .) "eks/fargate" }}
+{{- if eq .Values.distribution "eks/fargate" }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -271,11 +271,6 @@
         ""
       ]
     },
-    "provider": {
-      "description": "[DEPRECATED] Cloud provider where the collector is running",
-      "type": "string",
-      "deprecated": true
-    },
     "distribution": {
       "description": "Kubernetes distribution where the collector is running",
       "type": "string",
@@ -291,11 +286,6 @@
         " ",
         ""
       ]
-    },
-    "distro": {
-      "description": "[DEPRECATED] Kubernetes distribution where the collector is running",
-      "type": "string",
-      "deprecated": true
     },
     "environment": {
       "description": "Parameter that will be added to all the telemetry data (traces/logs/metrics) as an attribute.",


### PR DESCRIPTION
Use `distribution` instead of `distro` and `cloudProvider` instead of `provider`.