### PR TITLE
[chore][dependabot] Group pdatautil and pdata deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: "/functional_tests"
     schedule:
       interval: "weekly"
+    groups:
+      pdata:
+        patterns:
+          - "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/*"
+          - "go.opentelemetry.io/collector/pdata/*"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This is an attempt to avoid the issue hit in https://github.com/signalfx/splunk-otel-collector-chart/pull/2018. The PR updates the `pdatatest` pkg, but not core's `pdata/xdata` package, resulting in the following error:
```
Error: /home/runner/go/pkg/mod/go.opentelemetry.io/collector/pdata/xpdata@v0.130.0/request/context.go:19:30: undefined: pdataint.StateReadOnly
```
Upgrading the deps together should resolve this type of failure going forward.