### PR TITLE
delete k8sattributesprocessor from clusterReceiver

### DIFF
--- a/.chloggen/delete-k8sattributesprocessor-from-clusterreceiver.yaml
+++ b/.chloggen/delete-k8sattributesprocessor-from-clusterreceiver.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the `k8sattributesprocessor` from the `clusterReceiver` logs pipeline to fix incorrect enrichment of Kubernetes object and event data.
+# One or more tracking issues related to the change
+issues: [2075]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - The `k8sattributesprocessor` was previously misconfigured in the `clusterReceiver` pipeline, resulting in all Kubernetes objects and events being enriched with pod metadata, even when it was not appropriate.
+  - This led to incorrect and non-deterministic `k8s.pod.*` attributes being added to objects and events, such as enriching non-pod objects with pod fields.
+  - After this change:
+    - Events from the `k8s_events` receiver will no longer include `container.id`, `container.image.name`, and `container.image.tag` attributes.
+    - Events from the `k8sobjects` receiver will no longer have any `k8s.pod.*` or `container.*` attributes except `k8s.namespace.name` (when applicable) and `k8s.resource.name`
+  - This restores correct and predictable enrichment, and eliminates misleading data.
+  - If your downstream systems or dashboards depend on the removed attributes, please update them accordingly.

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -62,39 +62,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -199,7 +166,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bc6b1fd396185bdc975d57ef9c25a85369cd7d426bcd0a56be3ad4f4bdb846f1
+        checksum/config: 429d4704d8551d521e02553e3fe2d43ac7191e8e042f5118ee1f643743e14289
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -62,39 +62,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -199,7 +166,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bc6b1fd396185bdc975d57ef9c25a85369cd7d426bcd0a56be3ad4f4bdb846f1
+        checksum/config: 429d4704d8551d521e02553e3fe2d43ac7191e8e042f5118ee1f643743e14289
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -62,39 +62,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -199,7 +166,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bc6b1fd396185bdc975d57ef9c25a85369cd7d426bcd0a56be3ad4f4bdb846f1
+        checksum/config: 429d4704d8551d521e02553e3fe2d43ac7191e8e042f5118ee1f643743e14289
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,39 +56,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -207,7 +174,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         logs/objects:
@@ -219,7 +185,6 @@ data:
           - resourcedetection
           - resource
           - transform/add_sourcetype
-          - k8sattributes/clusterReceiver
           receivers:
           - k8sobjects
       telemetry:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: df2be9b160d20fea9359c629bf369996b21416388c52515f07cea37ed9a05934
+        checksum/config: 205036dcdf974f00ebb02c0cf763b3bfe7cff0cbae0f526e54e7215258e1426d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -79,39 +79,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       k8sattributes/metrics:
         extract:
           annotations:
@@ -249,7 +216,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 97f0c7f621904ee109e38a717909750b668f1f570cdea619451b1f2546355be5
+        checksum/config: 73bab70d84dc1a7bccd928dc45a2d58b1f83001cd29eb897299f0070c7e06dfb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -62,39 +62,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -205,7 +172,6 @@ data:
           - resource
           - resource/add_environment
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9c8fea87e721485e788ca7a8ce952da95bdf9c19b7bcd5a0521ee8ad2db3d63c
+        checksum/config: 518def5461a1162657cd2378960bc8a4ff9ce3de8ea1d3eedd0d7adda9374d05
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -79,39 +79,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       k8sattributes/metrics:
         extract:
           annotations:
@@ -249,7 +216,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 97f0c7f621904ee109e38a717909750b668f1f570cdea619451b1f2546355be5
+        checksum/config: 73bab70d84dc1a7bccd928dc45a2d58b1f83001cd29eb897299f0070c7e06dfb
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,39 +56,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -188,7 +155,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
       telemetry:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b09328f73d76f3a2a363edbc695e6414015636d56002cdb7112173d479c0f2d3
+        checksum/config: 9fa8cab06bc442bb6c0625bf7f113e6cc98d1e8cc29030ec6b37292aed15b2cf
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,39 +56,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -188,7 +155,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
       telemetry:

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b09328f73d76f3a2a363edbc695e6414015636d56002cdb7112173d479c0f2d3
+        checksum/config: 9fa8cab06bc442bb6c0625bf7f113e6cc98d1e8cc29030ec6b37292aed15b2cf
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -62,39 +62,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -199,7 +166,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: bc6b1fd396185bdc975d57ef9c25a85369cd7d426bcd0a56be3ad4f4bdb846f1
+        checksum/config: 429d4704d8551d521e02553e3fe2d43ac7191e8e042f5118ee1f643743e14289
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -79,39 +79,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       k8sattributes/metrics:
         extract:
           annotations:
@@ -249,7 +216,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b3aa3b615ce03d82b0cd3a15416f2751586a994cda03c48f8930188c579e7ef7
+        checksum/config: bf58de7f147845b3320cf9d843e63763e4df4e6930464dfac92806cbe7712050
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,39 +56,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -188,7 +155,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
       telemetry:

--- a/examples/only-logs-fluentd/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b09328f73d76f3a2a363edbc695e6414015636d56002cdb7112173d479c0f2d3
+        checksum/config: 9fa8cab06bc442bb6c0625bf7f113e6cc98d1e8cc29030ec6b37292aed15b2cf
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-otel/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,39 +56,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -188,7 +155,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
       telemetry:

--- a/examples/only-logs-otel/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-otel/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b09328f73d76f3a2a363edbc695e6414015636d56002cdb7112173d479c0f2d3
+        checksum/config: 9fa8cab06bc442bb6c0625bf7f113e6cc98d1e8cc29030ec6b37292aed15b2cf
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,39 +56,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -188,7 +155,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
       telemetry:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b09328f73d76f3a2a363edbc695e6414015636d56002cdb7112173d479c0f2d3
+        checksum/config: 9fa8cab06bc442bb6c0625bf7f113e6cc98d1e8cc29030ec6b37292aed15b2cf
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,39 +56,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -188,7 +155,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
       telemetry:

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b09328f73d76f3a2a363edbc695e6414015636d56002cdb7112173d479c0f2d3
+        checksum/config: 9fa8cab06bc442bb6c0625bf7f113e6cc98d1e8cc29030ec6b37292aed15b2cf
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -56,39 +56,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       memory_limiter:
         check_interval: 2s
         limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
@@ -188,7 +155,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
       telemetry:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b2d410e81de07229e3479fb26c8cf4efd12d192f38b6f5bffd7ab3292aaa3e12
+        checksum/config: a77169c586dba43204b8731ebad7f8388e2f23cd978c7122bd12580d6dc4efe2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -79,39 +79,6 @@ data:
           key: k8s.event.uid
       batch:
         send_batch_max_size: 32768
-      k8sattributes/clusterReceiver:
-        extract:
-          annotations:
-          - from: namespace
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: pod
-            key: splunk.com/sourcetype
-            tag_name: com.splunk.sourcetype
-          - from: namespace
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          - from: pod
-            key: splunk.com/index
-            tag_name: com.splunk.index
-          metadata:
-          - k8s.namespace.name
-          - k8s.node.name
-          - k8s.pod.name
-          - k8s.pod.uid
-          - container.id
-          - container.image.name
-          - container.image.tag
-        pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.uid
-        - sources:
-          - from: resource_attribute
-            name: k8s.namespace.name
-        - sources:
-          - from: resource_attribute
-            name: k8s.node.name
       k8sattributes/metrics:
         extract:
           annotations:
@@ -254,7 +221,6 @@ data:
           - resourcedetection
           - resource
           - transform/k8sevents
-          - k8sattributes/clusterReceiver
           receivers:
           - k8s_events
         metrics:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5c1665bc6df0c0d0e28a93c810dab5d0e80345558c9a0fc9e4cb521369049706
+        checksum/config: 3d7c4dfbc1cbe7da27207bc7c8429c16825f321b20866eacec8a1cb9be24d821
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -295,6 +295,7 @@ func testClusterReceiverEnabledOrDisabled(t *testing.T) {
 
 func testVerifyLogsAndMetricsAttributes(t *testing.T) {
 	attributesList := [4]string{"k8s.node.name", "k8s.pod.name", "k8s.pod.uid", "k8s.namespace.name"}
+	objectAttributesList := [3]string{"k8s.resource.name", "k8s.cluster.name", "k8s.namespace.name"}
 
 	hostEp := internal.HostEndpoint(t)
 	if len(hostEp) == 0 {
@@ -315,7 +316,7 @@ func testVerifyLogsAndMetricsAttributes(t *testing.T) {
 		internal.WaitForLogs(t, 5, logsObjectsConsumer)
 		t.Logf("===> >>>> Logs: %v", len(logsObjectsConsumer.AllLogs()))
 
-		for _, attr := range attributesList {
+		for _, attr := range objectAttributesList {
 			t.Log("Checking attribute: ", attr)
 			attrValues, notFoundCounter := getLogsAttributes(logsObjectsConsumer.AllLogs(), attr)
 			assert.GreaterOrEqual(t, len(attrValues), 1)

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -68,9 +68,6 @@ func Test_K8SEvents(t *testing.T) {
 			return re.ReplaceAllString(body, `Successfully pulled image "$1:latest" in <time> (<time> including waiting)`)
 		})
 
-		// the following attributes are added by the k8sattributes processor which might not be ready when the test runs
-		removeFlakyLogRecordAttr(k8sEventsLogs, "k8s.container.name")
-
 		expectedEventsLogsFile := "testdata/expected_k8sevents.yaml"
 		expectedEventsLogs, err := golden.ReadLogs(expectedEventsLogsFile)
 		require.NoError(t, err, "failed to read expected events logs from file")

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -69,9 +69,7 @@ func Test_K8SEvents(t *testing.T) {
 		})
 
 		// the following attributes are added by the k8sattributes processor which might not be ready when the test runs
-		removeFlakyLogRecordAttr(k8sEventsLogs, "container.id")
-		removeFlakyLogRecordAttr(k8sEventsLogs, "container.image.name")
-		removeFlakyLogRecordAttr(k8sEventsLogs, "container.image.tag")
+		removeFlakyLogRecordAttr(k8sEventsLogs, "k8s.container.name")
 
 		expectedEventsLogsFile := "testdata/expected_k8sevents.yaml"
 		expectedEventsLogs, err := golden.ReadLogs(expectedEventsLogsFile)
@@ -100,13 +98,6 @@ func Test_K8SEvents(t *testing.T) {
 		k8sObjectsLogs = updateLogRecordBody(k8sObjectsLogs, []string{"object", "metadata", "creationTimestamp"}, "2025-03-04T01:59:10Z")
 		k8sObjectsLogs = updateLogRecordBody(k8sObjectsLogs, []string{"object", "metadata", "managedFields", "0", "time"}, "2025-03-04T01:59:10Z")
 		k8sObjectsLogs = updateLogRecordBody(k8sObjectsLogs, []string{"object", "metadata", "managedFields", "0", "manager"}, "k8sevents.test") // changes when the test name which runs k8s client changes
-
-		// the following attributes are added by the k8sattributes processor which might not be ready when the test runs
-		removeFlakyLogRecordAttr(k8sObjectsLogs, "container.image.name")
-		removeFlakyLogRecordAttr(k8sObjectsLogs, "container.image.tag")
-		removeFlakyLogRecordAttr(k8sObjectsLogs, "k8s.node.name")
-		removeFlakyLogRecordAttr(k8sObjectsLogs, "k8s.pod.name")
-		removeFlakyLogRecordAttr(k8sObjectsLogs, "k8s.pod.uid")
 
 		expectedObjectsLogsFile := "testdata/expected_k8sobjects.yaml"
 		expectedObjectsLogs, err := golden.ReadLogs(expectedObjectsLogsFile)

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -247,19 +247,6 @@ func compareAttributes(attr1, attr2 pcommon.Map) bool {
 	return true
 }
 
-func removeFlakyLogRecordAttr(logs plog.Logs, attributeName string) {
-	for i := 0; i < logs.ResourceLogs().Len(); i++ {
-		resourceLogs := logs.ResourceLogs().At(i)
-		for j := 0; j < resourceLogs.ScopeLogs().Len(); j++ {
-			scopeLogs := resourceLogs.ScopeLogs().At(j)
-			for k := 0; k < scopeLogs.LogRecords().Len(); k++ {
-				logRecord := scopeLogs.LogRecords().At(k)
-				logRecord.Attributes().Remove(attributeName)
-			}
-		}
-	}
-}
-
 func updateLogRecordBody(logs plog.Logs, path []string, newValue string) plog.Logs {
 	for i := 0; i < logs.ResourceLogs().Len(); i++ {
 		resourceLogs := logs.ResourceLogs().At(i)

--- a/functional_tests/k8sevents/testdata/expected_k8sevents.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sevents.yaml
@@ -3,7 +3,7 @@ resourceLogs:
       attributes:
         - key: host.name
           value:
-            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6448fc5476rzlrl
+            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-7dd9dc4cf5d47n2
         - key: com.splunk.source
           value:
             stringValue: kubernetes
@@ -51,16 +51,16 @@ resourceLogs:
                   stringValue: k8sevents-test
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "581"
+                  stringValue: "612"
               - key: k8s.object.uid
                 value:
-                  stringValue: e7fa4314-3572-4803-900f-8cee97a36219
+                  stringValue: cf67d6ef-8e4c-43e9-be0a-705c6b0825d8
               - key: k8s.statefulset.name
                 value:
                   stringValue: k8sevents-test
               - key: k8s.statefulset.uid
                 value:
-                  stringValue: e7fa4314-3572-4803-900f-8cee97a36219
+                  stringValue: cf67d6ef-8e4c-43e9-be0a-705c6b0825d8
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -75,7 +75,7 @@ resourceLogs:
                   stringValue: Normal
             body:
               stringValue: create Pod k8sevents-test-0 in StatefulSet k8sevents-test successful
-            timeUnixNano: "1758784709000000000"
+            timeUnixNano: "1759215206000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -112,16 +112,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "583"
+                  stringValue: "614"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -136,7 +136,7 @@ resourceLogs:
                   stringValue: Normal
             body:
               stringValue: Successfully assigned k8sevents-test/k8sevents-test-0 to kind-control-plane
-            timeUnixNano: "1758784709000000000"
+            timeUnixNano: "1759215206000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -144,9 +144,9 @@ resourceLogs:
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: otel.log.severity.text
+              - key: k8s.container.name
                 value:
-                  stringValue: Normal
+                  stringValue: container-1
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -176,16 +176,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "585"
+                  stringValue: "615"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -195,9 +195,12 @@ resourceLogs:
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: Pulling image "busybox:latest"
-            timeUnixNano: "1758784710000000000"
+            timeUnixNano: "1759215207000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -205,9 +208,9 @@ resourceLogs:
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: otel.log.severity.text
+              - key: k8s.container.name
                 value:
-                  stringValue: Normal
+                  stringValue: container-1
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -237,16 +240,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "585"
+                  stringValue: "615"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -256,9 +259,12 @@ resourceLogs:
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: Successfully pulled image "busybox:latest" in <time> (<time> including waiting)
-            timeUnixNano: "1758784714000000000"
+            timeUnixNano: "1759215210000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -266,9 +272,9 @@ resourceLogs:
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: otel.log.severity.text
+              - key: k8s.container.name
                 value:
-                  stringValue: Normal
+                  stringValue: container-1
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -298,16 +304,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "585"
+                  stringValue: "615"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -317,9 +323,12 @@ resourceLogs:
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: 'Created container: container-1'
-            timeUnixNano: "1758784714000000000"
+            timeUnixNano: "1759215210000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -327,9 +336,9 @@ resourceLogs:
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: otel.log.severity.text
+              - key: k8s.container.name
                 value:
-                  stringValue: Normal
+                  stringValue: container-1
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -359,16 +368,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "585"
+                  stringValue: "615"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -378,9 +387,12 @@ resourceLogs:
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: Started container container-1
-            timeUnixNano: "1758784714000000000"
+            timeUnixNano: "1759215210000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -388,9 +400,9 @@ resourceLogs:
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: otel.log.severity.text
+              - key: k8s.container.name
                 value:
-                  stringValue: Normal
+                  stringValue: container-2
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -420,16 +432,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "585"
+                  stringValue: "615"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -439,9 +451,12 @@ resourceLogs:
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: Pulling image "alpine:latest"
-            timeUnixNano: "1758784714000000000"
+            timeUnixNano: "1759215210000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -449,9 +464,9 @@ resourceLogs:
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: otel.log.severity.text
+              - key: k8s.container.name
                 value:
-                  stringValue: Normal
+                  stringValue: container-2
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -481,16 +496,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "585"
+                  stringValue: "615"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -500,9 +515,12 @@ resourceLogs:
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: Successfully pulled image "alpine:latest" in <time> (<time> including waiting)
-            timeUnixNano: "1758784717000000000"
+            timeUnixNano: "1759215213000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -510,9 +528,9 @@ resourceLogs:
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: otel.log.severity.text
+              - key: k8s.container.name
                 value:
-                  stringValue: Normal
+                  stringValue: container-2
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -542,16 +560,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "585"
+                  stringValue: "615"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -561,9 +579,12 @@ resourceLogs:
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: 'Created container: container-2'
-            timeUnixNano: "1758784717000000000"
+            timeUnixNano: "1759215213000000000"
           - attributes:
               - key: deployment.environment
                 value:
@@ -571,9 +592,9 @@ resourceLogs:
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: otel.log.severity.text
+              - key: k8s.container.name
                 value:
-                  stringValue: Normal
+                  stringValue: container-2
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -603,16 +624,16 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "585"
+                  stringValue: "615"
               - key: k8s.object.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
+                  stringValue: e21a7ae8-45ba-4c8f-9726-b79ec70adb6e
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -622,7 +643,10 @@ resourceLogs:
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: Started container container-2
-            timeUnixNano: "1758784717000000000"
+            timeUnixNano: "1759215213000000000"
         scope: {}

--- a/functional_tests/k8sevents/testdata/expected_k8sevents.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sevents.yaml
@@ -3,7 +3,7 @@ resourceLogs:
       attributes:
         - key: host.name
           value:
-            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-85d7cfbb9bhldfw
+            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6448fc5476rzlrl
         - key: com.splunk.source
           value:
             stringValue: kubernetes
@@ -51,16 +51,16 @@ resourceLogs:
                   stringValue: k8sevents-test
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41768"
+                  stringValue: "581"
               - key: k8s.object.uid
                 value:
-                  stringValue: 4570e7a8-45cb-4ec3-a762-86d432681925
+                  stringValue: e7fa4314-3572-4803-900f-8cee97a36219
               - key: k8s.statefulset.name
                 value:
                   stringValue: k8sevents-test
               - key: k8s.statefulset.uid
                 value:
-                  stringValue: 4570e7a8-45cb-4ec3-a762-86d432681925
+                  stringValue: e7fa4314-3572-4803-900f-8cee97a36219
               - key: metric_source
                 value:
                   stringValue: kubernetes
@@ -75,33 +75,8 @@ resourceLogs:
                   stringValue: Normal
             body:
               stringValue: create Pod k8sevents-test-0 in StatefulSet k8sevents-test successful
-            spanId: ""
-            timeUnixNano: "1741277160000000000"
-            traceId: ""
-        scope: {}
-  - resource:
-      attributes:
-        - key: host.name
-          value:
-            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-85d7cfbb9bhldfw
-        - key: com.splunk.source
-          value:
-            stringValue: kubernetes
-        - key: com.splunk.sourcetype
-          value:
-            stringValue: kube:events
-        - key: com.splunk.index
-          value:
-            stringValue: index_from_pod
-    scopeLogs:
-      - logRecords:
+            timeUnixNano: "1758784709000000000"
           - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
-              - key: otel.log.severity.number
-                value:
-                  doubleValue: 9
               - key: deployment.environment
                 value:
                   stringValue: dev
@@ -122,7 +97,7 @@ resourceLogs:
                   stringValue: k8sevents-test
               - key: k8s.node.name
                 value:
-                  stringValue: kind-control-plane
+                  stringValue: ""
               - key: k8s.object.api_version
                 value:
                   stringValue: v1
@@ -137,43 +112,41 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41770"
+                  stringValue: "583"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
+              - key: otel.log.severity.number
+                value:
+                  doubleValue: 9
+              - key: otel.log.severity.text
+                value:
+                  stringValue: Normal
             body:
               stringValue: Successfully assigned k8sevents-test/k8sevents-test-0 to kind-control-plane
-            spanId: ""
-            timeUnixNano: "1741277160000000000"
-            traceId: ""
+            timeUnixNano: "1758784709000000000"
           - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
-              - key: otel.log.severity.number
-                value:
-                  doubleValue: 9
               - key: deployment.environment
                 value:
                   stringValue: dev
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: k8s.container.name
+              - key: otel.log.severity.text
                 value:
-                  stringValue: container-1
+                  stringValue: Normal
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -203,43 +176,38 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41773"
+                  stringValue: "585"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
+              - key: otel.log.severity.number
+                value:
+                  doubleValue: 9
             body:
               stringValue: Pulling image "busybox:latest"
-            spanId: ""
-            timeUnixNano: "1741277161000000000"
-            traceId: ""
+            timeUnixNano: "1758784710000000000"
           - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
-              - key: otel.log.severity.number
-                value:
-                  doubleValue: 9
               - key: deployment.environment
                 value:
                   stringValue: dev
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: k8s.container.name
+              - key: otel.log.severity.text
                 value:
-                  stringValue: container-1
+                  stringValue: Normal
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -269,43 +237,38 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41773"
+                  stringValue: "585"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
-            body:
-              stringValue: Successfully pulled image "busybox:latest" in <time> (<time> including waiting)
-            spanId: ""
-            timeUnixNano: "1741277162000000000"
-            traceId: ""
-          - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+            body:
+              stringValue: Successfully pulled image "busybox:latest" in <time> (<time> including waiting)
+            timeUnixNano: "1758784714000000000"
+          - attributes:
               - key: deployment.environment
                 value:
                   stringValue: dev
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: k8s.container.name
+              - key: otel.log.severity.text
                 value:
-                  stringValue: container-1
+                  stringValue: Normal
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -335,43 +298,38 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41773"
+                  stringValue: "585"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
-            body:
-              stringValue: "Created container: container-1"
-            spanId: ""
-            timeUnixNano: "1741277162000000000"
-            traceId: ""
-          - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+            body:
+              stringValue: 'Created container: container-1'
+            timeUnixNano: "1758784714000000000"
+          - attributes:
               - key: deployment.environment
                 value:
                   stringValue: dev
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: k8s.container.name
+              - key: otel.log.severity.text
                 value:
-                  stringValue: container-1
+                  stringValue: Normal
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -401,43 +359,38 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41773"
+                  stringValue: "585"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
-            body:
-              stringValue: Started container container-1
-            spanId: ""
-            timeUnixNano: "1741277162000000000"
-            traceId: ""
-          - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+            body:
+              stringValue: Started container container-1
+            timeUnixNano: "1758784714000000000"
+          - attributes:
               - key: deployment.environment
                 value:
                   stringValue: dev
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: k8s.container.name
+              - key: otel.log.severity.text
                 value:
-                  stringValue: container-2
+                  stringValue: Normal
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -467,43 +420,38 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41773"
+                  stringValue: "585"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
-            body:
-              stringValue: Pulling image "alpine:latest"
-            spanId: ""
-            timeUnixNano: "1741277162000000000"
-            traceId: ""
-          - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+            body:
+              stringValue: Pulling image "alpine:latest"
+            timeUnixNano: "1758784714000000000"
+          - attributes:
               - key: deployment.environment
                 value:
                   stringValue: dev
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: k8s.container.name
+              - key: otel.log.severity.text
                 value:
-                  stringValue: container-2
+                  stringValue: Normal
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -533,43 +481,38 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41773"
+                  stringValue: "585"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
-            body:
-              stringValue: Successfully pulled image "alpine:latest" in <time> (<time> including waiting)
-            spanId: ""
-            timeUnixNano: "1741277162000000000"
-            traceId: ""
-          - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+            body:
+              stringValue: Successfully pulled image "alpine:latest" in <time> (<time> including waiting)
+            timeUnixNano: "1758784717000000000"
+          - attributes:
               - key: deployment.environment
                 value:
                   stringValue: dev
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: k8s.container.name
+              - key: otel.log.severity.text
                 value:
-                  stringValue: container-2
+                  stringValue: Normal
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -599,43 +542,38 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41773"
+                  stringValue: "585"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
-            body:
-              stringValue: "Created container: container-2"
-            spanId: ""
-            timeUnixNano: "1741277162000000000"
-            traceId: ""
-          - attributes:
-              - key: otel.log.severity.text
-                value:
-                  stringValue: Normal
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
+            body:
+              stringValue: 'Created container: container-2'
+            timeUnixNano: "1758784717000000000"
+          - attributes:
               - key: deployment.environment
                 value:
                   stringValue: dev
               - key: k8s.cluster.name
                 value:
                   stringValue: dev-operator
-              - key: k8s.container.name
+              - key: otel.log.severity.text
                 value:
-                  stringValue: container-2
+                  stringValue: Normal
               - key: k8s.event.action
                 value:
                   stringValue: ""
@@ -665,25 +603,26 @@ resourceLogs:
                   stringValue: k8sevents-test-0
               - key: k8s.object.resource_version
                 value:
-                  stringValue: "41773"
+                  stringValue: "585"
               - key: k8s.object.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: k8s.pod.name
                 value:
                   stringValue: k8sevents-test-0
               - key: k8s.pod.uid
                 value:
-                  stringValue: 114fb04b-2063-4923-a43e-01376a3d3d60
+                  stringValue: 0bd16a9f-f902-424e-b511-efc514c7e762
               - key: metric_source
                 value:
                   stringValue: kubernetes
               - key: os.type
                 value:
                   stringValue: linux
+              - key: otel.log.severity.number
+                value:
+                  doubleValue: 9
             body:
               stringValue: Started container container-2
-            spanId: ""
-            timeUnixNano: "1741277163000000000"
-            traceId: ""
+            timeUnixNano: "1758784717000000000"
         scope: {}

--- a/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
@@ -3,7 +3,7 @@ resourceLogs:
       attributes:
         - key: host.name
           value:
-            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-859c547cf4gxb2v
+            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6448fc5476mgbpr
         - key: com.splunk.source
           value:
             stringValue: kubernetes
@@ -12,7 +12,7 @@ resourceLogs:
             stringValue: kube:object:services
         - key: com.splunk.index
           value:
-            stringValue: index_from_pod
+            stringValue: main
     scopeLogs:
       - logRecords:
           - attributes:
@@ -206,6 +206,5 @@ resourceLogs:
                   - key: type
                     value:
                       stringValue: ADDED
-            spanId: ""
-            traceId: ""
+            timeUnixNano: "1758636241030999808"
         scope: {}

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -228,43 +228,6 @@ k8sattributes:
       {{- include "splunk-otel-collector.addExtraLabels" . | nindent 6 }}
     {{- end }}
 {{- end }}
-{{- define "splunk-otel-collector.k8sClusterReceiverAttributesProcessor" -}}
-k8sattributes/clusterReceiver:
-  pod_association:
-    - sources:
-      - from: resource_attribute
-        name: k8s.pod.uid
-    - sources:
-      - from: resource_attribute
-        name: k8s.namespace.name
-    - sources:
-      - from: resource_attribute
-        name: k8s.node.name
-  extract:
-    metadata:
-      - k8s.namespace.name
-      - k8s.node.name
-      - k8s.pod.name
-      - k8s.pod.uid
-      - container.id
-      - container.image.name
-      - container.image.tag
-    {{- if eq (include "splunk-otel-collector.splunkPlatformEnabled" .) "true"}}
-    annotations:
-      - key: splunk.com/sourcetype
-        tag_name: com.splunk.sourcetype
-        from: namespace
-      - key: splunk.com/sourcetype
-        tag_name: com.splunk.sourcetype
-        from: pod
-      - key: splunk.com/index
-        tag_name: com.splunk.index
-        from: namespace
-      - key: splunk.com/index
-        tag_name: com.splunk.index
-        from: pod
-    {{- end}}
-{{- end }}
 
 {{/*
 Common config for K8s attributes processor adding k8s metadata to metrics resource attributes.

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -168,13 +168,6 @@ processors:
           - set(resource.attributes["com.splunk.sourcetype"], Concat(["kube:object:", attributes["k8s.resource.name"]], ""))
   {{- end }}
 
-  {{- if or
-    (and .Values.clusterReceiver.eventsEnabled (eq (include "splunk-otel-collector.logsEnabled" .) "true"))
-    (and (eq (include "splunk-otel-collector.objectsEnabled" .) "true") (eq (include "splunk-otel-collector.logsEnabled" .) "true"))
-  }}
-  {{- include "splunk-otel-collector.k8sClusterReceiverAttributesProcessor" . | nindent 2 }}
-  {{- end }}
-
   # Resource attributes specific to the collector itself.
   resource/add_collector_k8s:
     attributes:
@@ -386,7 +379,6 @@ service:
         - resource/add_environment
         {{- end }}
         - transform/k8sevents
-        - k8sattributes/clusterReceiver
       exporters:
         {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
         - splunk_hec/platform_logs
@@ -406,7 +398,6 @@ service:
         {{- if .Values.environment }}
         - resource/add_environment
         {{- end }}
-        - k8sattributes/clusterReceiver
       exporters:
         {{- if (eq (include "splunk-otel-collector.platformLogsEnabled" .) "true") }}
         - splunk_hec/platform_logs


### PR DESCRIPTION
**Description:** `k8sattributesprocessor` doesn't work well for k8s objects and k8s events. It provides wrong attributes, specifically:
- the same pod name for every pod object
- pod related attributes even for objects from a higher abstract layer (like `node`)
- pod related attributes for k8s events originating from cluster

**Link to Splunk idea:** N/A

**Testing:** manual tests

**Documentation:** <Describe the documentation added.>
