### PR TITLE
[chore] fix flaky functional tests

### DIFF
--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1171,7 +1171,16 @@ func testAgentMetrics(t *testing.T) {
 	expectedInternalMetrics, err := golden.ReadMetrics(expectedInternalMetricsFile)
 	require.NoError(t, err)
 
-	selectedInternalMetrics := selectMetricSet(expectedInternalMetrics, agentMetricsConsumer, metricNames)
+	var selectedInternalMetrics *pmetric.Metrics
+	require.Eventually(t, func() bool {
+		result := selectMetricSet(expectedInternalMetrics, agentMetricsConsumer, metricNames)
+		if result != nil {
+			selectedInternalMetrics = result
+			return true
+		}
+		return false
+	}, 30*time.Second, 2*time.Second, "Failed to find matching metrics set")
+
 	require.NotNil(t, selectedInternalMetrics)
 	internal.MaybeUpdateExpectedMetricsResults(t, expectedInternalMetricsFile, selectedInternalMetrics)
 


### PR DESCRIPTION
**Description:** Functional tests (`functional`) are pretty unstable, empirically I noticed it passes every time when I introduce time or add a few retries.

You can see how it fails on a release PR: https://github.com/signalfx/splunk-otel-collector-chart/pull/2068

**Testing:** N/A

**Documentation:** N/A
