### PR TITLE
[chore][dependabot] Group collector dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,10 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      pdata:
+      otelcol:
         patterns:
-          - "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/*"
-          - "go.opentelemetry.io/collector/pdata/*"
+          - "go.opentelemetry.io/collector*"
+          - "github.com/open-telemetry/opentelemetry-collector-contrib/*"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/otel*"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
https://github.com/signalfx/splunk-otel-collector-chart/pull/2030 didn't work as expected as `xpdata` is coming from a different import:
```
$ go mod why -m go.opentelemetry.io/collector/pdata/xpdata
# go.opentelemetry.io/collector/pdata/xpdata
github.com/signalfx/splunk-otel-collector-chart/functional_tests/internal
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk
go.opentelemetry.io/collector/exporter/exporterhelper
go.opentelemetry.io/collector/pdata/xpdata/request
```
This means that to properly update the xpdata dependency with `pdatatest`, we need to update the contrib receiver. The simplest solution is to update collector dependencies together. The matching pattern is taken [from the collector repo](https://github.com/signalfx/splunk-otel-collector/blob/d9a87c1f0faed4280e3df8b0623779242033a2be/.github/dependabot.yml#L11-L17).