### PR TITLE
update coredns scrape config for openshift

### DIFF
--- a/.chloggen/openshift-coredns.yaml
+++ b/.chloggen/openshift-coredns.yaml
@@ -1,0 +1,13 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update prometheus receiver configuration for CoreDNS in OpenShift to use secure endpoint and service account token
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - This aligns with OpenShift's default CoreDNS daemonset setup with kube-rbac-proxy which doesn't expose metrics over HTTP.

--- a/examples/distribution-openshift/distribution-openshift-values.yaml
+++ b/examples/distribution-openshift/distribution-openshift-values.yaml
@@ -6,4 +6,4 @@ splunkObservability:
 distribution: openshift
 # Openshift can be installed on multiple cloud providers, set this value
 # appropriately for a better experience.
-# cloudProvider: {aws|azure|gke}
+# cloudProvider: {aws|azure|gcp}

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -219,16 +219,19 @@ data:
             config:
               config:
                 scrape_configs:
-                - job_name: coredns
+                - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+                  job_name: coredns
                   metric_relabel_configs:
                   - action: keep
                     regex: (coredns_dns_request_duration_seconds|coredns_cache_misses_total|coredns_cache_hits_total|coredns_cache_entries|coredns_dns_responses_total|coredns_dns_requests_total|rest_client_requests_total|rest_client_request_duration_seconds)(?:_sum|_count|_bucket)?
                     source_labels:
                     - __name__
+                  scheme: https
                   static_configs:
                   - targets:
                     - '`endpoint`:9154'
                   tls_config:
+                    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
                     insecure_skip_verify: true
             rule: type == "pod" && namespace == "openshift-dns" && name contains "dns"
           prometheus/kube-controller-manager:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 26e62416a8dacffc68937a9c6da2dca433efdcd50b91e7392044ba8c19557c5e
+        checksum/config: e098d4c8b4989b8ece4cdab2bf9f44cbbf79caa50236f9c9661a4621799a3a82
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -266,8 +266,11 @@ receivers:
               {{- if eq .Values.distribution "openshift" }}
               static_configs:
                 - targets: ["`endpoint`:9154"]
+              scheme: https
               tls_config:
                 insecure_skip_verify: true
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
               {{- else }}
               static_configs:
                 - targets: ["`endpoint`:9153"]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Noticed openshift runs dns container with kube-rbac-proxy. The PR updates the scraper config for prometheus/coredns for OpenShift to use https and authenticate correctly. The `insecure_skip_verify` is added due to the cert not having the pod IP in CN/SAN configs. 

**Testing:** <Describe what testing was performed and which tests were added.>
Ran in a test openshift cluster. With the new changes, coredns metrics are exported correctly.
