### PR TITLE
[chart] Move istio sidecar injection annotation to label

### DIFF
--- a/.chloggen/movedeprecatedistioannotations.yaml
+++ b/.chloggen/movedeprecatedistioannotations.yaml
@@ -1,0 +1,13 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move deprecated Istio pod annotation to pod label
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The "sidecar.istio.io/inject" annotation is deprecated in favor of the label with the same name.

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -30,10 +30,10 @@ spec:
         app: splunk-otel-collector
         component: otel-collector-agent
         release: default
+        sidecar.istio.io/inject: "false"
       annotations:
         checksum/config: d2d16cc55113029807342c5b68b2d04773bafd92ce2f3c0c0df99eb6638c3dea
         kubectl.kubernetes.io/default-container: otel-collector
-        sidecar.istio.io/inject: "false"
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -29,9 +29,9 @@ spec:
         app: splunk-otel-collector
         component: otel-k8s-cluster-receiver
         release: default
+        sidecar.istio.io/inject: "false"
       annotations:
         checksum/config: 2e77337f2bf042ab3619a655c81fd96969615455aa65c8dc3b138cde8cb3d3e3
-        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/daemonset.yaml
+++ b/helm-charts/splunk-otel-collector/templates/daemonset.yaml
@@ -39,6 +39,9 @@ spec:
         app: {{ template "splunk-otel-collector.name" . }}
         component: otel-collector-agent
         release: {{ .Release.Name }}
+        {{- if .Values.autodetect.istio }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
         {{- if .Values.agent.podLabels }}
         {{- toYaml .Values.agent.podLabels | nindent 8 }}
         {{- end }}
@@ -47,9 +50,6 @@ spec:
         kubectl.kubernetes.io/default-container: otel-collector
         {{- if .Values.agent.podAnnotations }}
         {{- toYaml .Values.agent.podAnnotations | nindent 8 }}
-        {{- end }}
-        {{- if .Values.autodetect.istio }}
-        sidecar.istio.io/inject: "false"
         {{- end }}
     spec:
       {{- if and (.Values.agent.hostNetwork) (not .Values.isWindows) }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -38,6 +38,9 @@ spec:
         app: {{ template "splunk-otel-collector.name" . }}
         component: otel-k8s-cluster-receiver
         release: {{ .Release.Name }}
+        {{- if .Values.autodetect.istio }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
         {{- if .Values.clusterReceiver.podLabels }}
         {{- toYaml .Values.clusterReceiver.podLabels | nindent 8 }}
         {{- end }}
@@ -45,9 +48,6 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-cluster-receiver.yaml") . | sha256sum }}
         {{- if .Values.clusterReceiver.podAnnotations }}
         {{- toYaml .Values.clusterReceiver.podAnnotations | nindent 8 }}
-        {{- end }}
-        {{- if .Values.autodetect.istio }}
-        sidecar.istio.io/inject: "false"
         {{- end }}
     spec:
       {{- $hostNetworkEnabled := include "splunk-otel-collector.clusterReceiverHostNetworkEnabled" . }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-gateway.yaml
@@ -28,6 +28,9 @@ spec:
         app: {{ template "splunk-otel-collector.name" . }}
         component: otel-collector
         release: {{ .Release.Name }}
+        {{- if .Values.autodetect.istio }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
         {{- if .Values.gateway.podLabels }}
         {{- toYaml .Values.gateway.podLabels | nindent 8 }}
         {{- end }}
@@ -35,9 +38,6 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-gateway.yaml") . | sha256sum }}
         {{- if .Values.gateway.podAnnotations }}
         {{- toYaml .Values.gateway.podAnnotations | nindent 8 }}
-        {{- end }}
-        {{- if .Values.autodetect.istio }}
-        sidecar.istio.io/inject: "false"
         {{- end }}
     spec:
       serviceAccountName: {{ template "splunk-otel-collector.serviceAccountName" . }}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -236,9 +236,9 @@ distribution: ""
 autodetect:
   prometheus: false
   # This option is recommended for istio environments. It does the following things:
-  # - Enables scraping istio control plane metrics from Promethes endpoints.
+  # - Enables scraping istio control plane metrics from Prometheus endpoints.
   # - Add a `service.name` resource attribute to logs with the same value as istio generates for
-  #   traces to enable correlation between logs and traces usign this attribute.
+  #   traces to enable correlation between logs and traces using this attribute.
   istio: false
 
 ################################################################################


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The [annotation](https://istio.io/latest/docs/reference/config/annotations/#SidecarInject) `sidecar.istio.io/inject` has been deprecated in favor of the [label](https://istio.io/latest/docs/reference/config/labels/#SidecarInject) with the same name.

_Also fixes some typos in comments._