### PR TITLE
[chore] Add Target Allocator test

### DIFF
--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1002,7 +1002,7 @@ func testK8sObjects(t *testing.T) {
 
 func testTargetAllocator(t *testing.T) {
 	if !requiresPrometheusCRD(os.Getenv("KUBE_TEST_ENV")) {
-		t.Skip("skipping test as required Prometheus CRDs are not installed")
+		t.Fatalf("Required Prometheus CRDs are not installed")
 	}
 
 	testKubeConfig := requireEnv(t, "KUBECONFIG")
@@ -1017,6 +1017,7 @@ func testTargetAllocator(t *testing.T) {
 		taPodList, err = internal.GetPods(t, client, internal.DefaultNamespace, internal.TargetAllocatorLabelSelector)
 		assert.NoError(c, err)
 		containsReadyTAPod := false
+
 		for _, pod := range taPodList.Items {
 			if pod.Status.Phase != "Running" {
 				t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
@@ -1040,6 +1041,7 @@ func testTargetAllocator(t *testing.T) {
 		assert.NoError(c, err)
 		containsReadyAgentPod := false
 		var combinedPodLogs strings.Builder
+
 		for i, pod := range agentPodList.Items {
 			if pod.Status.Phase != "Running" {
 				t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1005,7 +1005,7 @@ func testTargetAllocator(t *testing.T) {
 			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
 			continue
 		}
-		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 100)
+		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
 		require.Contains(t, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
 	}
 

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1036,8 +1036,8 @@ func testTargetAllocator(t *testing.T) {
 		// Maybe combine logs from each pod and check at the end to make sure at least one has them?
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
 		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
-		require.Regexp(t, podLogs, regexp.MustCompile("Scrape job added.\\*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".\\*\\\"jobName\\\": \"serviceMonitor\\/default\\/prometheus-service-monitor\\/0\\\""), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-		require.Regexp(t, podLogs, regexp.MustCompile("Scrape job added.\\*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".\\*\\\"jobName\\\": \"podMonitor\\/default\\/pod-monitor\\/0\\\""), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Regexp(t, podLogs, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Regexp(t, podLogs, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
 
 		t.Logf("Agent pod logs: %s", podLogs)
 	}

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -679,7 +679,8 @@ func validateResourceAttributes(t *testing.T, clientset *kubernetes.Clientset, k
 		require.Failf(t, "failed to run validateResourceAttributes", "unknown role %q", role)
 	}
 
-	pods := internal.GetPods(t, clientset, internal.DefaultNamespace, labelSelector)
+	pods, err := internal.GetPods(t, clientset, internal.DefaultNamespace, labelSelector)
+	require.NoError(t, err)
 	require.NotEmpty(t, pods.Items, "no pods found for label %s", labelSelector)
 
 	podName := pods.Items[0].Name
@@ -1012,7 +1013,9 @@ func testTargetAllocator(t *testing.T) {
 
 	// check target allocator logs
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		taPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.TargetAllocatorLabelSelector)
+		var taPodList *corev1.PodList
+		taPodList, err = internal.GetPods(t, client, internal.DefaultNamespace, internal.TargetAllocatorLabelSelector)
+		assert.NoError(c, err)
 		containsReadyTAPod := false
 		for _, pod := range taPodList.Items {
 			if pod.Status.Phase != "Running" {
@@ -1020,7 +1023,9 @@ func testTargetAllocator(t *testing.T) {
 				continue
 			}
 			containsReadyTAPod = true
-			podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
+			var podLogs string
+			podLogs, err = internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
+			assert.NoError(c, err)
 			assert.Contains(c, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
 		}
 		assert.True(c, containsReadyTAPod, "No target allocator pod found ready")
@@ -1030,7 +1035,9 @@ func testTargetAllocator(t *testing.T) {
 	serviceMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`)
 	podMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		agentPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.AgentLabelSelector)
+		var agentPodList *corev1.PodList
+		agentPodList, err = internal.GetPods(t, client, internal.DefaultNamespace, internal.AgentLabelSelector)
+		assert.NoError(c, err)
 		containsReadyAgentPod := false
 		var combinedPodLogs strings.Builder
 		for i, pod := range agentPodList.Items {
@@ -1039,7 +1046,9 @@ func testTargetAllocator(t *testing.T) {
 				continue
 			}
 			containsReadyAgentPod = true
-			podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
+			var podLogs string
+			podLogs, err = internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
+			assert.NoError(c, err)
 			assert.Contains(c, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
 
 			if i > 0 {

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1007,6 +1007,7 @@ func testTargetAllocator(t *testing.T) {
 		}
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
 		require.Contains(t, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
+		t.Logf("Target allocator pod logs: %s", podLogs)
 	}
 
 	// check agent logs
@@ -1026,6 +1027,7 @@ func testTargetAllocator(t *testing.T) {
 		require.Contains(t, podLogs, "Scrape job added", "Collector failed to start scrape job. Received logs: %v", podLogs)
 		require.Contains(t, podLogs, "\"jobName\": \"serviceMonitor", "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
 		require.Contains(t, podLogs, "\"jobName\": \"podMonitor", "Collector failed to start scrape job for podMonitor. Received logs: %v", podLogs)
+		t.Logf("Agent pod logs: %s", podLogs)
 	}
 }
 

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1046,7 +1046,6 @@ func testTargetAllocator(t *testing.T) {
 				combinedPodLogs.WriteString("\n")
 			}
 			combinedPodLogs.WriteString(fmt.Sprintf("%v\n%v", pod.Name, podLogs))
-
 		}
 		assert.True(c, containsReadyAgentPod, "No OTel Collector agent pod found ready")
 		// NOTE: The target allocator distributes scrape jobs across agents when there are more than one.

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -114,6 +114,11 @@ func setupSinks(t *testing.T) {
 	}
 }
 
+func requiresPrometheusCRD(kubeTestEnv string) bool {
+	// ROSA forbids creation of Prometheus CRDs
+	return kubeTestEnv != rosaTestKubeEnv
+}
+
 func deployPrometheusResources(t *testing.T, extensionsClient *clientset.Clientset, dynamicClient dynamic.Interface) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
@@ -264,7 +269,9 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 	require.NoError(t, err)
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
-	deployPrometheusResources(t, extensionsClient, dynamicClient)
+	if requiresPrometheusCRD(kubeTestEnv) {
+		deployPrometheusResources(t, extensionsClient, dynamicClient)
+	}
 
 	var stream []byte
 	chartInfo := map[string]internal.ChartOptions{}
@@ -991,6 +998,12 @@ func testK8sObjects(t *testing.T) {
 }
 
 func testTargetAllocator(t *testing.T) {
+	kubeTestEnv, setKubeTestEnv := os.LookupEnv("KUBE_TEST_ENV")
+	require.True(t, setKubeTestEnv, "the environment variable KUBE_TEST_ENV must be set")
+	if !requiresPrometheusCRD(kubeTestEnv) {
+		t.Skip("Skipping test on ROSA - can't install required Prometheus CRDs")
+	}
+
 	testKubeConfig := requireEnv(t, "KUBECONFIG")
 	kubeConfig, err := clientcmd.BuildConfigFromFlags("", testKubeConfig)
 	require.NoError(t, err)
@@ -1024,8 +1037,8 @@ func testTargetAllocator(t *testing.T) {
 		// Maybe combine logs from each pod and check at the end to make sure at least one has them?
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
 		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
-		require.Contains(t, podLogs, "Scrape job added.*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".*\\\"jobName\\\": \"serviceMonitor\\/default\\/prometheus-service-monitor\\/0\\\"", "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-		require.Contains(t, podLogs, "Scrape job added.*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".*\\\"jobName\\\": \"podMonitor\\/default\\/pod-monitor\\/0\\\"", "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Regexp(t, podLogs, regexp.MustCompile("Scrape job added.*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".*\\\"jobName\\\": \"serviceMonitor\\/default\\/prometheus-service-monitor\\/0\\\""), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Regexp(t, podLogs, regexp.MustCompile("Scrape job added.*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".*\\\"jobName\\\": \"podMonitor\\/default\\/pod-monitor\\/0\\\""), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
 
 		t.Logf("Agent pod logs: %s", podLogs)
 	}

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -63,7 +63,6 @@ const (
 	gkeValuesDir                           = "expected_gke_values"
 	rosaValuesDir                          = "expected_rosa_values"
 	gceValuesDir                           = "expected_gce_values"
-	agentLabelSelector                     = "component=otel-collector-agent"
 	clusterReceiverLabelSelector           = "component=otel-k8s-cluster-receiver"
 	linuxPodMetricsPath                    = "/tmp/metrics.json"
 	winPodMetricsPath                      = "C:\\metrics.json"
@@ -113,10 +112,6 @@ func setupSinks(t *testing.T) {
 			signalFxReceiverK8sClusterReceiverPort),
 		tracesConsumer: internal.SetupOTLPTracesSink(t),
 	}
-}
-
-func requiresPrometheusCRD(kubeTestEnv string) bool {
-	return kubeTestEnv == kindTestKubeEnv
 }
 
 func deployPrometheusResources(t *testing.T, extensionsClient *clientset.Clientset, dynamicClient dynamic.Interface) {
@@ -269,9 +264,7 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 	require.NoError(t, err)
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
-	if requiresPrometheusCRD(kubeTestEnv) {
-		deployPrometheusResources(t, extensionsClient, dynamicClient)
-	}
+	deployPrometheusResources(t, extensionsClient, dynamicClient)
 
 	var stream []byte
 	chartInfo := map[string]internal.ChartOptions{}
@@ -514,9 +507,7 @@ func teardown(ctx context.Context, t *testing.T, testKubeConfig string) {
 		})
 	}
 
-	if requiresPrometheusCRD(os.Getenv("KUBE_TEST_ENV")) {
-		teardownPrometheusResources(ctx, t, extensionsClient)
-	}
+	teardownPrometheusResources(ctx, t, extensionsClient)
 
 	for _, nm := range namespaces {
 		nmClient := client.CoreV1().Namespaces()
@@ -587,6 +578,7 @@ func runLocalClusterTests(t *testing.T) {
 	t.Run("test HEC metrics", testHECMetrics)
 	t.Run("test k8s objects", testK8sObjects)
 	t.Run("test agent metrics", testAgentMetrics)
+	t.Run("test target allocator", testTargetAllocator)
 	// TODO: re-enable this test in 0.129.0 https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40788
 	// t.Run("test prometheus metrics", testPrometheusAnnotationMetrics)
 
@@ -598,7 +590,7 @@ func runLocalClusterTests(t *testing.T) {
 		client, err := kubernetes.NewForConfig(kubeConfig)
 		require.NoError(t, err)
 
-		internal.CheckComponentHealth(t, client, internal.DefaultNamespace, agentLabelSelector, kubeletstatsReceiverName)
+		internal.CheckComponentHealth(t, client, internal.DefaultNamespace, internal.AgentLabelSelector, kubeletstatsReceiverName)
 		internal.CheckComponentHealth(t, client, internal.DefaultNamespace, clusterReceiverLabelSelector, k8sClusterReceiverName)
 	})
 }
@@ -626,17 +618,17 @@ func runHostedClusterTests(t *testing.T, kubeTestEnv string) {
 
 		t.Run("component error logs checks", func(t *testing.T) {
 			if kubeTestEnv == eksTestKubeEnv {
-				internal.CheckComponentHealth(t, client, internal.DefaultNamespace, agentLabelSelector, journaldReceiverName)
+				internal.CheckComponentHealth(t, client, internal.DefaultNamespace, internal.AgentLabelSelector, journaldReceiverName)
 			}
-			internal.CheckComponentHealth(t, client, internal.DefaultNamespace, agentLabelSelector, kubeletstatsReceiverName)
+			internal.CheckComponentHealth(t, client, internal.DefaultNamespace, internal.AgentLabelSelector, kubeletstatsReceiverName)
 			internal.CheckComponentHealth(t, client, internal.DefaultNamespace, clusterReceiverLabelSelector, k8sClusterReceiverName)
 		})
 	case autopilotTestKubeEnv:
 		t.Run("component error logs checks", func(t *testing.T) {
-			internal.CheckPodsReady(t, client, internal.DefaultNamespace, agentLabelSelector, 3*time.Minute, 10*time.Second)
+			internal.CheckPodsReady(t, client, internal.DefaultNamespace, internal.AgentLabelSelector, 3*time.Minute, 10*time.Second)
 			internal.CheckPodsReady(t, client, internal.DefaultNamespace, clusterReceiverLabelSelector, 3*time.Minute, 10*time.Second)
 
-			internal.CheckComponentHealth(t, client, internal.DefaultNamespace, agentLabelSelector, kubeletstatsReceiverName)
+			internal.CheckComponentHealth(t, client, internal.DefaultNamespace, internal.AgentLabelSelector, kubeletstatsReceiverName)
 			internal.CheckComponentHealth(t, client, internal.DefaultNamespace, clusterReceiverLabelSelector, k8sClusterReceiverName)
 		})
 	default:
@@ -666,7 +658,7 @@ func validateResourceAttributes(t *testing.T, clientset *kubernetes.Clientset, k
 
 	switch role {
 	case roleAgent:
-		labelSelector = agentLabelSelector
+		labelSelector = internal.AgentLabelSelector
 		expectedResourceAttributesFile = filepath.Join(testDir, expectedValuesDir, "expected_resource_attributes_agent.yaml")
 	case roleClusterReceiver:
 		labelSelector = clusterReceiverLabelSelector
@@ -996,6 +988,45 @@ func testK8sObjects(t *testing.T) {
 
 	assert.True(t, foundCustomField1)
 	assert.True(t, foundCustomField2)
+}
+
+func testTargetAllocator(t *testing.T) {
+	testKubeConfig := requireEnv(t, "KUBECONFIG")
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", testKubeConfig)
+	require.NoError(t, err)
+	client, err := kubernetes.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+
+	// check target allocator logs
+	taPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.TargetAllocatorLabelSelector)
+	t.Logf("Target Allocator pod list has %v pods", len(taPodList.Items))
+	for _, pod := range taPodList.Items {
+		if pod.Status.Phase != "Running" {
+			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
+			continue
+		}
+		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 100)
+		require.Contains(t, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
+	}
+
+	// check agent logs
+	agentPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.AgentLabelSelector)
+	t.Logf("Agent pod list has %v pods", len(agentPodList.Items))
+	for _, pod := range agentPodList.Items {
+		if pod.Status.Phase != "Running" {
+			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
+			continue
+		}
+		// TODO: This might be an invalid test in some places since the target allocator spreads
+		// scrape jobs across pods. One pod might have a scrape job for serviceMonitor, the
+		// other has one for podMonitor.
+		// Maybe combine logs from each pod and check at the end to make sure at least one has them?
+		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
+		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
+		require.Contains(t, podLogs, "Scrape job added", "Collector failed to start scrape job. Received logs: %v", podLogs)
+		require.Contains(t, podLogs, "\"jobName\": \"serviceMonitor", "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Contains(t, podLogs, "\"jobName\": \"podMonitor", "Collector failed to start scrape job for podMonitor. Received logs: %v", podLogs)
+	}
 }
 
 // Internal telemetry metrics are only sent when an event occurs. Due to cluster

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -5,6 +5,7 @@ package functional
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1044,14 +1045,14 @@ func testTargetAllocator(t *testing.T) {
 			if i > 0 {
 				combinedPodLogs.WriteString("\n")
 			}
-			combinedPodLogs.WriteString(podLogs)
+			combinedPodLogs.WriteString(fmt.Sprintf("%v\n%v", pod.Name, podLogs))
 
 		}
 		assert.True(c, containsReadyAgentPod, "No OTel Collector agent pod found ready")
 		// NOTE: The target allocator distributes scrape jobs across agents when there are more than one.
 		// Compile all logs from agents first, then ensure that altogether they have the required logs.
 		assert.Regexp(c, serviceMonitorRegex, combinedPodLogs.String(), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", combinedPodLogs.String())
-		assert.Regexp(c, podMonitorRegex, combinedPodLogs.String(), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", combinedPodLogs.String())
+		assert.Regexp(c, podMonitorRegex, combinedPodLogs.String(), "Collector failed to start scrape job for podMonitor. Received logs: %v", combinedPodLogs.String())
 	}, 3*time.Minute, 3*time.Second, "Failed to find required agent pod logs")
 }
 

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1024,9 +1024,9 @@ func testTargetAllocator(t *testing.T) {
 		// Maybe combine logs from each pod and check at the end to make sure at least one has them?
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
 		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
-		require.Contains(t, podLogs, "Scrape job added", "Collector failed to start scrape job. Received logs: %v", podLogs)
-		require.Contains(t, podLogs, "\"jobName\": \"serviceMonitor", "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-		require.Contains(t, podLogs, "\"jobName\": \"podMonitor", "Collector failed to start scrape job for podMonitor. Received logs: %v", podLogs)
+		require.Contains(t, podLogs, "Scrape job added.*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".*\\\"jobName\\\": \"serviceMonitor\\/default\\/prometheus-service-monitor\\/0\\\"", "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Contains(t, podLogs, "Scrape job added.*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".*\\\"jobName\\\": \"podMonitor\\/default\\/pod-monitor\\/0\\\"", "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+
 		t.Logf("Agent pod logs: %s", podLogs)
 	}
 }

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -115,8 +115,7 @@ func setupSinks(t *testing.T) {
 }
 
 func requiresPrometheusCRD(kubeTestEnv string) bool {
-	// ROSA forbids creation of Prometheus CRDs
-	return kubeTestEnv != rosaTestKubeEnv
+	return kubeTestEnv == kindTestKubeEnv
 }
 
 func deployPrometheusResources(t *testing.T, extensionsClient *clientset.Clientset, dynamicClient dynamic.Interface) {
@@ -514,7 +513,9 @@ func teardown(ctx context.Context, t *testing.T, testKubeConfig string) {
 		})
 	}
 
-	teardownPrometheusResources(ctx, t, extensionsClient)
+	if requiresPrometheusCRD(os.Getenv("KUBE_TEST_ENV")) {
+		teardownPrometheusResources(ctx, t, extensionsClient)
+	}
 
 	for _, nm := range namespaces {
 		nmClient := client.CoreV1().Namespaces()
@@ -998,10 +999,8 @@ func testK8sObjects(t *testing.T) {
 }
 
 func testTargetAllocator(t *testing.T) {
-	kubeTestEnv, setKubeTestEnv := os.LookupEnv("KUBE_TEST_ENV")
-	require.True(t, setKubeTestEnv, "the environment variable KUBE_TEST_ENV must be set")
-	if !requiresPrometheusCRD(kubeTestEnv) {
-		t.Skip("Skipping test on ROSA - can't install required Prometheus CRDs")
+	if !requiresPrometheusCRD(os.Getenv("KUBE_TEST_ENV")) {
+		t.Skip("skipping test as required Prometheus CRDs are not installed")
 	}
 
 	testKubeConfig := requireEnv(t, "KUBECONFIG")
@@ -1037,8 +1036,8 @@ func testTargetAllocator(t *testing.T) {
 		// Maybe combine logs from each pod and check at the end to make sure at least one has them?
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
 		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
-		require.Regexp(t, podLogs, regexp.MustCompile("Scrape job added.*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".*\\\"jobName\\\": \"serviceMonitor\\/default\\/prometheus-service-monitor\\/0\\\""), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-		require.Regexp(t, podLogs, regexp.MustCompile("Scrape job added.*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".*\\\"jobName\\\": \"podMonitor\\/default\\/pod-monitor\\/0\\\""), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Regexp(t, podLogs, regexp.MustCompile("Scrape job added.\\*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".\\*\\\"jobName\\\": \"serviceMonitor\\/default\\/prometheus-service-monitor\\/0\\\""), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Regexp(t, podLogs, regexp.MustCompile("Scrape job added.\\*\\\"otelcol\\.component\\.id\\\": \\\"prometheus\\/ta\\\".\\*\\\"jobName\\\": \"podMonitor\\/default\\/pod-monitor\\/0\\\""), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
 
 		t.Logf("Agent pod logs: %s", podLogs)
 	}

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1010,42 +1010,45 @@ func testTargetAllocator(t *testing.T) {
 	require.NoError(t, err)
 
 	// check target allocator logs
-	taPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.TargetAllocatorLabelSelector)
-	containsReadyTAPod := false
-	for _, pod := range taPodList.Items {
-		if pod.Status.Phase != "Running" {
-			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
-			continue
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		taPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.TargetAllocatorLabelSelector)
+		containsReadyTAPod := false
+		for _, pod := range taPodList.Items {
+			if pod.Status.Phase != "Running" {
+				t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
+				continue
+			}
+			containsReadyTAPod = true
+			podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
+			require.Contains(c, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
 		}
-		containsReadyTAPod = true
-		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
-		require.Contains(t, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
-	}
-	require.True(t, containsReadyTAPod, "No target allocator pod found ready")
+		require.True(c, containsReadyTAPod, "No target allocator pod found ready")
+	}, 3*time.Minute, 3*time.Second, "Failed to find required target allocator pod logs")
 
 	// check agent logs
-	agentPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.AgentLabelSelector)
-	containsReadyAgentPod := false
-	for _, pod := range agentPodList.Items {
-		if pod.Status.Phase != "Running" {
-			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
-			continue
-		}
-		containsReadyAgentPod = true
-		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
-		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
-
-		// NOTE: These tests may eventually fail due to bigger test clusters. If this happens,
-		// consider combining all agent logs into one big string, then do the scrape job check,
-		// as one agent may have logs for the pod monitor scrape job, another may have been
-		// given the service monitor scrape target.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		agentPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.AgentLabelSelector)
+		containsReadyAgentPod := false
 		serviceMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`)
-		require.Regexp(t, serviceMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-
 		podMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`)
-		require.Regexp(t, podMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-	}
-	require.True(t, containsReadyAgentPod, "No OTel Collector agent pod found ready")
+		for _, pod := range agentPodList.Items {
+			if pod.Status.Phase != "Running" {
+				t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
+				continue
+			}
+			containsReadyAgentPod = true
+			podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
+			require.Contains(c, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
+
+			// NOTE: These tests may eventually fail due to bigger test clusters. If this happens,
+			// consider combining all agent logs into one big string, then do the scrape job check,
+			// as one agent may have logs for the pod monitor scrape job, another may have been
+			// given the service monitor scrape target.
+			require.Regexp(c, serviceMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+			require.Regexp(c, podMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		}
+		require.True(c, containsReadyAgentPod, "No OTel Collector agent pod found ready")
+	}, 3*time.Minute, 3*time.Second, "Failed to find required agent pod logs")
 }
 
 // Internal telemetry metrics are only sent when an event occurs. Due to cluster

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1020,34 +1020,38 @@ func testTargetAllocator(t *testing.T) {
 			}
 			containsReadyTAPod = true
 			podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
-			require.Contains(c, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
+			assert.Contains(c, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
 		}
-		require.True(c, containsReadyTAPod, "No target allocator pod found ready")
+		assert.True(c, containsReadyTAPod, "No target allocator pod found ready")
 	}, 3*time.Minute, 3*time.Second, "Failed to find required target allocator pod logs")
 
 	// check agent logs
+	serviceMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`)
+	podMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		agentPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.AgentLabelSelector)
 		containsReadyAgentPod := false
-		serviceMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`)
-		podMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`)
-		for _, pod := range agentPodList.Items {
+		var combinedPodLogs strings.Builder
+		for i, pod := range agentPodList.Items {
 			if pod.Status.Phase != "Running" {
 				t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
 				continue
 			}
 			containsReadyAgentPod = true
 			podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
-			require.Contains(c, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
+			assert.Contains(c, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
 
-			// NOTE: These tests may eventually fail due to bigger test clusters. If this happens,
-			// consider combining all agent logs into one big string, then do the scrape job check,
-			// as one agent may have logs for the pod monitor scrape job, another may have been
-			// given the service monitor scrape target.
-			require.Regexp(c, serviceMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-			require.Regexp(c, podMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+			if i > 0 {
+				combinedPodLogs.WriteString("\n")
+			}
+			combinedPodLogs.WriteString(podLogs)
+
 		}
-		require.True(c, containsReadyAgentPod, "No OTel Collector agent pod found ready")
+		assert.True(c, containsReadyAgentPod, "No OTel Collector agent pod found ready")
+		// NOTE: The target allocator distributes scrape jobs across agents when there are more than one.
+		// Compile all logs from agents first, then ensure that altogether they have the required logs.
+		assert.Regexp(c, serviceMonitorRegex, combinedPodLogs.String(), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", combinedPodLogs.String())
+		assert.Regexp(c, podMonitorRegex, combinedPodLogs.String(), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", combinedPodLogs.String())
 	}, 3*time.Minute, 3*time.Second, "Failed to find required agent pod logs")
 }
 

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1011,22 +1011,27 @@ func testTargetAllocator(t *testing.T) {
 
 	// check target allocator logs
 	taPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.TargetAllocatorLabelSelector)
+	containsReadyTAPod := false
 	for _, pod := range taPodList.Items {
 		if pod.Status.Phase != "Running" {
 			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
 			continue
 		}
+		containsReadyTAPod = true
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
 		require.Contains(t, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
 	}
+	require.True(t, containsReadyTAPod, "No target allocator pod found ready")
 
 	// check agent logs
 	agentPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.AgentLabelSelector)
+	containsReadyAgentPod := false
 	for _, pod := range agentPodList.Items {
 		if pod.Status.Phase != "Running" {
 			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
 			continue
 		}
+		containsReadyAgentPod = true
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
 		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
 
@@ -1040,6 +1045,7 @@ func testTargetAllocator(t *testing.T) {
 		podMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`)
 		require.Regexp(t, podMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
 	}
+	require.True(t, containsReadyAgentPod, "No OTel Collector agent pod found ready")
 }
 
 // Internal telemetry metrics are only sent when an event occurs. Due to cluster

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1027,14 +1027,18 @@ func testTargetAllocator(t *testing.T) {
 			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
 			continue
 		}
+		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
+		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
+
 		// NOTE: These tests may eventually fail due to bigger test clusters. If this happens,
 		// consider combining all agent logs into one big string, then do the scrape job check,
 		// as one agent may have logs for the pod monitor scrape job, another may have been
 		// given the service monitor scrape target.
-		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
-		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
-		require.Regexp(t, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`), podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-		require.Regexp(t, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`), podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		serviceMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`)
+		require.Regexp(t, serviceMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+
+		podMonitorRegex := regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`)
+		require.Regexp(t, podMonitorRegex, podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
 	}
 }
 

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1011,7 +1011,6 @@ func testTargetAllocator(t *testing.T) {
 
 	// check target allocator logs
 	taPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.TargetAllocatorLabelSelector)
-	t.Logf("Target Allocator pod list has %v pods", len(taPodList.Items))
 	for _, pod := range taPodList.Items {
 		if pod.Status.Phase != "Running" {
 			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
@@ -1019,27 +1018,23 @@ func testTargetAllocator(t *testing.T) {
 		}
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.TargetAllocatorContainerName, 100)
 		require.Contains(t, podLogs, "Service Discovery watch event received", "Target allocator pod logs failed to successfully discover targets. Received logs: %v", podLogs)
-		t.Logf("Target allocator pod logs: %s", podLogs)
 	}
 
 	// check agent logs
 	agentPodList := internal.GetPods(t, client, internal.DefaultNamespace, internal.AgentLabelSelector)
-	t.Logf("Agent pod list has %v pods", len(agentPodList.Items))
 	for _, pod := range agentPodList.Items {
 		if pod.Status.Phase != "Running" {
 			t.Logf("Skipping pod %s in phase %s", pod.Name, pod.Status.Phase)
 			continue
 		}
-		// TODO: This might be an invalid test in some places since the target allocator spreads
-		// scrape jobs across pods. One pod might have a scrape job for serviceMonitor, the
-		// other has one for podMonitor.
-		// Maybe combine logs from each pod and check at the end to make sure at least one has them?
+		// NOTE: These tests may eventually fail due to bigger test clusters. If this happens,
+		// consider combining all agent logs into one big string, then do the scrape job check,
+		// as one agent may have logs for the pod monitor scrape job, another may have been
+		// given the service monitor scrape target.
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
 		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
 		require.Regexp(t, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`), podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
 		require.Regexp(t, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`), podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-
-		t.Logf("Agent pod logs: %s", podLogs)
 	}
 }
 

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -1036,8 +1036,8 @@ func testTargetAllocator(t *testing.T) {
 		// Maybe combine logs from each pod and check at the end to make sure at least one has them?
 		podLogs := internal.GetPodLogs(t, client, internal.DefaultNamespace, pod.Name, internal.CollectorContainerName, 500)
 		require.Contains(t, podLogs, "Starting target allocator discovery", "Collector failed to start target allocator discovery. Received logs: %v", podLogs)
-		require.Regexp(t, podLogs, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
-		require.Regexp(t, podLogs, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`), "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Regexp(t, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "serviceMonitor/default/prometheus-service-monitor/0"`), podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
+		require.Regexp(t, regexp.MustCompile(`Scrape job added.*"otelcol\.component\.id": "prometheus/ta.*"jobName": "podMonitor/default/pod-monitor/0"`), podLogs, "Collector failed to start scrape job for serviceMonitor. Received logs: %v", podLogs)
 
 		t.Logf("Agent pod logs: %s", podLogs)
 	}

--- a/functional_tests/instrumentation_cr/instrumentation_cr_test.go
+++ b/functional_tests/instrumentation_cr/instrumentation_cr_test.go
@@ -376,7 +376,8 @@ func assertInjectionWorks(t *testing.T, cs *kubernetes.Clientset, label string) 
 	})
 
 	t.Run("injection: OTEL env vars present ("+label+")", func(t *testing.T) {
-		pods := internal.GetPods(t, cs, internal.DefaultNamespace, "app="+testDeploymentName)
+		pods, err := internal.GetPods(t, cs, internal.DefaultNamespace, "app="+testDeploymentName)
+		require.NoError(t, err)
 		require.NotEmpty(t, pods.Items)
 		pod := pods.Items[0]
 		assert.True(t, hasEnvVar(pod, "app", "JAVA_TOOL_OPTIONS"),

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -18,6 +18,7 @@ import (
 	docker "github.com/moby/moby/client"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 	k8stest "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -283,7 +284,7 @@ func GetPodLogs(t *testing.T, clientset *kubernetes.Clientset, namespace, podNam
 			t.Logf("Attempt %d/%d failed to get logs from pod %s: %v, retrying...", attempt+1, maxRetries, podName, err)
 			time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
 		} else {
-			require.NoError(t, err, "error getting logs from pod %s in namespace %s after %d attempts", podName, namespace, maxRetries)
+			assert.NoError(t, err, "error getting logs from pod %s in namespace %s after %d attempts", podName, namespace, maxRetries)
 		}
 	}
 	return ""
@@ -319,7 +320,7 @@ func GetPods(t *testing.T, clientset *kubernetes.Clientset, namespace, labelSele
 	pods, err := clientset.CoreV1().Pods(namespace).List(t.Context(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
-	require.NoError(t, err, "failed to list pods in namespace %s with label selector %s", namespace, labelSelector)
+	assert.NoError(t, err, "failed to list pods in namespace %s with label selector %s", namespace, labelSelector)
 	return pods
 }
 

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -18,7 +18,6 @@ import (
 	docker "github.com/moby/moby/client"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 	k8stest "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -267,7 +266,7 @@ func CopyFileFromPod(t *testing.T, clientset *kubernetes.Clientset, config *rest
 	require.NoError(t, err, "failed to stream file %s from pod", podFilePath)
 }
 
-func GetPodLogs(t *testing.T, clientset *kubernetes.Clientset, namespace, podName, containerName string, tailLines int64) string {
+func GetPodLogs(t *testing.T, clientset *kubernetes.Clientset, namespace, podName, containerName string, tailLines int64) (string, error) {
 	podLogOptions := v1.PodLogOptions{
 		Container: containerName,
 		Follow:    false,
@@ -275,19 +274,19 @@ func GetPodLogs(t *testing.T, clientset *kubernetes.Clientset, namespace, podNam
 	}
 
 	const maxRetries = 3
+	var err error
 	for attempt := range maxRetries {
-		logs, err := tryGetPodLogs(t, clientset, namespace, podName, &podLogOptions)
+		var logs string
+		logs, err = tryGetPodLogs(t, clientset, namespace, podName, &podLogOptions)
 		if err == nil {
-			return logs
+			return logs, nil
 		}
 		if attempt < maxRetries-1 {
 			t.Logf("Attempt %d/%d failed to get logs from pod %s: %v, retrying...", attempt+1, maxRetries, podName, err)
 			time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
-		} else {
-			assert.NoError(t, err, "error getting logs from pod %s in namespace %s after %d attempts", podName, namespace, maxRetries)
 		}
 	}
-	return ""
+	return "", err
 }
 
 func tryGetPodLogs(t *testing.T, clientset *kubernetes.Clientset, namespace, podName string, opts *v1.PodLogOptions) (string, error) {
@@ -316,12 +315,10 @@ func tryGetPodLogs(t *testing.T, clientset *kubernetes.Clientset, namespace, pod
 	return sb.String(), nil
 }
 
-func GetPods(t *testing.T, clientset *kubernetes.Clientset, namespace, labelSelector string) *v1.PodList {
-	pods, err := clientset.CoreV1().Pods(namespace).List(t.Context(), metav1.ListOptions{
+func GetPods(t *testing.T, clientset *kubernetes.Clientset, namespace, labelSelector string) (*v1.PodList, error) {
+	return clientset.CoreV1().Pods(namespace).List(t.Context(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
-	assert.NoError(t, err, "failed to list pods in namespace %s with label selector %s", namespace, labelSelector)
-	return pods
 }
 
 func CheckPodsReady(t *testing.T, clientset *kubernetes.Clientset, namespace, labelSelector string,

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -38,8 +38,12 @@ import (
 var DefaultNamespace = "default"
 
 const (
-	maxHistogramBucketCount = 32
-	waitTimeout             = 3 * time.Minute
+	AgentLabelSelector           = "component=otel-collector-agent"
+	CollectorContainerName       = "otel-collector"
+	maxHistogramBucketCount      = 32
+	TargetAllocatorContainerName = "targetallocator"
+	TargetAllocatorLabelSelector = "app=targetAllocator"
+	waitTimeout                  = 3 * time.Minute
 )
 
 func HostEndpoint(t *testing.T) string {

--- a/functional_tests/internal/component_health.go
+++ b/functional_tests/internal/component_health.go
@@ -46,8 +46,9 @@ func CheckComponentHealth(t *testing.T, clientset *kubernetes.Clientset, namespa
 
 		t.Logf("Checking logs for pod: %s, container: %s", pod.Name, CollectorContainerName)
 
-		logs := GetPodLogs(t, clientset, namespace, pod.Name, CollectorContainerName, 500)
-
+		var logs string
+		logs, err = GetPodLogs(t, clientset, namespace, pod.Name, CollectorContainerName, 500)
+		require.NoError(t, err, "failed to get logs for pod: %s", pod.Name)
 		// Debug: count total error lines and lines mentioning the component
 		totalLines := len(strings.Split(logs, "\n"))
 		errorCount := strings.Count(strings.ToLower(logs), "\terror\t")

--- a/functional_tests/internal/component_health.go
+++ b/functional_tests/internal/component_health.go
@@ -32,22 +32,21 @@ func CheckComponentHealth(t *testing.T, clientset *kubernetes.Clientset, namespa
 			continue
 		}
 
-		containerName := "otel-collector"
 		found := false
 		for _, container := range pod.Spec.Containers {
-			if container.Name == containerName {
+			if container.Name == CollectorContainerName {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Logf("Skipping pod %s - no container named %s", pod.Name, containerName)
+			t.Logf("Skipping pod %s - no container named %s", pod.Name, CollectorContainerName)
 			continue
 		}
 
-		t.Logf("Checking logs for pod: %s, container: %s", pod.Name, containerName)
+		t.Logf("Checking logs for pod: %s, container: %s", pod.Name, CollectorContainerName)
 
-		logs := GetPodLogs(t, clientset, namespace, pod.Name, containerName, 500)
+		logs := GetPodLogs(t, clientset, namespace, pod.Name, CollectorContainerName, 500)
 
 		// Debug: count total error lines and lines mentioning the component
 		totalLines := len(strings.Split(logs, "\n"))

--- a/functional_tests/logs/no_drop_logs_test.go
+++ b/functional_tests/logs/no_drop_logs_test.go
@@ -64,7 +64,7 @@ func Test_NoDropLogs(t *testing.T) {
 	// This can be verified by matching the number of log records to the test log file line count
 	t.Run("NoDropLogs", func(t *testing.T) {
 		time.Sleep(10 * time.Second)
-		podLogs := internal.GetPodLogs(t, clientset, internal.DefaultNamespace, podName, internal.TargetAllocatorContainerName, 100)
+		podLogs := internal.GetPodLogs(t, clientset, internal.DefaultNamespace, podName, internal.CollectorContainerName, 100)
 		require.Contains(t, podLogs, "Exporting failed. Rejecting data.", "expected log message not found in pod logs")
 
 		logsConsumer := internal.SetupHECLogsSink(t)

--- a/functional_tests/logs/no_drop_logs_test.go
+++ b/functional_tests/logs/no_drop_logs_test.go
@@ -64,7 +64,9 @@ func Test_NoDropLogs(t *testing.T) {
 	// This can be verified by matching the number of log records to the test log file line count
 	t.Run("NoDropLogs", func(t *testing.T) {
 		time.Sleep(10 * time.Second)
-		podLogs := internal.GetPodLogs(t, clientset, internal.DefaultNamespace, podName, internal.CollectorContainerName, 100)
+		var podLogs string
+		podLogs, err = internal.GetPodLogs(t, clientset, internal.DefaultNamespace, podName, internal.CollectorContainerName, 100)
+		require.NoError(t, err, "failed to get logs for pod: %s", podName)
 		require.Contains(t, podLogs, "Exporting failed. Rejecting data.", "expected log message not found in pod logs")
 
 		logsConsumer := internal.SetupHECLogsSink(t)
@@ -104,7 +106,8 @@ func deployChart(t *testing.T, testKubeConfig string, clientset *kubernetes.Clie
 
 func deployTestLogToPod(t *testing.T, clientset *kubernetes.Clientset, config *rest.Config) {
 	// log file is copied to only one randomly selected pod, and we need to remember the pod name for later log retrieval
-	pods := internal.GetPods(t, clientset, internal.DefaultNamespace, internal.AgentLabelSelector)
+	pods, err := internal.GetPods(t, clientset, internal.DefaultNamespace, internal.AgentLabelSelector)
+	require.NoError(t, err)
 	if len(pods.Items) == 0 {
 		require.Failf(t, "no pods found for label %s", internal.AgentLabelSelector)
 	}

--- a/functional_tests/logs/no_drop_logs_test.go
+++ b/functional_tests/logs/no_drop_logs_test.go
@@ -22,8 +22,6 @@ const (
 	testDir            = "testdata"
 	remoteTestFile     = "/tmp/temp-log-test/test.log"
 	valuesTemplateFile = "no_drop_logs_values.yaml.tmpl"
-	containerName      = "otel-collector"
-	podLabelSelector   = "component=otel-collector-agent"
 )
 
 var podName string
@@ -66,7 +64,7 @@ func Test_NoDropLogs(t *testing.T) {
 	// This can be verified by matching the number of log records to the test log file line count
 	t.Run("NoDropLogs", func(t *testing.T) {
 		time.Sleep(10 * time.Second)
-		podLogs := internal.GetPodLogs(t, clientset, internal.DefaultNamespace, podName, containerName, 100)
+		podLogs := internal.GetPodLogs(t, clientset, internal.DefaultNamespace, podName, internal.TargetAllocatorContainerName, 100)
 		require.Contains(t, podLogs, "Exporting failed. Rejecting data.", "expected log message not found in pod logs")
 
 		logsConsumer := internal.SetupHECLogsSink(t)
@@ -93,7 +91,7 @@ func deployChart(t *testing.T, testKubeConfig string, clientset *kubernetes.Clie
 	}
 	internal.ChartInstallOrUpgrade(t, testKubeConfig, valuesFile, replacements, 0, internal.GetDefaultChartOptions())
 
-	internal.CheckPodsReady(t, clientset, internal.DefaultNamespace, podLabelSelector, 3*time.Minute, 5*time.Second)
+	internal.CheckPodsReady(t, clientset, internal.DefaultNamespace, internal.AgentLabelSelector, 3*time.Minute, 5*time.Second)
 
 	t.Cleanup(func() {
 		if os.Getenv("SKIP_TEARDOWN") == "true" {
@@ -106,14 +104,14 @@ func deployChart(t *testing.T, testKubeConfig string, clientset *kubernetes.Clie
 
 func deployTestLogToPod(t *testing.T, clientset *kubernetes.Clientset, config *rest.Config) {
 	// log file is copied to only one randomly selected pod, and we need to remember the pod name for later log retrieval
-	pods := internal.GetPods(t, clientset, internal.DefaultNamespace, podLabelSelector)
+	pods := internal.GetPods(t, clientset, internal.DefaultNamespace, internal.AgentLabelSelector)
 	if len(pods.Items) == 0 {
-		require.Failf(t, "no pods found for label %s", podLabelSelector)
+		require.Failf(t, "no pods found for label %s", internal.AgentLabelSelector)
 	}
 	podName = pods.Items[0].Name
 	testLogFile, err := filepath.Abs(filepath.Join(testDir, testFile))
 	require.NoError(t, err)
-	internal.CopyFileToPod(t, clientset, config, internal.DefaultNamespace, podName, containerName, testLogFile, remoteTestFile)
+	internal.CopyFileToPod(t, clientset, config, internal.DefaultNamespace, podName, internal.CollectorContainerName, testLogFile, remoteTestFile)
 }
 
 func teardown(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Three main changes:
- Add target allocator test. This tests the target allocator logs to ensure it correctly finishes service discovery, checks collector agent logs to ensure the scrape jobs are correctly picked up from the target allocator.
- Move local test constants to central location to be re-used across test packages.
- `GetPods` and `GetPodLogs` now return errors to let callers handle them on their own. This allows `require.EventuallyWithT` to call these functions without hiding errors from `require`.