### PR TITLE
[chore] Bump google-github-actions/auth from 2.1.12 to 3.0.0

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -196,7 +196,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
-      - uses: 'google-github-actions/auth@v2.1.12'
+      - uses: 'google-github-actions/auth@v3.0.0'
         with:
           project_id: ${{ secrets.GKE_PROJECT }}
           credentials_json: ${{ secrets.GKE_SA_KEY }}
@@ -238,7 +238,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: '**/go.sum'
-      - uses: 'google-github-actions/auth@v2.1.12'
+      - uses: 'google-github-actions/auth@v3.0.0'
         with:
           project_id: ${{ secrets.GKE_PROJECT }}
           credentials_json: ${{ secrets.GKE_SA_KEY }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Workflows are skipped when they're coming from dependabot, so I'm opening this in an effort to test before merging into main. Changes taken from https://github.com/signalfx/splunk-otel-collector-chart/pull/2011