### PR TITLE
bug_fix: profiling configs

### DIFF
--- a/.chloggen/fix-gateway-profiling-ports.yaml
+++ b/.chloggen/fix-gateway-profiling-ports.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: gateway
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `profiling` to gateway OTLP port `enabled_for` lists
+# One or more tracking issues related to the change
+issues: [2365]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The gateway OTLP ports (4317, 4318) were missing `profiling` in their `enabled_for`
+  lists, unlike the agent ports which already included it. This meant the profiling signal
+  alone could not enable the gateway OTLP ports.

--- a/.chloggen/fix-profiler-env-dedup.yaml
+++ b/.chloggen/fix-profiler-env-dedup.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: operator
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Respect user-defined SPLUNK_PROFILER_ENABLED and SPLUNK_PROFILER_MEMORY_ENABLED in `instrumentation.spec.env`
+# One or more tracking issues related to the change
+issues: [2365]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When `splunkObservability.profilingEnabled` is true, the chart auto-injects
+  `SPLUNK_PROFILER_ENABLED=true` and `SPLUNK_PROFILER_MEMORY_ENABLED=true` into
+  the Instrumentation CR. Previously, setting these to "false" in
+  `instrumentation.spec.env` to globally disable profiling while keeping the
+  pipeline active was silently overridden. The chart now correctly honors
+  user-defined values and skips injection when they are already present.

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -60,12 +60,17 @@ these frameworks often have pre-built instrumentation capabilities already avail
 - **Auto-instrumentation Configuration Overrides (Optional)**
   - **[Default Instrumentation](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml) Object Deployment**
     - Automatically deploys with `operator.enabled=true`.
-    - Supports AlwaysOn Profiling when `splunkObservability.profilingEnabled=true`.
+    - Supports AlwaysOn Profiling when `splunkObservability.profilingEnabled=true`. When enabled, the chart:
+      - Configures the collector's logs pipeline and `splunk_hec/o11y` exporter to forward profiling data to Splunk Observability Cloud.
+      - Automatically injects `SPLUNK_PROFILER_ENABLED=true` and `SPLUNK_PROFILER_MEMORY_ENABLED=true` into the Instrumentation CR's global `spec.env`, unless already defined there.
+      - To disable profiling for specific languages, override these vars in the per-language env (e.g. `instrumentation.spec.java.env`). See the [partially enable profiling](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-profiling-partially.yaml) example.
+      - To disable profiling globally while keeping the pipeline active, set `SPLUNK_PROFILER_ENABLED=false` and `SPLUNK_PROFILER_MEMORY_ENABLED=false` in `instrumentation.spec.env`.
   - **Customizing Instrumentation**
-    - `operator.instrumentation.spec`: Override values under this parameter to customize the deployed opentelemetry.io/v1alpha1 Instrumentation object.
+    - `instrumentation.spec`: Override values under this parameter to customize the deployed opentelemetry.io/v1alpha1 Instrumentation object.
       - **Examples**
         - [Custom environment span tags](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation_add_custom_environment_span_tag.yaml)
         - [trace sampler](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-add-trace-sampler.yaml)
+        - [enable profiling](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-profiling.yaml)
         - [partially enable profiling](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-profiling-partially.yaml)
         - [enable useLabelsForResourceAttributes](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-use-labels-for-resource-attributes.yaml).
 

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -55,7 +55,7 @@ these frameworks often have pre-built instrumentation capabilities already avail
 
   - **Alternative Methods**
     - **Instrumentation Spec**
-      - `operator.instrumentation.spec.env`: Use with the `OTEL_RESOURCE_ATTRIBUTES` environment variable to specify the deployment environment.
+      - `instrumentation.spec.env`: Use with the `OTEL_RESOURCE_ATTRIBUTES` environment variable to specify the deployment environment.
 
 - **Auto-instrumentation Configuration Overrides (Optional)**
   - **[Default Instrumentation](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml) Object Deployment**
@@ -68,7 +68,7 @@ these frameworks often have pre-built instrumentation capabilities already avail
   - **Customizing Instrumentation**
     - `instrumentation.spec`: Override values under this parameter to customize the deployed opentelemetry.io/v1alpha1 Instrumentation object.
       - **Examples**
-        - [Custom environment span tags](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation_add_custom_environment_span_tag.yaml)
+        - [Custom environment span tags](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-add-custom-environment-span-tag.yaml)
         - [trace sampler](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-add-trace-sampler.yaml)
         - [enable profiling](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-profiling.yaml)
         - [partially enable profiling](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-profiling-partially.yaml)

--- a/examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-profiling-partially.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-profiling-partially.yaml
@@ -9,14 +9,14 @@
 #   profilingEnabled: true
 # operator:
 #   enabled: true
-#   instrumentation:
-#     spec:
-#       java:
-#         env:
-#           - name: SPLUNK_PROFILER_ENABLED
-#             value: "false"
-#           - name: SPLUNK_PROFILER_MEMORY_ENABLED
-#             value: "false"
+# instrumentation:
+#   spec:
+#     java:
+#       env:
+#         - name: SPLUNK_PROFILER_ENABLED
+#           value: "false"
+#         - name: SPLUNK_PROFILER_MEMORY_ENABLED
+#           value: "false"
 # certmanager:
 #   enabled: true
 # Output instrumentation.yaml:

--- a/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
@@ -95,10 +95,10 @@ sampler:
 {{- define "splunk-otel-collector.operator.instrumentation-env" -}}
   {{- $env := .Values.instrumentation.spec.env | default list -}}
   {{- if .Values.splunkObservability.profilingEnabled -}}
-    {{- if eq (include "splunk-otel-collector.operator.env-has" (dict "env" .Values.instrumentation.env "envName" "SPLUNK_PROFILER_ENABLED")) "false" }}
+    {{- if eq (include "splunk-otel-collector.operator.env-has" (dict "env" .Values.instrumentation.spec.env "envName" "SPLUNK_PROFILER_ENABLED")) "false" }}
       {{- $env = append $env (dict "name" "SPLUNK_PROFILER_ENABLED" "value" "true") -}}
     {{- end }}
-    {{- if eq (include "splunk-otel-collector.operator.env-has" (dict "env" .Values.instrumentation.env "envName" "SPLUNK_PROFILER_MEMORY_ENABLED")) "false" }}
+    {{- if eq (include "splunk-otel-collector.operator.env-has" (dict "env" .Values.instrumentation.spec.env "envName" "SPLUNK_PROFILER_MEMORY_ENABLED")) "false" }}
       {{- $env = append $env (dict "name" "SPLUNK_PROFILER_MEMORY_ENABLED" "value" "true") -}}
     {{- end }}
   {{- end -}}

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -168,10 +168,13 @@ splunkObservability:
   # Consider using `clusterReceiver.eventsEnabled` option instead.
   infrastructureMonitoringEventsEnabled: false
 
-  # This option just enables the shared pipeline for logs and profiling data.
-  # There is no active collection of profiling data.
-  # Instrumentation libraries must be configured to send it to the collector.
-  # If you don't use AlwaysOn Profiling for Splunk APM, you can disable it.
+  # Enables the shared logs pipeline and the splunk_hec/o11y exporter for profiling data.
+  # This does not actively collect profiling data on its own.
+  # Instrumentation libraries must be configured to send profiling data to the collector
+  # via the OTLP receiver (ports 4317/4318).
+  # When the operator is enabled, setting this to true also injects SPLUNK_PROFILER_ENABLED
+  # and SPLUNK_PROFILER_MEMORY_ENABLED into the Instrumentation CR's global environment.
+  # If you don't use AlwaysOn Profiling for Splunk APM, you can leave this disabled.
   profilingEnabled: false
 
   # Enables Secure Application features
@@ -849,11 +852,11 @@ gateway:
     otlp:
       containerPort: 4317
       protocol: TCP
-      enabled_for: [metrics, traces, logs]
+      enabled_for: [metrics, traces, logs, profiling]
     otlp-http:
       containerPort: 4318
       protocol: TCP
-      enabled_for: [metrics, traces, logs]
+      enabled_for: [metrics, traces, logs, profiling]
     jaeger-thrift:
       containerPort: 14268
       protocol: TCP

--- a/unittests/operator_customized_test.yaml
+++ b/unittests/operator_customized_test.yaml
@@ -39,3 +39,32 @@ tests:
           content:
             name: SPLUNK_PROFILER_MEMORY_ENABLED
             value: "false"
+
+  - it: should respect user-defined SPLUNK_PROFILER vars in global spec.env and not duplicate them
+    set:
+      instrumentation.spec.env:
+        - name: SPLUNK_PROFILER_ENABLED
+          value: "false"
+        - name: SPLUNK_PROFILER_MEMORY_ENABLED
+          value: "false"
+    asserts:
+      - contains:
+          path: spec.env
+          content:
+            name: SPLUNK_PROFILER_ENABLED
+            value: "false"
+      - contains:
+          path: spec.env
+          content:
+            name: SPLUNK_PROFILER_MEMORY_ENABLED
+            value: "false"
+      - notContains:
+          path: spec.env
+          content:
+            name: SPLUNK_PROFILER_ENABLED
+            value: "true"
+      - notContains:
+          path: spec.env
+          content:
+            name: SPLUNK_PROFILER_MEMORY_ENABLED
+            value: "true"

--- a/unittests/values/operator_customized.yaml
+++ b/unittests/values/operator_customized.yaml
@@ -2,7 +2,7 @@ clusterName: test-gateway
 splunkObservability:
   realm: test
   accessToken: test
-  # Should update instrumentation.env to include SPLUNK_PROFILER_ENABLED="true" and SPLUNK_PROFILER_MEMORY_ENABLED="true"
+  # Should update instrumentation.spec.env to include SPLUNK_PROFILER_ENABLED="true" and SPLUNK_PROFILER_MEMORY_ENABLED="true"
   profilingEnabled: true
 environment: test
 agent:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fixes two bugs in AlwaysOn Profiling chart configuration and updates related documentation.

- **Operator: Respect user-defined profiler env vars in `instrumentation.spec.env`**
  When `splunkObservability.profilingEnabled=true`, the chart auto-injects `SPLUNK_PROFILER_ENABLED=true` and
  `SPLUNK_PROFILER_MEMORY_ENABLED=true` into the Instrumentation CR. The dedup check that should skip injection
  when these vars are already defined was reading from a non-existent values path (`.Values.instrumentation.env`)
  instead of the correct path (`.Values.instrumentation.spec.env`). This caused user-defined overrides to be
  silently ignored - setting these to `"false"` in `instrumentation.spec.env` had no effect.
  
- **Gateway: Add `profiling` to OTLP port `enabled_for` lists**
  The gateway OTLP ports were missing `profiling` in their `enabled_for` lists. The gateway correctly configures `splunk_hec/o11y` with `profiling_data_enabled: true` when profiling is enabled, but the profiling signal alone could not enable the OTLP ports to receive that data.

