### PR TITLE
[chore] Allow a no-op k8sVersion param

### DIFF
--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -15,6 +15,10 @@
     "global": {
       "type": "object"
     },
+    "k8sVersion": {
+      "description": "Required for EKS Add-on compatibility. Not used by the chart.",
+      "type": "string"
+    },
     "nameOverride": {
       "description": "Override name of the chart used in Kubernetes object names.",
       "type": "string"


### PR DESCRIPTION
It's a param set by some EKS Add-on verification flows. Need to allow it to pass them
