### PR TITLE
[chore][dependabot] Remove dep update schedule from group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,8 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "gomod"
-    directory: "/functional_tests"
-    schedule:
-      interval: "weekly"
+    directories:
+      - "**/*"
     groups:
       otelcol:
         patterns:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Updated to match [collector repo](https://github.com/signalfx/splunk-otel-collector/blob/d9a87c1f0faed4280e3df8b0623779242033a2be/.github/dependabot.yml#L7-L9), the update PR should be created as soon as new releases are available