### PR TITLE
Add ability to deploy additional manifests

### DIFF
--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: splunk-otel-collector
-version: 0.132.0
+version: 0.133.0
 appVersion: 0.132.0
 description: Splunk OpenTelemetry Collector for Kubernetes
 icon: https://github.com/signalfx/splunk-otel-collector-chart/tree/main/splunk.png

--- a/helm-charts/splunk-otel-collector/templates/extra-manifests.yaml
+++ b/helm-charts/splunk-otel-collector/templates/extra-manifests.yaml
@@ -1,0 +1,15 @@
+{{- /* Normalize extraManifests to a list, easier to loop over */ -}}
+{{- $extraManifests := .Values.extraManifests | default (list) -}}
+
+{{- if kindIs "map" $extraManifests -}}
+  {{- $extraManifests = values $extraManifests -}}
+{{- end -}}
+
+{{- range $extraManifests }}
+---
+  {{- if kindIs "map" . }}
+    {{- tpl (toYaml .) $ | nindent 0 }}
+  {{- else if kindIs "string" . }}
+    {{- tpl . $ | nindent 0 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1542,6 +1542,39 @@
       "description": "Helm Chart Feature Gates.",
       "type": "object",
       "additionalProperties": true
+    },
+    "extraManifests": {
+      "description": "Additional manifests to deploy with the chart. Can be an array of manifests or an object where keys are ignored and values are manifests.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": true
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": true
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        }
+      ]
     }
   },
   "allOf": [

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1427,3 +1427,41 @@ featureGates:
   # This feature gate introduces a prometheus receiver to collect metrics from the EKS Apiserver for Splunk Observability.
   # NOTE - OTLP histograms are sent as histograms to Splunk Observability for this feature.
   enableEKSApiServerMetrics: true
+
+################################################################################
+# Extra Manifests
+# Extra manifests to deploy. Can be of type dict or list.
+# If dict, keys are ignored and only values are used.
+# Items contained within extraManifests can be defined as dict or string and are passed through tpl.
+################################################################################
+extraManifests:
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-config
+  #   data:
+  #     extra-data: "value"
+  #
+  # can be defined as a string, useful for templating field names
+  # - |
+  #   apiVersion: v1
+  #   kind: Secret
+  #   type: Opaque
+  #   metadata:
+  #     name: super-secret
+  #     labels:
+  #       {{- range $key, $value := .Values.agent.podLabels }}
+  #       {{ $key }}: {{ $value }}
+  #       {{- end }}
+  #   data:
+  #     plaintext: Zm9vYmFy
+  #     templated: '{{ print "foobar" | upper | b64enc }}'
+  #
+  # or as a dict, useful for when you want to merge multiple values files.
+  # extraDict:
+  #   apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: extra-config-as-dict
+  #   data:
+  #     extra-data: "value"


### PR DESCRIPTION
**Description:**
Adding a feature - allows the user to define additional manifests to be deployed alongside the chart.

**Link to Splunk idea:** n/a

**Testing:** Have run a series of helm templates with differing values configuration

**Documentation:** Configuration options are described in comments in values.yaml
