### PR TITLE
add transformed k8s.hpa.scaletargetref as cluster resource attribute

### DIFF
--- a/.chloggen/hpa.yaml
+++ b/.chloggen/hpa.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Added `k8s.hpa.scaletargetref` as resource attributes in the Kubernetes cluster receiver configuration."
+# One or more tracking issues related to the change
+issues: [2101]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -125,6 +125,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -132,6 +143,12 @@ data:
         - signalfx
         resource_attributes:
           k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
             enabled: true
       k8s_events:
         auth_type: serviceAccount
@@ -176,6 +193,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e77337f2bf042ab3619a655c81fd96969615455aa65c8dc3b138cde8cb3d3e3
+        checksum/config: 7403d294d5cbb42123a6508f3ba93e2ba6b34d172571a5cc28402529a124abfe
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -125,6 +125,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -132,6 +143,12 @@ data:
         - signalfx
         resource_attributes:
           k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
             enabled: true
       k8s_events:
         auth_type: serviceAccount
@@ -176,6 +193,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e77337f2bf042ab3619a655c81fd96969615455aa65c8dc3b138cde8cb3d3e3
+        checksum/config: 7403d294d5cbb42123a6508f3ba93e2ba6b34d172571a5cc28402529a124abfe
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -125,6 +125,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -132,6 +143,12 @@ data:
         - signalfx
         resource_attributes:
           k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
             enabled: true
       k8s_events:
         auth_type: serviceAccount
@@ -176,6 +193,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e77337f2bf042ab3619a655c81fd96969615455aa65c8dc3b138cde8cb3d3e3
+        checksum/config: 7403d294d5cbb42123a6508f3ba93e2ba6b34d172571a5cc28402529a124abfe
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -125,6 +125,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5146af7e48374ca0b260afa410dc59777c902002756df0eec2f7b717b08669e6
+        checksum/config: f683b46bfd059746b9d641ee8b43b09615147409236b3822a07beaf8ce60e7b7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/crio-logging/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -180,6 +180,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -227,6 +238,7 @@ data:
           - resource
           - k8sattributes/metrics
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c4347db29a9866bd347e83ec6bcbd0b65b439a584119bf260665191cc5a98c1c
+        checksum/config: 07a635eacb57d9e5be0ec9724235366b499a87fb1f92e3c84dca08f7588b7768
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -80,6 +80,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -109,6 +115,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 41e634d8179a872ac83462bf88c62ceeee6fc5a65f3d8f733cdf8550fb393165
+        checksum/config: 0096b06505dfcb9942c6af318c47d847658c4c5d935d0912a2129398d8993c10
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,6 +116,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -163,6 +169,7 @@ data:
           - resourcedetection/k8s_cluster_name
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7365f3833dd54938904baf18db844ad3c37767e258ea63fb52d2b5638d8aea5e
+        checksum/config: 6c05e25e13204a82c32ebd8eaf5f80dfb20246c5b6ba45437339c1a25e8d2e48
     spec:
       hostNetwork: true
       serviceAccountName: default-splunk-otel-collector

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -93,6 +93,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -156,6 +162,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 520433a2ad8ffb4ed25790e6646aaf993e54cbd9da05b0130aee6eb120577034
+        checksum/config: 6ca733fc27535fb36bf27112eb22885678a33302ae3ccdf5dc1267e1b26028da
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -103,6 +103,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -149,6 +155,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5b5aace07be87eba7a2ddce3b6ede11f57199da3237bc466f2cccb85dfc450da
+        checksum/config: e64ad43f1dcddb33ca69e306946f5d63aef8dbb383d8b203f3f56e6d0e678302
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -79,6 +79,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -108,6 +114,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8a3316ded381cc7d13cef5edcd0fb766c777761e2dd8f13598230e938e6b5f85
+        checksum/config: 9a7a69e4483922c7e13ce08894a54e1ebb8166d79d0c62cd8580d56bb406d9e0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -79,6 +79,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -108,6 +114,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 8a3316ded381cc7d13cef5edcd0fb766c777761e2dd8f13598230e938e6b5f85
+        checksum/config: 9a7a69e4483922c7e13ce08894a54e1ebb8166d79d0c62cd8580d56bb406d9e0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -79,6 +79,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -108,6 +114,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fd91fc4405f0014d37300326808795613256c7afbe84529f83510eed2a3fc984
+        checksum/config: 28b2ae925d2ff36df7e87b47f14ed553f666cefaa1d1f2f2887731fc5407ba3c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -130,6 +130,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -137,6 +148,12 @@ data:
         - signalfx
         resource_attributes:
           k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
             enabled: true
       k8s_events:
         auth_type: serviceAccount
@@ -182,6 +199,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aaa4f14486462e722619a46bbd66987ce73932d36533bf3062a4079f98e99a0b
+        checksum/config: 30f8140d6a857325fb7fbb2a7535f6474f6d3a8e7ca37738aada779b0d9b6727
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -180,6 +180,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -227,6 +238,7 @@ data:
           - resource
           - k8sattributes/metrics
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c4347db29a9866bd347e83ec6bcbd0b65b439a584119bf260665191cc5a98c1c
+        checksum/config: 07a635eacb57d9e5be0ec9724235366b499a87fb1f92e3c84dca08f7588b7768
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -119,6 +119,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-multiline-logs-java-stack-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1022a4dad80e694e15f1062ea12cfce2a1e184f3bde379e483ecb90d2eb0b773
+        checksum/config: 3f83931f1ac50d1b6da4873c52ba4b7e5c6c4913456b52d6c0108bb1cfcf8b79
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/configmap-cluster-receiver.yaml
@@ -119,6 +119,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/fluentd-refresh-interval/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1022a4dad80e694e15f1062ea12cfce2a1e184f3bde379e483ecb90d2eb0b773
+        checksum/config: 3f83931f1ac50d1b6da4873c52ba4b7e5c6c4913456b52d6c0108bb1cfcf8b79
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -125,6 +125,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -132,6 +143,12 @@ data:
         - signalfx
         resource_attributes:
           k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
             enabled: true
       k8s_events:
         auth_type: serviceAccount
@@ -176,6 +193,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2e77337f2bf042ab3619a655c81fd96969615455aa65c8dc3b138cde8cb3d3e3
+        checksum/config: 7403d294d5cbb42123a6508f3ba93e2ba6b34d172571a5cc28402529a124abfe
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -180,6 +180,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -227,6 +238,7 @@ data:
           - resource
           - k8sattributes/metrics
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4114cc04cd43b342ac31feb872b67fb0e852a6201ed1691f57f2b9a2c5ba913e
+        checksum/config: 1f8692e196091569e3b680ced83a039d5ec97019f6806f10ebf3f4412ddff2ec
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-fluentd/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/configmap-cluster-receiver.yaml
@@ -119,6 +119,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/only-logs-fluentd/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-fluentd/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1022a4dad80e694e15f1062ea12cfce2a1e184f3bde379e483ecb90d2eb0b773
+        checksum/config: 3f83931f1ac50d1b6da4873c52ba4b7e5c6c4913456b52d6c0108bb1cfcf8b79
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-otel/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-otel/rendered_manifests/configmap-cluster-receiver.yaml
@@ -119,6 +119,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/only-logs-otel/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-otel/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1022a4dad80e694e15f1062ea12cfce2a1e184f3bde379e483ecb90d2eb0b773
+        checksum/config: 3f83931f1ac50d1b6da4873c52ba4b7e5c6c4913456b52d6c0108bb1cfcf8b79
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -119,6 +119,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1022a4dad80e694e15f1062ea12cfce2a1e184f3bde379e483ecb90d2eb0b773
+        checksum/config: 3f83931f1ac50d1b6da4873c52ba4b7e5c6c4913456b52d6c0108bb1cfcf8b79
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -158,6 +158,7 @@ data:
           - resource
           - k8sattributes/metrics
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 36d3b509154fa817ea2a86f740da4b5af7c0d025aadeb5369a263afbcc2364b8
+        checksum/config: d26f2913b478dbec6f8e9ce725bac71b514d95e9f11a7136136e0f952a9f5219
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 154365cd11f5aa0212f917c9215c8bddd731928193e215ab44e7cdc9b2c31cab
+        checksum/config: 2380aded72775554ada6c8dc5a544560551599b4029ff37e4e18dab4a346b7c8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -119,6 +119,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1022a4dad80e694e15f1062ea12cfce2a1e184f3bde379e483ecb90d2eb0b773
+        checksum/config: 3f83931f1ac50d1b6da4873c52ba4b7e5c6c4913456b52d6c0108bb1cfcf8b79
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -119,6 +119,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 89e94433bf38b9df44828769270111d28a125600788725167b56c9f1e8050973
+        checksum/config: 86987e56ba278abbb59885c38abf2d2f81cf0026a3e8a51657cc42f2b9c22ea4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -185,6 +185,17 @@ data:
           - merge_maps(resource.cache, ExtractPatterns(resource.attributes["k8s.object.fieldpath"],
             "spec.containers\\{(?P<k8s_container_name>[^\\}]+)\\}"), "insert")
           - set(resource.attributes["k8s.container.name"], resource.cache["k8s_container_name"])
+      transform/k8shpascaletargetref:
+        error_mode: ignore
+        metric_statements:
+        - context: resource
+          statements:
+          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
+          - set(attributes["k8s.statefulSet.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
+          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+            where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:
         auth_type: serviceAccount
@@ -233,6 +244,7 @@ data:
           - k8sattributes/metrics
           - resource/metrics
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2aee0f30ee44b5b7b3a177f1d0edcf60ba1df891d38873d00b62596fde5f14cd
+        checksum/config: e35e1a0ae5d7a9d7f0e5a53b9c94515745f13cde64f9b80b19669aeb7e7b66fe
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -78,6 +78,12 @@ data:
         resource_attributes:
           k8s.container.status.last_terminated_reason:
             enabled: true
+          k8s.hpa.scaletargetref.apiversion:
+            enabled: true
+          k8s.hpa.scaletargetref.kind:
+            enabled: true
+          k8s.hpa.scaletargetref.name:
+            enabled: true
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:
@@ -107,6 +113,7 @@ data:
           - batch
           - resource
           - resource/k8s_cluster
+          - transform/k8shpascaletargetref
           receivers:
           - k8s_cluster
         metrics/collector:

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9a27f9ee8ec804d79dd99d255aa271138c479c2e6e895655d8d45a89a8bb06fd
+        checksum/config: eb2d0157465bb88c80f0ae6e2cd0f69370f3493ede73b5f8438d0685e8ea66e9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:


### PR DESCRIPTION
change_type: enhancement
component: clusterReceiver
note: "Added `k8s.hpa.scaletargetref` as resource attributes in the Kubernetes cluster receiver configuration."

insert k8s.replicaset.name when k8s.hpa.scaletargetref.kind is ReplicaSet
insert k8s.statefulSet.name when k8s.hpa.scaletargetref.kind is StatefulSet
insert k8s.deployment.name when k8s.hpa.scaletargetref.kind is Deployment