### PR TITLE
Remove support of deprecated `otel`-prefixed configuration sections

### DIFF
--- a/.chloggen/remove-deprecated-otel-sections.yaml
+++ b/.chloggen/remove-deprecated-otel-sections.yaml
@@ -1,0 +1,13 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove support of deprecated `otelAgent`, `otelCollector`, and `otelK8sClusterReceiver` configuration sections.
+# One or more tracking issues related to the change
+issues: [1990]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Use `agent` instead of `otelAgent`, `gateway` instead of `otelCollector`, and `clusterReceiver` instead of `otelK8sClusterReceiver`.

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3d55dd7c9449096dadfd07f75bcd28410a3bb57c9b544e9084bbc61a75eee474
+        checksum/config: 820cb220dbf000157bd619b594ef36bd5ab71489ef0a849273874eb944714298
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7f31b3b42c14bfb7bcd2eb7c269ce6274f8c4d706df460dcb9817a72340d909f
+        checksum/config: fb82437081fdfa62e8adc232877b6679f12e83e16820afd6d149c58ddaceb104
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d96c811575f51ec1face3067dc205f717b3dd8cbcb9df672d8d17f89dbd45923
+        checksum/config: b548f85843015205b2a0a1b19ef8cef3cbc3330256aad63cb2a6e08f0b580ef0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7f31b3b42c14bfb7bcd2eb7c269ce6274f8c4d706df460dcb9817a72340d909f
+        checksum/config: fb82437081fdfa62e8adc232877b6679f12e83e16820afd6d149c58ddaceb104
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 075c3294fa29ce8b2818a3c243a42e6d0de69ce0c722f07fe6e63d5080435e88
+        checksum/config: d190dc99727acd1c67b61d1101cfb48cadca00fe83065d85d0ea38de0fb66ed4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8ec707029d01d0663b18078bfbaead8a6239b4e985e9b180246c32c22d3adbd5
+        checksum/config: 1616dbdef1b83f71daeceebfbac6164dd18d2e3085630de71d4c85f6712230fc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c349792b145c23fb8111d60ffa6774e2251a75f38f468aca362705a151241e84
+        checksum/config: 928d7d4423c10900aee6399e94a578e4ef0e55de2fd878f59fd683856cfe0505
         kubectl.kubernetes.io/default-container: otel-collector
         sidecar.istio.io/inject: "false"
     spec:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7f31b3b42c14bfb7bcd2eb7c269ce6274f8c4d706df460dcb9817a72340d909f
+        checksum/config: fb82437081fdfa62e8adc232877b6679f12e83e16820afd6d149c58ddaceb104
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 350eb1312c74096a020480afe8a65e27268915d2a16de61f2f88e1e38a0e7ad8
+        checksum/config: 943add453c01437cca140a6e55ac0693b2e301f0e3b0c572f0e554ea34aaf3a9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c2ea93e164fe231f2c35eae17d3a166a618f31315bf7db732b7d297d742dd8e6
+        checksum/config: fc4ba8a7d50929ac4c45432a2406d3954a55f40383a6011bc3eb1093a9149dc4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 66ec34b464ff62d8d044bbaad464426248d5739ae8d2932dba203c2e4b17f088
+        checksum/config: 9ae347e2620df5f2ee8801ca95910d8b96add56389868ee34f7bf8b64c9b909f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8e22a9992d6b8881cc9cc0e41d2e2b90eba19c0a846c910c3ed62ce6f554147a
+        checksum/config: 3f2f3d892b0dd2e0eb887eae8bfc1310741df87c6181e1ebbd7b620d78829280
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 66ec34b464ff62d8d044bbaad464426248d5739ae8d2932dba203c2e4b17f088
+        checksum/config: 9ae347e2620df5f2ee8801ca95910d8b96add56389868ee34f7bf8b64c9b909f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 350eb1312c74096a020480afe8a65e27268915d2a16de61f2f88e1e38a0e7ad8
+        checksum/config: 943add453c01437cca140a6e55ac0693b2e301f0e3b0c572f0e554ea34aaf3a9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/daemonset.yaml
+++ b/examples/crio-logging/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 350eb1312c74096a020480afe8a65e27268915d2a16de61f2f88e1e38a0e7ad8
+        checksum/config: 943add453c01437cca140a6e55ac0693b2e301f0e3b0c572f0e554ea34aaf3a9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 350eb1312c74096a020480afe8a65e27268915d2a16de61f2f88e1e38a0e7ad8
+        checksum/config: 943add453c01437cca140a6e55ac0693b2e301f0e3b0c572f0e554ea34aaf3a9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 98174e456f24b1b8eb76792e1b91948137624cc81af12ef3ae11a879ae71ba02
+        checksum/config: 177ac33c3ea0d516a3e3b1045d517f87a13d6377ed9a1cfb13419249c89d8d4e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 29e07c4eaecc99e11203b9520c8807442f96937ed33bb031b21a82a07df90cf1
+        checksum/config: 8d93e7c0d444e83fc1814426aed2038edb4d26914adc1c34b104b6f69aceab86
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8d0ab4fac8f8192f15b68f5991f161b4369ac511cf4f908d2a3bc25171f34a03
+        checksum/config: 6f1580a8f45c07be80b3bca94af0bf565f95a75af5764675d1185fab3baf74f3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 799879d9fb1a90c2cc4848819d056d974e30af72f138577dd3ef1976fa949309
+        checksum/config: d21786f6c15f118ca40682491948b3888807ee0c46416781ccd0c8e34a04a94a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 17c667a11083598ff36f11522caceca3128123737ccfc4398b1cd060e8b69130
+        checksum/config: d077a62fefd0384c1099f842e016c890195afac0823c16ee209f428aa457b216
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 456690f809cc56d71e0a96f8107fddcbe35e5dcbcfd29bea3ed8c091ffc27a42
+        checksum/config: 754349e16c1be6bf3b18e4b40e2b69c47c2b17d3d5260e7331fa89eb6725c527
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c4737b2ee51b9744ad0b8b6e0dd641e94cd140c6e19fa0811cd64802692807b
+        checksum/config: a09033d4773f69c26df0ba359214e757cf4a9f8fa3092dec5444f04b5781d64d
     spec:
       hostNetwork: true
       serviceAccountName: default-splunk-otel-collector

--- a/examples/distribution-eks-auto-mode/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6ccfc351cdf36003541ce1740810cdf4b54b7af5efd1dc54dd9d5dcef384b049
+        checksum/config: fcd8a2dd1495df5524a6410dc6eae77f8cbe3eda78f4a6930492c71b98601fac
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fb2697772220316acc3227a219fdd036baac9ad97eb845af3b1b909e50f3eb22
+        checksum/config: 32c20f7cb15d7d1cceec385a0580bbb032577d2f9acfe1b5989549121b5f7f11
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 66ec34b464ff62d8d044bbaad464426248d5739ae8d2932dba203c2e4b17f088
+        checksum/config: 9ae347e2620df5f2ee8801ca95910d8b96add56389868ee34f7bf8b64c9b909f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: dca6cb5c681e5c0f9dd62696a34769e13c806ffb4e47fb2ba4d0a887c8f5e1cf
+        checksum/config: 350261242e107b1b079b8f86f8bcada47f743704d1d6e1b262fd9e670ea82ac1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 63325758e38834eeebc7c201dd797a16e8438742d89b015d673d92c98ee16973
+        checksum/config: 583484fe6a3184b01dba9e0bc3524d60c35450f5b2240e15b55af68d9ce41a5f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ba33c9a04dbb1b919cac22123de99d45cdbac4e245cdaa9910bc0d50f2aefe27
+        checksum/config: 401ab593966f3096201a37262068c696a5b89cd2bb13d9dd26165945060a2f45
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3ebc71319764ca4f7c085d60e9d5195b4d8c4c0fea9dd58189b5303653494ad2
+        checksum/config: 548169fe4066c8f79de7ea2b4442086f274904cf941abf9cf3b69a5dca6f9b5a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 057cf2d7a8fb02c1b20271ff4637626f3e4cdb2d79a40d662778b7fece6251cf
+        checksum/config: 15ff3227f700b49b6312578c68be11fd95e7d0b235dd806b931b1b13ade1dbbe
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3ebc71319764ca4f7c085d60e9d5195b4d8c4c0fea9dd58189b5303653494ad2
+        checksum/config: 548169fe4066c8f79de7ea2b4442086f274904cf941abf9cf3b69a5dca6f9b5a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 455f35b5bb157f66b9c122fb34aa8a68e25fcb9eac583f7e5fd47fca3c8a0ca6
+        checksum/config: 41adc52570b31ac208fe69b806228bd96c30d7d0aa57c8cb784bd117089145bc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 50bbf0e93887ea294ffeb32c97d9348d844fde92e84ea67a3b3eee2ed090487b
+        checksum/config: 88dd13ae11b2f2263f35f40822298b566b97d9c441b2f554e6be577493f9159e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f555a12c7da5c5fa7bb1d02414294286ec51085dad875ee9f415e8a7f6b926f2
+        checksum/config: 48928c3faa5ccd5031da35b9869534ec12e0168296fd0b37c98168ba8c147800
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 61929c3c419c33bda9601f9135396c58bf5473b0fb426a729b72fcfad6875ce4
+        checksum/config: ac12d130b3a21e5c603f2b533b28748bacfb7b5d31fa57ebfa2b77a8600c6fe2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e772c14c0d8096542a3206c9ce8f0adabc0e7b56797befce621c711a75f95944
+        checksum/config: eabe47502e2cbe94cc290191780cc1fafea01fe632704c038331cdd219083381
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 29e07c4eaecc99e11203b9520c8807442f96937ed33bb031b21a82a07df90cf1
+        checksum/config: 8d93e7c0d444e83fc1814426aed2038edb4d26914adc1c34b104b6f69aceab86
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cfbb82383cce82dea8148cd7df53c76768b2c57f705067f639724d108389ec5a
+        checksum/config: 89ced8d71090cf350c0ab02ada171ba0dd383261aa4dbce53a4bc8de2d6a5727
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 23e4e9af7a615a6b148f4b8d19fca2146f0c681d50c9bb82bda9244b5877cd55
+        checksum/config: b1d38c80460ea3a077c48245818eb7ffd68900b02c40248fe663e2fbedb09f0f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1f61a304bcc0f175f6831d8db5b4256c7274496a46dfacd27b92ad55bec04fc1
+        checksum/config: 3d55ff4ccf0ff181b1cb8da883efb5ef317c9db734115f7d51167537675a2dc6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1b018c05cfd2c6d22303eb0a39de00d17c82dad9de70fd1b75ba4cbae2015ae4
+        checksum/config: fe5e11d371fd9e2a20ba22cd5a1b5e6fcbb062ef0f866b2bd2cd0d2563c87b2b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7f31b3b42c14bfb7bcd2eb7c269ce6274f8c4d706df460dcb9817a72340d909f
+        checksum/config: fb82437081fdfa62e8adc232877b6679f12e83e16820afd6d149c58ddaceb104
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0211e7fc9802db9e428fe55cf7dc7b29265f9bfe983e0494a1f1edcc12568485
+        checksum/config: bed74954873ba81bb714756fc2ce4db09f475b34ea0b3cea15a8e482f6710161
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7f31b3b42c14bfb7bcd2eb7c269ce6274f8c4d706df460dcb9817a72340d909f
+        checksum/config: fb82437081fdfa62e8adc232877b6679f12e83e16820afd6d149c58ddaceb104
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1e07b91b3456f1d8915b3bc899752f0664dbc0bafabfa26ca9243b6ec39eb1c9
+        checksum/config: 7138d9cc511375f42b4dece1964d6ac0222570a56b2f35e0df38c1a917051c54
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7f31b3b42c14bfb7bcd2eb7c269ce6274f8c4d706df460dcb9817a72340d909f
+        checksum/config: fb82437081fdfa62e8adc232877b6679f12e83e16820afd6d149c58ddaceb104
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e48eaca5bc01666db2cc38eeac1ccc8536990044b64e609e729e1e4e599363d3
+        checksum/config: 9dcd5c33938cd8027d9ec487698fa8cef769fa1d21541a4631139a04a1e07785
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bf3fb1aaeef2b87a866a130699414b9238b27401ddbde78ea9a2707e1e5ac7bb
+        checksum/config: 7aa8cce3041357505b6209e95afa9dd600b275883f8a5b2bbf1342e10977c68d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3c89a7c5d19ead3d2a1b846f09604d0cef11e866e734edb59f0545c60982c0b6
+        checksum/config: 74754481295c540471bb24bcf8208a026ac89c2920aea8c56ca479ec46f774e8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-fluentd/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 093bfe5087293c715f19aaba65a6329d52a246b91b14bff4e7bbd58fae6330d3
+        checksum/config: d186846382e2c525fcae5a3a19fe42ddafb5804305b3e257e48fa24ed036e897
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-otel/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-otel/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3d7ba85ceef167a6a288afcc918065feff7e4840eb9b531614592c746e1f4c54
+        checksum/config: 7a58ba0f59f89d8d2c6cefd9a54d0880dde80cc049d309e723535418d3af80ae
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-otel/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-otel/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 093bfe5087293c715f19aaba65a6329d52a246b91b14bff4e7bbd58fae6330d3
+        checksum/config: d186846382e2c525fcae5a3a19fe42ddafb5804305b3e257e48fa24ed036e897
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3bbb50e3c3251a0696193a43a056d42f9802ff77b7d6072d3fcfda8d7b84a63d
+        checksum/config: 7d1c212aac986cebde88a8a589fd3b1cec05a5c6279afb78d49ba6770066f985
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 093bfe5087293c715f19aaba65a6329d52a246b91b14bff4e7bbd58fae6330d3
+        checksum/config: d186846382e2c525fcae5a3a19fe42ddafb5804305b3e257e48fa24ed036e897
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 063b12c14fd90cf93f8c4fe5a1f60dd5c1c020688871f7b70a6b7dc40ed84e91
+        checksum/config: afe65b6fba73af44e66541a95283c6ddbefeb24be112810fb6c82cb37cb7f957
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 43c52ca93c65f346c7d17cb6065ab1a270513b429a09927eb9a6a3793697f885
+        checksum/config: e0d57cf044adc2d230e41fd449fe99ecc3b3cafe835965c941038011aa9ebded
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fd3c3e451c13453bb56fe5708e0b90177204220c3c3e246ba26918b3d8901325
+        checksum/config: 0ab01984e401533175adeec405eb372d8c24e0b6c7120fb7391a43a3decf6eff
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 45ff8d2e5b3763af4be1a7c68d19fb5a7abdd15f67cee10fff9dbf329d84f8ba
+        checksum/config: b4aa7a07542b6097d2921c52b36cb9694f08f19d4ebaadd749efabe9005d3ee4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 23e4e9af7a615a6b148f4b8d19fca2146f0c681d50c9bb82bda9244b5877cd55
+        checksum/config: b1d38c80460ea3a077c48245818eb7ffd68900b02c40248fe663e2fbedb09f0f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/otlp-token-passthrough/rendered_manifests/daemonset.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f838e840fb9d5f7572d076cbe533be98352472aa9e716a27098a6e3c04ec8b04
+        checksum/config: 2540c598a9ee74f9edb04f09051509a7f4a56f00f7fcfbc51c959f3c813b823d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/otlp-token-passthrough/rendered_manifests/deployment-gateway.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/deployment-gateway.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 0461cd2433ca5d16004625c4f1682645a30b9195aaec465e0bc8dca0799cd15b
+        checksum/config: 0877374f5148bdf3ec32eddafdb666a013591ac0ebed7817bb4159c2a142158b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 79b259fd9abf3e3abf85521b6835afa08e3026f915e8f8d2914a663d614b8de5
+        checksum/config: ce6e432d030ac20f251abc50079d16e2615ba42dffad7642bad8a79e182f15c5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 22b66e000cdeb23f1a4bec6943ef4fdce923eb030ae1ea4f06ca444ffa6121a0
+        checksum/config: ea27aeab82c9df8375cf33cc00723f966d3a4997efc04ff5befbffdbae0fb5ea
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ae18bb801e9fc50cb71839b04eb7703180011e820e461c36bacd1e68e68bb364
+        checksum/config: 7f33e42d44ad94d752bfcc00c5dfa2b1b4be8d9fe8ee843ec26247b9a41ebfd0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 093bfe5087293c715f19aaba65a6329d52a246b91b14bff4e7bbd58fae6330d3
+        checksum/config: d186846382e2c525fcae5a3a19fe42ddafb5804305b3e257e48fa24ed036e897
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8d1f0a8620dbfd7d00257a661f65696cecaa0583efbf32ebb4ddb5a13cf73a1f
+        checksum/config: c32ea2201f8f9d93cbde6ae736ea96c2e0f3dc06aa650d9669b820e04b5e4c09
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f403e34ba064b716c94dc1252e6c9ae98ab7909d7f99847928529913d3dd7155
+        checksum/config: 618422c86f435ee8292f1b1eb7bf97929c3ee1162de4281c8b89d27594371a8d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5a94f5c6c57a1f966ca8a987775c067662ba036404e375eb9656ec8741db74e2
+        checksum/config: 8de6d38cf601e9efb31787b87b3e729a6e2d9bcb672c53bb4ec1593ec12b63d3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 350eb1312c74096a020480afe8a65e27268915d2a16de61f2f88e1e38a0e7ad8
+        checksum/config: 943add453c01437cca140a6e55ac0693b2e301f0e3b0c572f0e554ea34aaf3a9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9ec3a1f0e6d256b93653527fc68dd7dfd476e94f08db7debbdd790df1f3b7824
+        checksum/config: 65b06c2e356936581a35dc8d6cb2c77bf9fa2a11a2a1885b6d69eab2c18bd019
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a5af579045f9fe9213788fc7a1e5731d29d3ac3707f74a41969cb64063d1ee30
+        checksum/config: 37faa867c054397ef760410ad2a04077fa1fb087186d78c258be7c8f2875b50a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -10,7 +10,7 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
           For more information about deploying Splunk Opentelemetry in EKS Auto Mode cluster, see guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#eks-auto-mode
 {{- end }}
 
-{{- if and (eq .Values.distribution "eks/auto-mode") (eq (include "splunk-otel-collector.gatewayEnabled" .) "true") }}
+{{- if and (eq .Values.distribution "eks/auto-mode") .Values.gateway.enabled }}
 [WARNING] Deploying a Gateway in EKS Auto Mode requires Pod Identity to be enabled and configured, otherwise some functionalities will be missing.
           For more information about deploying Splunk Opentelemetry in EKS Auto Mode cluster, see guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/advanced-configuration.md#eks-auto-mode
 {{- end }}
@@ -23,24 +23,11 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
 [WARNING] ".Values.extraAttributes.podLabels" parameter is deprecated, please use ".Values.extraAttributes.fromLabels" instead.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
 {{ end }}
-{{- if not (eq (toString .Values.otelAgent) "<nil>") }}
-[WARNING] "otelAgent" parameter group is deprecated, please rename it to "agent" in your custom values.yaml.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
-{{ end }}
-{{- if not (eq (toString .Values.otelCollector) "<nil>") }}
-[WARNING] "otelCollector" parameter group is deprecated, please rename it to "gateway" in your custom values.yaml.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
-{{ end }}
-{{- if not (eq (toString .Values.otelK8sClusterReceiver) "<nil>") }}
-[WARNING] "otelK8sClusterReceiver" parameter group is deprecated, please rename it to "clusterReceiver" in your custom values.yaml.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
-{{ end }}
 {{- if not (eq (toString .Values.image.fluentd.initContainer) "<nil>") }}
 [WARNING] "image.fluentd.initContainer" parameter is deprecated now. Now we use the same splunk/fluentd-hec image in init container.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0371-to-0380
 {{ end }}
-{{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{- if not (eq (toString $clusterReceiver.k8sEventsEnabled) "<nil>") }}
+{{- if not (eq (toString .Values.clusterReceiver.k8sEventsEnabled) "<nil>") }}
 [WARNING] "clusterReceiver.k8sEventsEnabled" parameter is deprecated. Please use clusterReceiver.eventsEnabled and splunkObservability.infrastructureMonitoringEventsEnabled.
           Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#0532-to-0540
 {{ end }}

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -291,18 +291,6 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end -}}
 
 {{/*
-Helper that returns "agent" parameter group yaml taking care of backward
-compatibility with the old config group name: "otelAgent".
-*/}}
-{{- define "splunk-otel-collector.agent" -}}
-{{- if eq (toString .Values.otelAgent) "<nil>" }}
-{{- .Values.agent | toYaml }}
-{{- else }}
-{{- deepCopy .Values.otelAgent | mustMergeOverwrite (deepCopy .Values.agent) | toYaml }}
-{{- end }}
-{{- end -}}
-
-{{/*
 The apiVersion for podDisruptionBudget policies.
 */}}
 {{- define "splunk-otel-collector.PDB-apiVersion" -}}
@@ -318,38 +306,6 @@ The name of the gateway service.
 */}}
 {{- define "splunk-otel-collector.gatewayServiceName" -}}
 {{  (include "splunk-otel-collector.fullname" . ) | trunc 63 | trimSuffix "-" }}
-{{- end -}}
-
-{{/*
-Whether the gateway is enabled, either through network explorer, or through its own flag.
-*/}}
-{{- define "splunk-otel-collector.gatewayEnabled" -}}
-{{- $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
-{{- $gateway.enabled }}
-{{- end -}}
-
-{{/*
-Helper that returns "gateway" parameter group yaml taking care of backward
-compatibility with the old config group name: "otelCollector".
-*/}}
-{{- define "splunk-otel-collector.gateway" -}}
-{{- if eq (toString .Values.otelCollector) "<nil>" }}
-{{- .Values.gateway | toYaml }}
-{{- else }}
-{{- deepCopy .Values.otelCollector | mustMergeOverwrite (deepCopy .Values.gateway) | toYaml }}
-{{- end }}
-{{- end -}}
-
-{{/*
-Helper that returns "clusterReceiver" parameter group yaml taking care of backward
-compatibility with the old config group name: "otelK8sClusterReceiver".
-*/}}
-{{- define "splunk-otel-collector.clusterReceiver" -}}
-{{- if eq (toString .Values.otelK8sClusterReceiver) "<nil>" }}
-{{- .Values.clusterReceiver | toYaml }}
-{{- else }}
-{{- deepCopy .Values.otelK8sClusterReceiver | mustMergeOverwrite (deepCopy .Values.clusterReceiver) | toYaml }}
-{{- end }}
 {{- end -}}
 
 {{/*
@@ -377,11 +333,10 @@ compatibility with the old config group name: "otelK8sClusterReceiver".
 "o11yInfraMonEventsEnabled" helper defines whether Observability Infrastructure monitoring events are enabled
 */}}
 {{- define "splunk-otel-collector.o11yInfraMonEventsEnabled" -}}
-{{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{- if eq (toString $clusterReceiver.k8sEventsEnabled) "<nil>" }}
+{{- if eq (toString .Values.clusterReceiver.k8sEventsEnabled) "<nil>" }}
 {{- .Values.splunkObservability.infrastructureMonitoringEventsEnabled }}
 {{- else }}
-{{- $clusterReceiver.k8sEventsEnabled }}
+{{- .Values.clusterReceiver.k8sEventsEnabled }}
 {{- end }}
 {{- end -}}
 
@@ -390,16 +345,14 @@ compatibility with the old config group name: "otelK8sClusterReceiver".
 Whether object collection by k8s object receiver is enabled
 */}}
 {{- define "splunk-otel-collector.objectsEnabled" -}}
-{{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{- gt (len $clusterReceiver.k8sObjects) 0 }}
+{{- gt (len .Values.clusterReceiver.k8sObjects) 0 }}
 {{- end -}}
 
 {{/*
 Whether object collection by k8s object receiver or/and event collection by k8s event receiver is enabled
 */}}
 {{- define "splunk-otel-collector.objectsOrEventsEnabled" -}}
-{{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{- or $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.objectsEnabled" .) "true") -}}
+{{- or .Values.clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.objectsEnabled" .) "true") -}}
 {{- end -}}
 
 
@@ -407,8 +360,7 @@ Whether object collection by k8s object receiver or/and event collection by k8s 
 Whether clusterReceiver should be enabled
 */}}
 {{- define "splunk-otel-collector.clusterReceiverEnabled" -}}
-{{- $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
-{{- and $clusterReceiver.enabled (or (eq (include "splunk-otel-collector.metricsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true")) -}}
+{{- and .Values.clusterReceiver.enabled (or (eq (include "splunk-otel-collector.metricsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true")) -}}
 {{- end -}}
 
 

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -3,7 +3,6 @@ Config for the otel-collector k8s cluster receiver deployment.
 The values can be overridden in .Values.clusterReceiver.config
 */}}
 {{- define "splunk-otel-collector.clusterReceiverConfig" -}}
-{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) -}}
 extensions:
   health_check:
     endpoint: 0.0.0.0:13134
@@ -33,7 +32,7 @@ receivers:
     auth_type: serviceAccount
     objects: {{ .Values.clusterReceiver.k8sObjects | toYaml | nindent 6 }}
   {{- end }}
-  {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+  {{- if and .Values.clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
   k8s_events:
     auth_type: serviceAccount
   {{- end }}
@@ -125,7 +124,7 @@ processors:
         value: {{ .Values.clusterName }}
   {{- end }}
 
-  {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+  {{- if and .Values.clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
 
   # Add k8s event attributes - k8s.<kind>.name and k8s.<kind>.uid
   transform/k8sevents:
@@ -167,7 +166,7 @@ processors:
   {{- end }}
 
   {{- if or
-    (and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true"))
+    (and .Values.clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true"))
     (and (eq (include "splunk-otel-collector.objectsEnabled" .) "true") (eq (include "splunk-otel-collector.logsEnabled" .) "true"))
   }}
   {{- include "splunk-otel-collector.k8sClusterReceiverAttributesProcessor" . | nindent 2 }}
@@ -267,7 +266,7 @@ exporters:
 
   {{- if and (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") (eq (include "splunk-otel-collector.objectsOrEventsEnabled" .) "true") }}
   {{- include "splunk-otel-collector.splunkPlatformLogsExporter" . | nindent 2 }}
-  {{- if $clusterReceiver.eventsEnabled }}
+  {{- if .Values.clusterReceiver.eventsEnabled }}
     sourcetype: kube:events
   {{- end }}
   {{- end }}
@@ -380,7 +379,7 @@ service:
         {{- end }}
     {{- end }}
 
-    {{- if and $clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
+    {{- if and .Values.clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true") }}
     logs:
       receivers:
         - k8s_events

--- a/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
@@ -1,8 +1,7 @@
-{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
 {{/*
 Fargate doesn't support daemonsets so never use for that platform
 */}}
-{{- if and $agent.enabled (ne .Values.distribution "eks/fargate") }}
+{{- if and .Values.agent.enabled (ne .Values.distribution "eks/fargate") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,12 +15,12 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   relay: |
-    {{- $config := include "splunk-otel-collector.agentConfig" . | fromYaml }}
-    {{- $agent.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
+    {{- $defaultConfig := include "splunk-otel-collector.agentConfig" . | fromYaml }}
+    {{- .Values.agent.config | mustMergeOverwrite $defaultConfig | toYaml | nindent 4 }}
 {{- if .Values.agent.discovery.enabled }}
   discovery.properties: |
     splunk.discovery:
     {{- $properties := include "splunk-otel-collector.agentDiscoveryProperties" . | fromYaml }}
-    {{- $agent.discovery.properties | mustMergeOverwrite $properties | toYaml | nindent 6 }}
+    {{- .Values.agent.discovery.properties | mustMergeOverwrite $properties | toYaml | nindent 6 }}
 {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
@@ -1,4 +1,3 @@
-{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
 {{ if eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" }}
 apiVersion: v1
 kind: ConfigMap
@@ -13,6 +12,6 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   relay: |
-    {{- $config := include "splunk-otel-collector.clusterReceiverConfig" . | fromYaml }}
-    {{- $clusterReceiver.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
+    {{- $defaultConfig := include "splunk-otel-collector.clusterReceiverConfig" . | fromYaml }}
+    {{- .Values.clusterReceiver.config | mustMergeOverwrite $defaultConfig | toYaml | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd-json.yaml
@@ -1,5 +1,4 @@
-{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
-{{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") $agent.enabled (eq .Values.logsEngine "fluentd") }}
+{{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.agent.enabled (eq .Values.logsEngine "fluentd") }}
 {{/*
 Fluentd config parts applied only to clusters with docker runtime.
 */}}

--- a/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-fluentd.yaml
@@ -1,5 +1,4 @@
-{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
-{{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") $agent.enabled (eq .Values.logsEngine "fluentd") }}
+{{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") .Values.agent.enabled (eq .Values.logsEngine "fluentd") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
@@ -1,6 +1,4 @@
-{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
-{{ $gatewayEnabled := eq (include "splunk-otel-collector.gatewayEnabled" .) "true" }}
-{{ if $gatewayEnabled }}
+{{ if .Values.gateway.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,6 +12,6 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   relay: |
-    {{- $config := include "splunk-otel-collector.gatewayConfig" . | fromYaml }}
-    {{- $gateway.config | mustMergeOverwrite $config | toYaml | nindent 4 }}
+    {{- $defaultConfig := include "splunk-otel-collector.gatewayConfig" . | fromYaml }}
+    {{- .Values.gateway.config | mustMergeOverwrite $defaultConfig | toYaml | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -1,8 +1,7 @@
-{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
 {{/*
 Fargate doesn't support daemonsets so never use for that platform
 */}}
-{{- if and $agent.enabled (ne .Values.distribution "eks/fargate") }}
+{{- if and .Values.agent.enabled (ne .Values.distribution "eks/fargate") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -18,9 +17,9 @@ metadata:
     {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (eq .Values.logsEngine "fluentd") }}
     engine: fluentd
     {{- end }}
-  {{- if $agent.annotations }}
+  {{- if .Values.agent.annotations }}
   annotations:
-    {{- toYaml $agent.annotations | nindent 4 }}
+    {{- toYaml .Values.agent.annotations | nindent 4 }}
   {{- end }}
 spec:
   updateStrategy:
@@ -41,14 +40,14 @@ spec:
         app: {{ template "splunk-otel-collector.name" . }}
         component: otel-collector-agent
         release: {{ .Release.Name }}
-        {{- if $agent.podLabels }}
-        {{- toYaml $agent.podLabels | nindent 8 }}
+        {{- if .Values.agent.podLabels }}
+        {{- toYaml .Values.agent.podLabels | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ print (include (print $.Template.BasePath "/configmap-fluentd.yaml") .) (include (print $.Template.BasePath "/configmap-agent.yaml") .) | sha256sum }}
         kubectl.kubernetes.io/default-container: otel-collector
-        {{- if $agent.podAnnotations }}
-        {{- toYaml $agent.podAnnotations | nindent 8 }}
+        {{- if .Values.agent.podAnnotations }}
+        {{- toYaml .Values.agent.podAnnotations | nindent 8 }}
         {{- end }}
         {{- if .Values.autodetect.istio }}
         sidecar.istio.io/inject: "false"
@@ -78,7 +77,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (not .Values.isWindows) (not $agent.skipInitContainers) }}
+      {{- if and (eq (include "splunk-otel-collector.logsEnabled" .) "true") (not .Values.isWindows) (not .Values.agent.skipInitContainers) }}
       initContainers:
         {{- if and (eq .Values.logsEngine "fluentd") (not (eq .Values.distribution "gke/autopilot")) }}
         - name: prepare-fluentd-config
@@ -97,7 +96,7 @@ spec:
             - name: LOG_FORMAT_TYPE
               value: "{{ .Values.fluentd.config.containers.logFormatType }}"
           resources:
-            {{- toYaml $agent.resources | nindent 12 }}
+            {{- toYaml .Values.agent.resources | nindent 12 }}
           volumeMounts:
             - name: varlogdest
               mountPath: {{ .Values.fluentd.config.containers.pathDest }}
@@ -134,7 +133,7 @@ spec:
           - name: JOURNALD_LOG_CAPTURE_REGEX
             value: '\/splunkd\-fluentd\-journald\-(?P<name>[\w0-9-_]+)\.pos\.json'
           resources:
-            {{- toYaml $agent.resources | nindent 12 }}
+            {{- toYaml .Values.agent.resources | nindent 12 }}
           volumeMounts:
             - name: checkpoint
               mountPath: /var/addon/splunk/otel_pos
@@ -143,44 +142,44 @@ spec:
             - name: varlibdockercontainers
               mountPath: /var/lib/docker/containers
         {{- end }}
-        {{- if and $agent.securityContext.runAsUser $agent.securityContext.runAsGroup }}
+        {{- if and .Values.agent.securityContext.runAsUser .Values.agent.securityContext.runAsGroup }}
         - name: patch-log-dirs
           image: {{ template "splunk-otel-collector.image.initPatchLogDirs" . }}
           imagePullPolicy: {{ .Values.image.initPatchLogDirs.pullPolicy }}
           command: ['sh', '-c', '
           mkdir -p {{ .Values.logsCollection.checkpointPath }};
-          chown -Rv {{ $agent.securityContext.runAsUser | default 999 }}:{{ $agent.securityContext.runAsGroup | default 999 }} {{ .Values.logsCollection.checkpointPath }};
+          chown -Rv {{ .Values.agent.securityContext.runAsUser | default 999 }}:{{ .Values.agent.securityContext.runAsGroup | default 999 }} {{ .Values.logsCollection.checkpointPath }};
           chmod -v g+rwxs {{ .Values.logsCollection.checkpointPath }};
           {{ if .Values.logsCollection.containers.enabled -}}
           if [ -d "/var/lib/docker/containers" ];
           then
-              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx /var/lib/docker/containers;
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx /var/lib/docker/containers;
           fi;
           if [ -d "/var/log/crio/pods" ];
           then
-              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx /var/log/crio/pods;
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx /var/log/crio/pods;
           fi;
           if [ -d "/var/log/pods" ];
           then
-              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx /var/log/pods;
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx /var/log/pods;
           fi;
           {{- end }}
           {{- if .Values.logsCollection.journald.enabled }}
           if [ -d "{{ .Values.logsCollection.journald.directory }}" ];
           then
-              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx {{ .Values.logsCollection.journald.directory }};
+              setfacl -n -Rm d:m::rx,m::rx,d:g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx {{ .Values.logsCollection.journald.directory }};
           fi;
           {{- end }}
           {{- if .Values.splunkPlatform.sendingQueue.persistentQueue.enabled }}
           mkdir -p {{ .Values.splunkPlatform.sendingQueue.persistentQueue.storagePath }}/agent;
-          chown -Rv {{ $agent.securityContext.runAsUser | default 999 }}:{{ $agent.securityContext.runAsGroup | default 999 }} {{ .Values.splunkPlatform.sendingQueue.persistentQueue.storagePath }}/agent;
+          chown -Rv {{ .Values.agent.securityContext.runAsUser | default 999 }}:{{ .Values.agent.securityContext.runAsGroup | default 999 }} {{ .Values.splunkPlatform.sendingQueue.persistentQueue.storagePath }}/agent;
           chmod -v g+rwxs {{ .Values.splunkPlatform.sendingQueue.persistentQueue.storagePath }}/agent;
-          setfacl -n -Rm d:m::rx,m::rx,d:g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ $agent.securityContext.runAsGroup | default 999 }}:rx {{ .Values.splunkPlatform.sendingQueue.persistentQueue.storagePath }}/agent;
+          setfacl -n -Rm d:m::rx,m::rx,d:g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx,g:{{ .Values.agent.securityContext.runAsGroup | default 999 }}:rx {{ .Values.splunkPlatform.sendingQueue.persistentQueue.storagePath }}/agent;
           {{- end }}']
           securityContext:
             runAsUser: 0
           resources:
-            {{- toYaml $agent.resources | nindent 12 }}
+            {{- toYaml .Values.agent.resources | nindent 12 }}
           volumeMounts:
             - name: checkpoint
               mountPath: {{ .Values.logsCollection.checkpointPath }}
@@ -257,7 +256,7 @@ spec:
         - --discovery
         {{- end }}
         ports:
-        {{- range $key, $port := $agent.ports }}
+        {{- range $key, $port := .Values.agent.ports }}
         {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) (and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for)) }}
         - name: {{ $key }}
           {{- omit $port "enabled_for" | toYaml | trim | nindent 10 }}
@@ -265,17 +264,17 @@ spec:
         {{- end }}
         image: {{ template "splunk-otel-collector.image.otelcol" . }}
         imagePullPolicy: {{ .Values.image.otelcol.pullPolicy }}
-        {{- if or $agent.securityContext (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (eq .Values.logsEngine "otel")) }}
+        {{- if or .Values.agent.securityContext (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (eq .Values.logsEngine "otel")) }}
         securityContext:
-          {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $agent.securityContext "setRunAsUser" true) | nindent 10 }}
+          {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" .Values.agent.securityContext "setRunAsUser" true) | nindent 10 }}
         {{- end }}
         env:
           {{- if .Values.featureGates.useMemoryLimitPercentage }}
           - name: GOMEMLIMIT
-            value: "{{ include "splunk-otel-collector.convertMemToBytes" $agent.resources.limits.memory | int64 }}"
+            value: "{{ include "splunk-otel-collector.convertMemToBytes" .Values.agent.resources.limits.memory | int64 }}"
           {{- else }}
           - name: SPLUNK_MEMORY_TOTAL_MIB
-            value: "{{ include "splunk-otel-collector.convertMemToMib" $agent.resources.limits.memory | int64 }}"
+            value: "{{ include "splunk-otel-collector.convertMemToMib" .Values.agent.resources.limits.memory | int64 }}"
           {{- end }}
           - name: K8S_NODE_NAME
             valueFrom:
@@ -317,7 +316,7 @@ spec:
                 name: {{ include "splunk-otel-collector.secret" . }}
                 key: splunk_platform_hec_token
           {{- end }}
-          {{- with $agent.extraEnvs }}
+          {{- with .Values.agent.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}
 
@@ -336,7 +335,7 @@ spec:
             path: /
             port: 13133
         resources:
-          {{- toYaml $agent.resources | nindent 10 }}
+          {{- toYaml .Values.agent.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /conf
           name: otel-configmap
@@ -424,8 +423,8 @@ spec:
           name: serviceaccount-token
           readOnly: true
         {{- end }}
-        {{- if $agent.extraVolumeMounts }}
-        {{- toYaml $agent.extraVolumeMounts | nindent 8 }}
+        {{- if .Values.agent.extraVolumeMounts }}
+        {{- toYaml .Values.agent.extraVolumeMounts | nindent 8 }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
@@ -568,8 +567,8 @@ spec:
             - key: discovery.properties
               path: properties.discovery.yaml
       {{- end }}
-      {{- if $agent.extraVolumes }}
-      {{- toYaml $agent.extraVolumes | nindent 6 }}
+      {{- if .Values.agent.extraVolumes }}
+      {{- toYaml .Values.agent.extraVolumes | nindent 6 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -1,4 +1,3 @@
-{{ $clusterReceiver := fromYaml (include "splunk-otel-collector.clusterReceiver" .) }}
 {{- if eq (include "splunk-otel-collector.clusterReceiverEnabled" .) "true" }}
 apiVersion: apps/v1
 {{- /*
@@ -19,9 +18,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     app.kubernetes.io/component: otel-k8s-cluster-receiver
-  {{- if $clusterReceiver.annotations }}
+  {{- if .Values.clusterReceiver.annotations }}
   annotations:
-    {{- toYaml $clusterReceiver.annotations | nindent 4 }}
+    {{- toYaml .Values.clusterReceiver.annotations | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{- if eq .Values.distribution "eks/fargate" }} 2 {{- else }} 1 {{- end }}
@@ -40,13 +39,13 @@ spec:
         app: {{ template "splunk-otel-collector.name" . }}
         component: otel-k8s-cluster-receiver
         release: {{ .Release.Name }}
-        {{- if $clusterReceiver.podLabels }}
-        {{- toYaml $clusterReceiver.podLabels | nindent 8 }}
+        {{- if .Values.clusterReceiver.podLabels }}
+        {{- toYaml .Values.clusterReceiver.podLabels | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-cluster-receiver.yaml") . | sha256sum }}
-        {{- if $clusterReceiver.podAnnotations }}
-        {{- toYaml $clusterReceiver.podAnnotations | nindent 8 }}
+        {{- if .Values.clusterReceiver.podAnnotations }}
+        {{- toYaml .Values.clusterReceiver.podAnnotations | nindent 8 }}
         {{- end }}
         {{- if .Values.autodetect.istio }}
         sidecar.istio.io/inject: "false"
@@ -61,16 +60,16 @@ spec:
       automountServiceAccountToken: false
       {{- end }}
       nodeSelector:
-        {{- if $clusterReceiver.nodeSelector }}
-        {{ toYaml $clusterReceiver.nodeSelector | nindent 8 }}
+        {{- if .Values.clusterReceiver.nodeSelector }}
+        {{ toYaml .Values.clusterReceiver.nodeSelector | nindent 8 }}
         {{- else }}
           kubernetes.io/os: {{ .Values.isWindows | ternary "windows" "linux" }}
         {{- end }}
-      {{- if $clusterReceiver.tolerations }}
+      {{- if .Values.clusterReceiver.tolerations }}
       tolerations:
-        {{ toYaml $clusterReceiver.tolerations | nindent 8 }}
+        {{ toYaml .Values.clusterReceiver.tolerations | nindent 8 }}
       {{- end }}
-      {{- if or $clusterReceiver.affinity (eq .Values.distribution "eks/fargate") }}
+      {{- if or .Values.clusterReceiver.affinity (eq .Values.distribution "eks/fargate") }}
       affinity:
         {{- $clusterReceiverPodAntiAffinity := `
         podAntiAffinity:
@@ -83,9 +82,9 @@ spec:
                       - otel-k8s-cluster-receiver
               topologyKey: kubernetes.io/hostname
         ` }}
-        {{- $clusterReceiver.affinity | mustMergeOverwrite (fromYaml $clusterReceiverPodAntiAffinity) | toYaml | nindent 8 }}
+        {{- .Values.clusterReceiver.affinity | mustMergeOverwrite (fromYaml $clusterReceiverPodAntiAffinity) | toYaml | nindent 8 }}
       {{- end }}
-      {{- $podSecurityContext := $clusterReceiver.podSecurityContext | default $clusterReceiver.securityContext }}
+      {{- $podSecurityContext := .Values.clusterReceiver.podSecurityContext | default .Values.clusterReceiver.securityContext }}
       {{- if $podSecurityContext }}
       securityContext:
         {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $podSecurityContext) | nindent 8 }}
@@ -133,10 +132,10 @@ spec:
         env:
           {{- if .Values.featureGates.useMemoryLimitPercentage }}
           - name: GOMEMLIMIT
-            value: "{{ include "splunk-otel-collector.convertMemToBytes" $clusterReceiver.resources.limits.memory | int64 }}"
+            value: "{{ include "splunk-otel-collector.convertMemToBytes" .Values.clusterReceiver.resources.limits.memory | int64 }}"
           {{- else }}
           - name: SPLUNK_MEMORY_TOTAL_MIB
-            value: "{{ include "splunk-otel-collector.convertMemToMib" $clusterReceiver.resources.limits.memory | int64 }}"
+            value: "{{ include "splunk-otel-collector.convertMemToMib" .Values.clusterReceiver.resources.limits.memory | int64 }}"
           {{- end }}
           - name: K8S_NODE_NAME
             valueFrom:
@@ -173,7 +172,7 @@ spec:
                 name: {{ include "splunk-otel-collector.secret" . }}
                 key: splunk_platform_hec_token
           {{- end }}
-          {{- with $clusterReceiver.extraEnvs }}
+          {{- with .Values.clusterReceiver.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}
         readinessProbe:
@@ -191,7 +190,7 @@ spec:
             path: /
             port: 13134
         resources:
-          {{- toYaml $clusterReceiver.resources | nindent 10 }}
+          {{- toYaml .Values.clusterReceiver.resources | nindent 10 }}
         volumeMounts:
         {{- if .Values.featureGates.explicitMountServiceAccountToken }}
         - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
@@ -212,10 +211,10 @@ spec:
         - mountPath: /usr/lib/splunk-otel-collector/agent-bundle/run/collectd
           name: run-collectd
           readOnly: false
-        {{- if $clusterReceiver.extraVolumeMounts }}
-        {{- toYaml $clusterReceiver.extraVolumeMounts | nindent 8 }}
+        {{- if .Values.clusterReceiver.extraVolumeMounts }}
+        {{- toYaml .Values.clusterReceiver.extraVolumeMounts | nindent 8 }}
         {{- end }}
-      terminationGracePeriodSeconds: {{ $clusterReceiver.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.clusterReceiver.terminationGracePeriodSeconds }}
       volumes:
       {{- if .Values.featureGates.explicitMountServiceAccountToken }}
       - name: serviceaccount-token
@@ -261,10 +260,10 @@ spec:
       - name: messages
         emptyDir: {}
       {{- end }}
-      {{- if $clusterReceiver.extraVolumes }}
-      {{- toYaml $clusterReceiver.extraVolumes | nindent 6 }}
+      {{- if .Values.clusterReceiver.extraVolumes }}
+      {{- toYaml .Values.clusterReceiver.extraVolumes | nindent 6 }}
       {{- end }}
-      {{- if $clusterReceiver.priorityClassName }}
-      priorityClassName: {{ $clusterReceiver.priorityClassName }}
+      {{- if .Values.clusterReceiver.priorityClassName }}
+      priorityClassName: {{ .Values.clusterReceiver.priorityClassName }}
       {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -1,6 +1,4 @@
-{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
-{{ $gatewayEnabled := eq (include "splunk-otel-collector.gatewayEnabled" .) "true" }}
-{{ if $gatewayEnabled }}
+{{ if .Values.gateway.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,12 +12,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     app.kubernetes.io/component: otel-collector
-  {{- if $gateway.annotations }}
+  {{- if .Values.gateway.annotations }}
   annotations:
-    {{- toYaml $gateway.annotations | nindent 4 }}
+    {{- toYaml .Values.gateway.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ $gateway.replicaCount }}
+  replicas: {{ .Values.gateway.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "splunk-otel-collector.name" . }}
@@ -31,13 +29,13 @@ spec:
         app: {{ template "splunk-otel-collector.name" . }}
         component: otel-collector
         release: {{ .Release.Name }}
-        {{- if $gateway.podLabels }}
-        {{- toYaml $gateway.podLabels | nindent 8 }}
+        {{- if .Values.gateway.podLabels }}
+        {{- toYaml .Values.gateway.podLabels | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-gateway.yaml") . | sha256sum }}
-        {{- if $gateway.podAnnotations }}
-        {{- toYaml $gateway.podAnnotations | nindent 8 }}
+        {{- if .Values.gateway.podAnnotations }}
+        {{- toYaml .Values.gateway.podAnnotations | nindent 8 }}
         {{- end }}
         {{- if .Values.autodetect.istio }}
         sidecar.istio.io/inject: "false"
@@ -48,20 +46,20 @@ spec:
       automountServiceAccountToken: false
       {{- end }}
       nodeSelector:
-        {{- if $gateway.nodeSelector }}
-        {{ toYaml $gateway.nodeSelector | nindent 8 }}
+        {{- if .Values.gateway.nodeSelector }}
+        {{ toYaml .Values.gateway.nodeSelector | nindent 8 }}
         {{- else }}
           kubernetes.io/os: {{ .Values.isWindows | ternary "windows" "linux" }}
         {{- end }}
-      {{- if $gateway.tolerations }}
+      {{- if .Values.gateway.tolerations }}
       tolerations:
-        {{ toYaml $gateway.tolerations | nindent 8 }}
+        {{ toYaml .Values.gateway.tolerations | nindent 8 }}
       {{- end }}
-      {{- if $gateway.affinity }}
+      {{- if .Values.gateway.affinity }}
       affinity:
-        {{- toYaml $gateway.affinity | nindent 8 }}
+        {{- toYaml .Values.gateway.affinity | nindent 8 }}
       {{- end }}
-      {{- $podSecurityContext := $gateway.podSecurityContext | default $gateway.securityContext }}
+      {{- $podSecurityContext := .Values.gateway.podSecurityContext | default .Values.gateway.securityContext }}
       {{- if $podSecurityContext }}
       securityContext:
         {{- include "splunk-otel-collector.securityContext" (dict "isWindows" .Values.isWindows "securityContext" $podSecurityContext) | nindent 8 }}
@@ -82,10 +80,10 @@ spec:
         env:
           {{- if .Values.featureGates.useMemoryLimitPercentage }}
           - name: GOMEMLIMIT
-            value: "{{ include "splunk-otel-collector.convertMemToBytes" $gateway.resources.limits.memory | int64 }}"
+            value: "{{ include "splunk-otel-collector.convertMemToBytes" .Values.gateway.resources.limits.memory | int64 }}"
           {{- else }}
           - name: SPLUNK_MEMORY_TOTAL_MIB
-            value: "{{ include "splunk-otel-collector.convertMemToMib" $gateway.resources.limits.memory | int64 }}"
+            value: "{{ include "splunk-otel-collector.convertMemToMib" .Values.gateway.resources.limits.memory | int64 }}"
           {{- end }}
           - name: K8S_NODE_NAME
             valueFrom:
@@ -122,11 +120,11 @@ spec:
                 name: {{ include "splunk-otel-collector.secret" . }}
                 key: splunk_platform_hec_token
           {{- end }}
-          {{- with $gateway.extraEnvs }}
+          {{- with .Values.gateway.extraEnvs }}
           {{- . | toYaml | nindent 10 }}
           {{- end }}
         ports:
-        {{- range $key, $port := $gateway.ports }}
+        {{- range $key, $port := .Values.gateway.ports }}
         {{- if eq true (and (eq (include "splunk-otel-collector.metricsEnabled" $) "true") (has "metrics" $port.enabled_for)) (and (eq (include "splunk-otel-collector.tracesEnabled" $) "true") (has "traces" $port.enabled_for)) (and (eq (include "splunk-otel-collector.logsEnabled" $) "true") (has "logs" $port.enabled_for)) (and (eq (include "splunk-otel-collector.profilingEnabled" $) "true") (has "profiling" $port.enabled_for)) }}
         - name: {{ $key }}
           {{- omit $port "enabled_for" | toYaml | trim | nindent 10 }}
@@ -147,7 +145,7 @@ spec:
             path: /
             port: 13133
         resources:
-          {{- toYaml $gateway.resources | nindent 10 }}
+          {{- toYaml .Values.gateway.resources | nindent 10 }}
         volumeMounts:
         {{- if .Values.featureGates.explicitMountServiceAccountToken }}
         - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
@@ -161,10 +159,10 @@ spec:
         {{- end }}
         - mountPath: /conf
           name: collector-configmap
-        {{- if $gateway.extraVolumeMounts }}
-        {{- toYaml $gateway.extraVolumeMounts | nindent 8 }}
+        {{- if .Values.gateway.extraVolumeMounts }}
+        {{- toYaml .Values.gateway.extraVolumeMounts | nindent 8 }}
         {{- end }}
-      terminationGracePeriodSeconds: {{ $gateway.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
       volumes:
       {{- if .Values.featureGates.explicitMountServiceAccountToken }}
       - name: serviceaccount-token
@@ -196,10 +194,10 @@ spec:
         secret:
           secretName: {{ template "splunk-otel-collector.secret" . }}
       {{- end }}
-      {{- if $gateway.extraVolumes }}
-      {{- toYaml $gateway.extraVolumes | nindent 6 }}
+      {{- if .Values.gateway.extraVolumes }}
+      {{- toYaml .Values.gateway.extraVolumes | nindent 6 }}
       {{- end }}
-      {{- if $gateway.priorityClassName }}
-      priorityClassName: {{ $gateway.priorityClassName }}
+      {{- if .Values.gateway.priorityClassName }}
+      priorityClassName: {{ .Values.gateway.priorityClassName }}
       {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/pdb-gateway.yaml
@@ -1,6 +1,4 @@
-{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
-{{ $gatewayEnabled := eq (include "splunk-otel-collector.gatewayEnabled" .) "true" }}
-{{- if and $gatewayEnabled .Values.podDisruptionBudget }}
+{{- if and .Values.gateway.enabled .Values.podDisruptionBudget }}
 apiVersion: {{ include "splunk-otel-collector.PDB-apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/helm-charts/splunk-otel-collector/templates/service-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service-agent.yaml
@@ -1,10 +1,9 @@
-{{ $agent := fromYaml (include "splunk-otel-collector.agent" .) }}
 {{- $svc := (include "splunk-otel-collector.getServiceConfig" (dict "context" . "svc" .Values.agent.service) | fromYaml) }}
 {{- if .Values.agent.service.enabled }}
 {{/*
 Fargate doesn't support daemonsets so never use for that platform
 */}}
-{{- if and $agent.enabled (ne .Values.distribution "eks/fargate") }}
+{{- if and .Values.agent.enabled (ne .Values.distribution "eks/fargate") }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,7 +24,7 @@ metadata:
 spec:
   type: {{ $svc.type }}
   ports:
-  {{- range $key, $port := $agent.ports }}
+  {{- range $key, $port := .Values.agent.ports }}
   {{- $metricsEnabled   := and (eq (include "splunk-otel-collector.metricsEnabled"   $) "true") (has "metrics"   $port.enabled_for) }}
   {{- $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
   {{- $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}

--- a/helm-charts/splunk-otel-collector/templates/service.yaml
+++ b/helm-charts/splunk-otel-collector/templates/service.yaml
@@ -1,7 +1,5 @@
-{{ $gateway := fromYaml (include "splunk-otel-collector.gateway" .) }}
-{{ $gatewayEnabled := eq (include "splunk-otel-collector.gatewayEnabled" .) "true" }}
 {{- $svc := (include "splunk-otel-collector.getServiceConfig" (dict "context" . "svc" .Values.gateway.service) | fromYaml) }}
-{{ if and $gatewayEnabled }}
+{{ if and .Values.gateway.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,7 +23,7 @@ spec:
   trafficDistribution: {{ $svc.trafficDistribution }}
   {{- end }}
   ports:
-  {{- range $key, $port := $gateway.ports }}
+  {{- range $key, $port := .Values.gateway.ports }}
   {{- $metricsEnabled   := and (eq (include "splunk-otel-collector.metricsEnabled"   $) "true") (has "metrics"   $port.enabled_for) }}
   {{- $tracesEnabled    := and (eq (include "splunk-otel-collector.tracesEnabled"    $) "true") (has "traces"    $port.enabled_for) }}
   {{- $logsEnabled      := and (eq (include "splunk-otel-collector.logsEnabled"      $) "true") (has "logs"      $port.enabled_for) }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -681,11 +681,6 @@
         }
       }
     },
-    "otelAgent": {
-      "description": "[DEPRECATED] Splunk OpenTelemetry Collector agent configuration.",
-      "type": "object",
-      "deprecated": true
-    },
     "clusterReceiver": {
       "description": "Splunk OpenTelemetry Collector cluster receiver configuration.",
       "type": "object",
@@ -813,11 +808,6 @@
           "type": "object"
         }
       }
-    },
-    "otelK8sClusterReceiver": {
-      "description": "[DEPRECATED] Splunk OpenTelemetry Collector cluster receiver configuration.",
-      "type": "object",
-      "deprecated": true
     },
     "logsCollection": {
       "description": "Native OpenTelemetry logs collection configuration.",
@@ -1450,11 +1440,6 @@
           "type": "object"
         }
       }
-    },
-    "otelCollector": {
-      "description": "[DEPRECATED] Splunk OpenTelemetry Collector gateway deployment configuration.",
-      "type": "object",
-      "deprecated": true
     },
     "service": {
       "description": "[DEPRECATED] OpenTelemetry collector service configuration. Please use agent.service and gateway.service instead.",


### PR DESCRIPTION
Use `agent` instead of `otelAgent`, `gateway` instead of `otelCollector`, and `clusterReceiver` instead of `otelK8sClusterReceiver`.
