### PR TITLE
[chore] Bump google-github-actions/get-gke-credentials from 2.3.4 to 3.0.0

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -203,7 +203,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v2.2.0
         with:
           project_id: ${{ secrets.GKE_PROJECT }}
-      - uses: google-github-actions/get-gke-credentials@v2.3.4
+      - uses: google-github-actions/get-gke-credentials@v3.0.0
         with:
           cluster_name: ${{ secrets.GKE_AUTOPILOT_CLUSTER }}
           location: ${{ secrets.GKE_REGION }}
@@ -245,7 +245,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v2.2.0
         with:
           project_id: ${{ secrets.GKE_PROJECT }}
-      - uses: google-github-actions/get-gke-credentials@v2.3.4
+      - uses: google-github-actions/get-gke-credentials@v3.0.0
         with:
           cluster_name: ${{ secrets.GKE_AUTOPILOT_CLUSTER }}
           location: ${{ secrets.GKE_REGION }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Same as https://github.com/signalfx/splunk-otel-collector-chart/pull/2021, opened manually so tests requiring secrets could run.