### PR TITLE
[chore] Bump google-github-actions/setup-gcloud from 2.2.0 to 3.0.1

### DIFF
--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -200,7 +200,7 @@ jobs:
         with:
           project_id: ${{ secrets.GKE_PROJECT }}
           credentials_json: ${{ secrets.GKE_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@v2.2.0
+      - uses: google-github-actions/setup-gcloud@v3.0.1
         with:
           project_id: ${{ secrets.GKE_PROJECT }}
       - uses: google-github-actions/get-gke-credentials@v2.3.4
@@ -242,7 +242,7 @@ jobs:
         with:
           project_id: ${{ secrets.GKE_PROJECT }}
           credentials_json: ${{ secrets.GKE_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@v2.2.0
+      - uses: google-github-actions/setup-gcloud@v3.0.1
         with:
           project_id: ${{ secrets.GKE_PROJECT }}
       - uses: google-github-actions/get-gke-credentials@v2.3.4


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Same as https://github.com/signalfx/splunk-otel-collector-chart/pull/2010, done manually to run tests that require secrets.