### PR TITLE
[chore] Remove required section from values.schema.yaml

### DIFF
--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "type": "object",
-  "required": [
-    "cloudProvider",
-    "distribution"
-  ],
   "title": "Values",
   "additionalProperties": false,
   "properties": {


### PR DESCRIPTION
The requirement isn't applicable to the regular helm install/upgrade since the `values.yaml` have empty string values by defaults for the `cloudProvider` and `distribution` fields. However, the EKS Addon validator treats the `required` field differently making the `cloudProvider` and `distribution` to be required from the user with every installation even if we pre-set `aws` and `eks` in the values.yaml.
