### PR TITLE
Remove cert-manager subchart

### DIFF
--- a/.chloggen/remove-cert-manager.yaml
+++ b/.chloggen/remove-cert-manager.yaml
@@ -1,0 +1,14 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: operator
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove cert-manager subchart
+# One or more tracking issues related to the change
+issues: [2049]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - cert-manager is no longer included as a subchart dependency
+  - Users who need cert-manager for webhook certificates must install it separately. See [installation instructions](docs/auto-instrumentation-install.md).

--- a/.github/workflows/migration_tests.yaml
+++ b/.github/workflows/migration_tests.yaml
@@ -62,9 +62,6 @@ jobs:
       - name: Update dependencies
         run: |
           make dep-update
-      - name: Deploy cert-manager
-        run: |
-          make cert-manager
       - name: Deploy collector as deployment
         run: kubectl apply -f migration_tests/collector_deployment.yaml
       - name: Deploy SCK

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -827,22 +827,12 @@ func shortenNames(value string) string {
 	if strings.HasPrefix(value, "sock-splunk-otel-collector-k8s-cluster-receiver") {
 		return "sock-splunk-otel-collector-k8s-cluster-receiver"
 	}
-	if strings.HasPrefix(value, "cert-manager-cainjector") {
-		return "cert-manager-cainjector"
-	}
 	if strings.HasPrefix(value, "sock-operator") {
 		return "sock-operator"
 	}
 	if strings.HasPrefix(value, "nodejs-test") {
 		return "nodejs-test"
 	}
-	if strings.HasPrefix(value, "cert-manager-webhook") {
-		return "cert-manager-webhook"
-	}
-	if strings.HasPrefix(value, "cert-manager") {
-		return "cert-manager"
-	}
-
 	return value
 }
 

--- a/helm-charts/splunk-otel-collector/Chart.yaml
+++ b/helm-charts/splunk-otel-collector/Chart.yaml
@@ -23,11 +23,6 @@ dependencies:
   # Subchart Notes:
   # - Avoid uppercase letters in aliases, they cause install failure due to subchart resource naming
   # - Avoid hyphen characters in aliases, they introduce template rendering complications (https://github.com/helm/helm/issues/2192)
-  - name: cert-manager
-    version: v1.14.4
-    alias: certmanager
-    repository: https://charts.jetstack.io
-    condition: certmanager.enabled
   - name: opentelemetry-operator-crds
     version: 0.0.4
     alias: operatorcrds

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1495,17 +1495,6 @@
         "additionalProperties": true
       }
     },
-    "certmanager": {
-      "description": "[Deprecated] cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.",
-      "type": "object",
-      "deprecated": true,
-      "additionalProperties": true
-    },
-    "cert-manager": {
-      "description": "Configuration for cert-manager (legacy). Prefer using 'certmanager' for new installations. This field is included to support backward compatibility with older Helm versions or custom distributions. cert-manager adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing and using those certificates.",
-      "type": "object",
-      "additionalProperties": true
-    },
     "targetAllocator": {
       "description": "Target Allocator configuration.",
       "type": "object",

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1356,15 +1356,6 @@ instrumentation:
       #     value: python_value
   # Auto-instrumentation Libraries (End)
 
-# Note - Installing certmanager as a subchart is deprecated and will be removed in the future.
-# The recommended approach is to use the chart's default of generating self-signed cert or
-# to install cert-manager separately.
-# The cert-manager is a CNCF application deployed as a subchart and used for supporting operators that require TLS certificates.
-# Full list of Helm value configurations: https://artifacthub.io/packages/helm/cert-manager/cert-manager?modal=values
-certmanager:
-  enabled: false
-  installCRDs: true
-
 ################################################################################
 # Target Allocator
 # Notice: Target Allocator related features should be considered to have an alpha

--- a/migration_tests/README.md
+++ b/migration_tests/README.md
@@ -16,7 +16,6 @@ You can recreate the execution of the step on your machine with the following se
    export K8S_VERSION=v1.28.0
    kind create cluster --kubeconfig=$KUBECONFIG --config=.github/workflows/configs/kind-config.yaml --image=kindest/node:$K8S_VERSION --name=migration-tests
    kubectl get csr -o=jsonpath='{range.items[?(@.spec.signerName=="kubernetes.io/kubelet-serving")]}{.metadata.name}{" "}{end}' | xargs kubectl certificate approve
-   make cert-manager
    ```
 1. Deploy a collector as a service that can act as a log sink for HEC traffic, alongside with a deployment that outputs logs every second:
    ```


### PR DESCRIPTION
- cert-manager is no longer included as a subchart dependency
- Users who need cert-manager for webhook certificates must install it separately
