### PR TITLE
Remove resourcedetector from cluster receiver event/object

### DIFF
--- a/.chloggen/fix-cluster-receiver-event-resourcedetection.yaml
+++ b/.chloggen/fix-cluster-receiver-event-resourcedetection.yaml
@@ -5,7 +5,7 @@ component: clusterReceiver
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Remove resourcedetection processor from cluster-scoped event and object pipelines
 # One or more tracking issues related to the change
-issues: []
+issues: [2369]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/.chloggen/fix-cluster-receiver-event-resourcedetection.yaml
+++ b/.chloggen/fix-cluster-receiver-event-resourcedetection.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove resourcedetection processor from cluster-scoped event and object pipelines
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The cluster receiver's `logs` (k8s_events), `logs/objects`, and `logs/events` pipelines
+  incorrectly used the full `resourcedetection` processor, which added host and
+  cloud-provider attributes (host.id, host.name, cloud.provider, cloud.platform,
+  cloud.account.id, cloud.region, etc.) to cluster-scoped data. These attributes reflected
+  the cluster receiver pod rather than the source of the event or object, making them
+  misleading.

--- a/.chloggen/fix-cluster-receiver-event-resourcedetection.yaml
+++ b/.chloggen/fix-cluster-receiver-event-resourcedetection.yaml
@@ -11,8 +11,8 @@ issues: [2369]
 # Use pipe (|) for multiline entries.
 subtext: |
   The cluster receiver's `logs` (k8s_events), `logs/objects`, and `logs/events` pipelines
-  incorrectly used the full `resourcedetection` processor, which added host and
+  previously used the `resourcedetection` processor, which added host and
   cloud-provider attributes (host.id, host.name, cloud.provider, cloud.platform,
-  cloud.account.id, cloud.region, etc.) to cluster-scoped data. These attributes reflected
-  the cluster receiver pod rather than the source of the event or object, making them
-  misleading.
+  cloud.account.id, cloud.region, etc.) from the cluster receiver pod itself.
+  These pipelines now only add `k8s.cluster.name`. The Splunk HEC `host` field for these pipelines
+  is now set to the node name of the cluster receiver pod.

--- a/.chloggen/fix-cluster-receiver-event-resourcedetection.yaml
+++ b/.chloggen/fix-cluster-receiver-event-resourcedetection.yaml
@@ -14,5 +14,7 @@ subtext: |
   previously used the `resourcedetection` processor, which added host and
   cloud-provider attributes (host.id, host.name, cloud.provider, cloud.platform,
   cloud.account.id, cloud.region, etc.) from the cluster receiver pod itself.
-  These pipelines now only add `k8s.cluster.name`. The Splunk HEC `host` field for these pipelines
-  is now set to the node name of the cluster receiver pod.
+  These host-level attributes were misleading because cluster-scoped events and objects are not
+  tied to any single host; they should reflect the cluster. These pipelines now only add `k8s.cluster.name`.
+  A `host.name` resource attribute is still set to the node name of the cluster receiver pod (`K8S_NODE_NAME`)
+  for use as the Splunk HEC `host` field.

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -214,7 +214,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -225,7 +224,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -73,6 +73,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -215,6 +220,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -225,6 +231,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
-=======
-        checksum/config: 91e0732f5343ed0d0841ff7d7e5ddcb721f9e625f74cf1ba167d19c821a70ec1
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 6f163b6817dc03250b5a981bc8a5c866c109dbec48d24eb0a1ed2b93e61670d7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
+=======
+        checksum/config: 91e0732f5343ed0d0841ff7d7e5ddcb721f9e625f74cf1ba167d19c821a70ec1
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -214,7 +214,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -225,7 +224,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -73,6 +73,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -215,6 +220,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -225,6 +231,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,15 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-<<<<<<< HEAD
-        checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
-=======
-        checksum/config: 118312ee496d5219fa804f491b74f1117654ab57a2fe27297bf9247f695cc361
->>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
-=======
-        checksum/config: 91e0732f5343ed0d0841ff7d7e5ddcb721f9e625f74cf1ba167d19c821a70ec1
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 6f163b6817dc03250b5a981bc8a5c866c109dbec48d24eb0a1ed2b93e61670d7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,10 +31,14 @@ spec:
         release: default
       annotations:
 <<<<<<< HEAD
+<<<<<<< HEAD
         checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
 =======
         checksum/config: 118312ee496d5219fa804f491b74f1117654ab57a2fe27297bf9247f695cc361
 >>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
+=======
+        checksum/config: 91e0732f5343ed0d0841ff7d7e5ddcb721f9e625f74cf1ba167d19c821a70ec1
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
+=======
+        checksum/config: 118312ee496d5219fa804f491b74f1117654ab57a2fe27297bf9247f695cc361
+>>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -214,7 +214,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -225,7 +224,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -73,6 +73,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -215,6 +220,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -225,6 +231,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,15 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-<<<<<<< HEAD
-<<<<<<< HEAD
-        checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
-=======
-        checksum/config: 118312ee496d5219fa804f491b74f1117654ab57a2fe27297bf9247f695cc361
->>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
-=======
-        checksum/config: 91e0732f5343ed0d0841ff7d7e5ddcb721f9e625f74cf1ba167d19c821a70ec1
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 6f163b6817dc03250b5a981bc8a5c866c109dbec48d24eb0a1ed2b93e61670d7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,10 +32,14 @@ spec:
         sidecar.istio.io/inject: "false"
       annotations:
 <<<<<<< HEAD
+<<<<<<< HEAD
         checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
 =======
         checksum/config: 118312ee496d5219fa804f491b74f1117654ab57a2fe27297bf9247f695cc361
 >>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
+=======
+        checksum/config: 91e0732f5343ed0d0841ff7d7e5ddcb721f9e625f74cf1ba167d19c821a70ec1
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,11 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
+<<<<<<< HEAD
         checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
+=======
+        checksum/config: 118312ee496d5219fa804f491b74f1117654ab57a2fe27297bf9247f695cc361
+>>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -197,7 +197,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -208,7 +207,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -67,6 +67,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -198,6 +203,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -208,6 +214,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3c8bfbaef0e370af46815f8b0c97b8f5eb975ce0fa9ec9e4e0dbc20a5595566e
+        checksum/config: 71dc6bba9311209202046105ffc343a8f32b220553e6bb3f957a5a33c4cdba0d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dd1ac235b3863cfbc19315c2f94e3bc2a2a673426be03bd7f9f97472f0d90919
+        checksum/config: 3c8bfbaef0e370af46815f8b0c97b8f5eb975ce0fa9ec9e4e0dbc20a5595566e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -251,7 +251,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -262,7 +261,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -128,6 +128,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -252,6 +257,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -262,6 +268,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a43f51b7d4636ef393b8b4ad8d0cb42f382784c99ff1d5f30f2d72d7fdf6c475
+        checksum/config: c53920a8f28bbefc746b0d7582379ded51ca043f827d0d03df2917df43271c75
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c53920a8f28bbefc746b0d7582379ded51ca043f827d0d03df2917df43271c75
+        checksum/config: fae159f9a646ebd3b880c6607b1294a551461f06e73dfb1582103727fa75f38a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: ccb5f6aa4db8d802f8c3b70f2ccffd673bf61695d3607dbe06930ba773cbfcab
+=======
+        checksum/config: a06a386be703dfeff6b7956e9a798c253eed5a025da1f4d02f7f9f1860f32b45
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: ccb5f6aa4db8d802f8c3b70f2ccffd673bf61695d3607dbe06930ba773cbfcab
-=======
-        checksum/config: a06a386be703dfeff6b7956e9a798c253eed5a025da1f4d02f7f9f1860f32b45
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 157393db1a06073f7ae41f03a7d1bf55769d7827cf12ef1b8940de18a942d771
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
@@ -44,6 +44,11 @@ data:
         - action: insert
           key: metric_source
           value: kubernetes
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: 5afb581cfc55b75fc1272ea5bc1d356bddaa1e1082ba6fdfa8f1963b75820afa
-=======
-        checksum/config: 6a06570fa4ee0c72e7f95781ba4d316a1831806b1f776786589d97c460df186a
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 380720d3803166a559f80e01f78542ee57be45d423514dff5f3c2a6025a2a2d7
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: 5afb581cfc55b75fc1272ea5bc1d356bddaa1e1082ba6fdfa8f1963b75820afa
+=======
+        checksum/config: 6a06570fa4ee0c72e7f95781ba4d316a1831806b1f776786589d97c460df186a
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -49,6 +49,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,11 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: 687ff4e7b5b1257d9ba79d67425d34e88266cbd6e1b0ea4a377bb215f94408a3
-=======
-        checksum/config: 2afecee722f5cd8e047fc07fcc040806fd22246ef329b5d7cda3291ec6a2d3dd
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 0ff78a0171fb00e9ded4e7a82b3bb62f7e4207929d2600b95341e709415c5cb5
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: 687ff4e7b5b1257d9ba79d67425d34e88266cbd6e1b0ea4a377bb215f94408a3
+=======
+        checksum/config: 2afecee722f5cd8e047fc07fcc040806fd22246ef329b5d7cda3291ec6a2d3dd
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -47,6 +47,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: 7e2fbd17fe8d3dd3d129fe9ce0e66b22b4e894efe1d73ad3386edecf1dd0e679
+=======
+        checksum/config: bbf7701152c1bb4efe05e36a1438f16524f1748bed49e0c4e0b49d8b567a282c
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: 7e2fbd17fe8d3dd3d129fe9ce0e66b22b4e894efe1d73ad3386edecf1dd0e679
-=======
-        checksum/config: bbf7701152c1bb4efe05e36a1438f16524f1748bed49e0c4e0b49d8b567a282c
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: bedb181ce4a065feaccd16258c7a7d7432b956f26a599f66812e8f07b0cc6b72
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -37,6 +37,11 @@ data:
         - action: insert
           key: metric_source
           value: kubernetes
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: 7704b04b9b21d3e684aa1d85dac158990e171e3b5fc689663a4a836d6f53d891
+=======
+        checksum/config: cc451e83d5509aec28e14069f506e8ade60b40a45cee6ecaf2bd44381b752ca5
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: 7704b04b9b21d3e684aa1d85dac158990e171e3b5fc689663a4a836d6f53d891
-=======
-        checksum/config: cc451e83d5509aec28e14069f506e8ade60b40a45cee6ecaf2bd44381b752ca5
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: ede08dc7ac66b1edaa09e8a7e5def2fba62dacf357d2d4f599d0f5da348854c2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -37,6 +37,11 @@ data:
         - action: insert
           key: metric_source
           value: kubernetes
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: 7704b04b9b21d3e684aa1d85dac158990e171e3b5fc689663a4a836d6f53d891
+=======
+        checksum/config: cc451e83d5509aec28e14069f506e8ade60b40a45cee6ecaf2bd44381b752ca5
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: 7704b04b9b21d3e684aa1d85dac158990e171e3b5fc689663a4a836d6f53d891
-=======
-        checksum/config: cc451e83d5509aec28e14069f506e8ade60b40a45cee6ecaf2bd44381b752ca5
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: ede08dc7ac66b1edaa09e8a7e5def2fba62dacf357d2d4f599d0f5da348854c2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: 3eae7324ac7a37ded61c2bb09682efe90d5dbda370acb0f0942b48c888cb0cf4
+=======
+        checksum/config: c4311c4a0a88430be967b614ed6e22aa6082b0b350ee75f61e1ed56f2dc50f24
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: 3eae7324ac7a37ded61c2bb09682efe90d5dbda370acb0f0942b48c888cb0cf4
-=======
-        checksum/config: c4311c4a0a88430be967b614ed6e22aa6082b0b350ee75f61e1ed56f2dc50f24
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 27d1dd2cd1597f9e8ae0777dd3375357413ccf7070939a4b97e175a1fc2423a2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/ebpf-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -219,7 +219,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - resource/add_environment
           - transform/k8sevents
@@ -231,7 +230,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           - resource/add_environment

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -73,6 +73,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -220,6 +225,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - resource/add_environment
           - transform/k8sevents
           receivers:
@@ -231,6 +237,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           - resource/add_environment
           receivers:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: c613c8de6c5187ce8fb21ee8ee5efc771ac2418d1e751fb1bcf492482c3f887a
+=======
+        checksum/config: 8b635320d0a091760af1b6b0dc4b81b58b734db0db31f41209c20ee7805b7a03
+>>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,15 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-<<<<<<< HEAD
-        checksum/config: c613c8de6c5187ce8fb21ee8ee5efc771ac2418d1e751fb1bcf492482c3f887a
-=======
-        checksum/config: 8b635320d0a091760af1b6b0dc4b81b58b734db0db31f41209c20ee7805b7a03
->>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
-=======
-        checksum/config: aa4cb62f4443e6470c6fe00da0c16237d1b967a13f4cf6bcfdc3f8ef8980a873
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: b434504813da1c328e019093c2c3d6faaa295dc88ea0179eddacb76274540251
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,10 +31,14 @@ spec:
         release: default
       annotations:
 <<<<<<< HEAD
+<<<<<<< HEAD
         checksum/config: c613c8de6c5187ce8fb21ee8ee5efc771ac2418d1e751fb1bcf492482c3f887a
 =======
         checksum/config: 8b635320d0a091760af1b6b0dc4b81b58b734db0db31f41209c20ee7805b7a03
 >>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
+=======
+        checksum/config: aa4cb62f4443e6470c6fe00da0c16237d1b967a13f4cf6bcfdc3f8ef8980a873
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -251,7 +251,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -262,7 +261,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -128,6 +128,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -252,6 +257,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -262,6 +268,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a43f51b7d4636ef393b8b4ad8d0cb42f382784c99ff1d5f30f2d72d7fdf6c475
+        checksum/config: c53920a8f28bbefc746b0d7582379ded51ca043f827d0d03df2917df43271c75
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c53920a8f28bbefc746b0d7582379ded51ca043f827d0d03df2917df43271c75
+        checksum/config: fae159f9a646ebd3b880c6607b1294a551461f06e73dfb1582103727fa75f38a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-cluster-receiver.yaml
@@ -34,6 +34,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/enable-trace-sampling/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 10136f02bd6ebc13724f51c5ad276068c1a8a715e6a9a9be6e15a0ed68f904ed
+        checksum/config: f742961c28efad646b20e6557205a41b161ac62265c684844204da8ead5fb879
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -134,6 +134,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -276,6 +281,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -286,6 +292,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -275,7 +275,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -286,7 +285,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f14d8852d229099f218d26876f8016113c7d1b15861a8dc82ad30badc52b8dfd
+=======
+        checksum/config: bd59c8e228643efb41035c1f75ab9ee0885e172712df1f70ce858076f602db9e
+>>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,15 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-<<<<<<< HEAD
-        checksum/config: f14d8852d229099f218d26876f8016113c7d1b15861a8dc82ad30badc52b8dfd
-=======
-        checksum/config: bd59c8e228643efb41035c1f75ab9ee0885e172712df1f70ce858076f602db9e
->>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
-=======
-        checksum/config: cbe45049f0e0af8dc1dc255dcc139ab0938fab7722e2848de2bfee8f0611f8eb
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 06b6386ca6696cdcce6868c71c7deeabeaad6a69a564507267e42978b7f74c2d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,10 +31,14 @@ spec:
         release: default
       annotations:
 <<<<<<< HEAD
+<<<<<<< HEAD
         checksum/config: f14d8852d229099f218d26876f8016113c7d1b15861a8dc82ad30badc52b8dfd
 =======
         checksum/config: bd59c8e228643efb41035c1f75ab9ee0885e172712df1f70ce858076f602db9e
 >>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
+=======
+        checksum/config: cbe45049f0e0af8dc1dc255dcc139ab0938fab7722e2848de2bfee8f0611f8eb
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -251,7 +251,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -262,7 +261,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -128,6 +128,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -252,6 +257,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -262,6 +268,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 82cd184009b954aba5e259fb38600a3c19dfbb3bfc3a6f470bba4c0250c54f08
+        checksum/config: 6320798e782e45eeba3dc59020b58044cca1333c95acfc030be7a6be6aa729c7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e530bdca81c086959bcd3d6860e7215367fbe767f1c7876d3a627801962e245e
+        checksum/config: 82cd184009b954aba5e259fb38600a3c19dfbb3bfc3a6f470bba4c0250c54f08
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -67,6 +67,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -191,6 +196,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -201,6 +207,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -190,7 +190,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -201,7 +200,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 62e977cda2f2bbee142340d387ad8f0378de37ab95c7ec946d8f3723334e6ac7
+        checksum/config: c0e9ab05dd647d961c65195b29454cffeda0b61e896bc7adbad878a492d4169d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7b0e93f6197d962823c7d7da4069e115f5af9c26cc4617b630d0682c7c9a88c4
+        checksum/config: 62e977cda2f2bbee142340d387ad8f0378de37ab95c7ec946d8f3723334e6ac7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
@@ -194,7 +194,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -205,7 +204,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
@@ -53,6 +53,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -195,6 +200,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -205,6 +211,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: ff3944c13cd4b7615c439b795db549f5cf4c6bc6f47d68dfe8be990fecc89882
+=======
+        checksum/config: 832be64b3e8f8228cf49e54e78b127c7f10e69448161e8e41163e8a4789e33bc
+>>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,15 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-<<<<<<< HEAD
-        checksum/config: ff3944c13cd4b7615c439b795db549f5cf4c6bc6f47d68dfe8be990fecc89882
-=======
-        checksum/config: 832be64b3e8f8228cf49e54e78b127c7f10e69448161e8e41163e8a4789e33bc
->>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
-=======
-        checksum/config: a3990435a381759178c6870d04905ed4e119dc973a95dde87f7f749d538b6a7e
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: a14516def2750aa660eb9375a41de0ac28208dddd921af82941d1af1dbd502bf
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,10 +31,14 @@ spec:
         release: default
       annotations:
 <<<<<<< HEAD
+<<<<<<< HEAD
         checksum/config: ff3944c13cd4b7615c439b795db549f5cf4c6bc6f47d68dfe8be990fecc89882
 =======
         checksum/config: 832be64b3e8f8228cf49e54e78b127c7f10e69448161e8e41163e8a4789e33bc
 >>>>>>> 7e3b01a1 (Remove full resourcedetection from cluster receiver event/object pipelines)
+=======
+        checksum/config: a3990435a381759178c6870d04905ed4e119dc973a95dde87f7f749d538b6a7e
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -214,7 +214,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -225,7 +224,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -73,6 +73,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -215,6 +220,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -225,6 +231,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
-=======
-        checksum/config: 91e0732f5343ed0d0841ff7d7e5ddcb721f9e625f74cf1ba167d19c821a70ec1
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 6f163b6817dc03250b5a981bc8a5c866c109dbec48d24eb0a1ed2b93e61670d7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: b1289aa628be17944bc917da48778b5a183fe80e8fdcb2db1054910b51cb3e5e
+=======
+        checksum/config: 91e0732f5343ed0d0841ff7d7e5ddcb721f9e625f74cf1ba167d19c821a70ec1
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -251,7 +251,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -262,7 +261,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -128,6 +128,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -252,6 +257,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -262,6 +268,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 70bebfd52e36532ba4bb965debd9e75e95d217e6953b6dcda0e56d3c2cf604b5
+        checksum/config: d49a1c9e2c6ecbb46c7d08b68c54bf60f15c4978aaa3c2a0aba6a0f7abbd8a65
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d49a1c9e2c6ecbb46c7d08b68c54bf60f15c4978aaa3c2a0aba6a0f7abbd8a65
+        checksum/config: 87d309ec6a9df6815f937a3b8ea255652b3917ea5e47f7b70ecdf6280d6b3e4a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -67,6 +67,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -191,6 +196,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -201,6 +207,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -190,7 +190,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -201,7 +200,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 62e977cda2f2bbee142340d387ad8f0378de37ab95c7ec946d8f3723334e6ac7
+        checksum/config: c0e9ab05dd647d961c65195b29454cffeda0b61e896bc7adbad878a492d4169d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7b0e93f6197d962823c7d7da4069e115f5af9c26cc4617b630d0682c7c9a88c4
+        checksum/config: 62e977cda2f2bbee142340d387ad8f0378de37ab95c7ec946d8f3723334e6ac7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -67,6 +67,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -191,6 +196,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -201,6 +207,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -190,7 +190,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -201,7 +200,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 62e977cda2f2bbee142340d387ad8f0378de37ab95c7ec946d8f3723334e6ac7
+        checksum/config: c0e9ab05dd647d961c65195b29454cffeda0b61e896bc7adbad878a492d4169d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7b0e93f6197d962823c7d7da4069e115f5af9c26cc4617b630d0682c7c9a88c4
+        checksum/config: 62e977cda2f2bbee142340d387ad8f0378de37ab95c7ec946d8f3723334e6ac7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -95,6 +95,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 40616fe28d8d6217fb2194eb7564c3d55b1dee0d78518c7633e2c7dc46e04ab2
+        checksum/config: 72429e51a5cc5d61498299d626e73c7f227abd0e13901c0c96893c06ff019f65
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -34,6 +34,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/only-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 10136f02bd6ebc13724f51c5ad276068c1a8a715e6a9a9be6e15a0ed68f904ed
+        checksum/config: f742961c28efad646b20e6557205a41b161ac62265c684844204da8ead5fb879
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 95af290a8cf76a3f358f65d4daa44d351ce65d02af5cc1fb775b4a230410f54d
+        checksum/config: 6cca2824492f7ba6bc0503c50cc4220a2b8ad8600f8a762e057cb47892c217d7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -67,6 +67,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -191,6 +196,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -201,6 +207,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -190,7 +190,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -201,7 +200,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 62e977cda2f2bbee142340d387ad8f0378de37ab95c7ec946d8f3723334e6ac7
+        checksum/config: c0e9ab05dd647d961c65195b29454cffeda0b61e896bc7adbad878a492d4169d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7b0e93f6197d962823c7d7da4069e115f5af9c26cc4617b630d0682c7c9a88c4
+        checksum/config: 62e977cda2f2bbee142340d387ad8f0378de37ab95c7ec946d8f3723334e6ac7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -67,6 +67,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -191,6 +196,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -201,6 +207,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -190,7 +190,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -201,7 +200,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 71dc3d084ab3f6e10502e8f81936d9b898d16472fa34c49d84bf347963feeffc
+        checksum/config: d83caa64c7611af8653440b5841149471dc05304c091d80888a49fdfae9361f6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d83caa64c7611af8653440b5841149471dc05304c091d80888a49fdfae9361f6
+        checksum/config: f0b8c93d52955df96415bd41dbd5f808e0e5b0e3e39a5f51c9b24905bf20ec54
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -256,7 +256,6 @@ data:
           - memory_limiter
           - batch
           - attributes/drop_event_attrs
-          - resourcedetection
           - resource
           - transform/k8sevents
           receivers:
@@ -267,7 +266,6 @@ data:
           processors:
           - memory_limiter
           - batch
-          - resourcedetection
           - resource
           - transform/add_sourcetype
           receivers:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -128,6 +128,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert
@@ -257,6 +262,7 @@ data:
           - batch
           - attributes/drop_event_attrs
           - resource
+          - resource/add_cluster_host
           - transform/k8sevents
           receivers:
           - k8s_events
@@ -267,6 +273,7 @@ data:
           - memory_limiter
           - batch
           - resource
+          - resource/add_cluster_host
           - transform/add_sourcetype
           receivers:
           - k8sobjects

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: cc262ef92b5bfeb7d004580af3d1f0ba9f965ab5618fbcc7ccf517f987d53bf7
+        checksum/config: 7c528f27b9f94efd1ec54df941fc21725290c764bafa0b4db73542f36d58f52e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7937fa1cb0ef1550bea28a2570ab0eb52d6062257288cbe2ee506eedf6ee90fc
+        checksum/config: cc262ef92b5bfeb7d004580af3d1f0ba9f965ab5618fbcc7ccf517f987d53bf7
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,11 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-<<<<<<< HEAD
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
-=======
-        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
->>>>>>> ab68bd09 (host.name as node name)
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,11 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
+<<<<<<< HEAD
         checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+=======
+        checksum/config: 604a308eacd412a532a5209f30792a1c0704075ee535b27e381945e2edc14b32
+>>>>>>> ab68bd09 (host.name as node name)
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -40,6 +40,11 @@ data:
         - action: upsert
           key: k8s.cluster.name
           value: CHANGEME
+      resource/add_cluster_host:
+        attributes:
+        - action: insert
+          key: host.name
+          value: ${K8S_NODE_NAME}
       resource/add_collector_k8s:
         attributes:
         - action: insert

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f083fa82bd157588eb04c3d03ae2f1fe4d41e44d4c2c427bf26256570d82a8b6
+        checksum/config: 87a96888f272cfc35a34ebb80ada2d426b1de461a2bcb834b2e61252b50113de
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -91,6 +91,7 @@ func Test_K8SEvents(t *testing.T) {
 		err = plogtest.CompareLogs(expectedEventsLogs, k8sEventsLogs,
 			plogtest.IgnoreTimestamp(),
 			plogtest.IgnoreObservedTimestamp(),
+			plogtest.IgnoreResourceAttributeValue("host.name"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.object.uid"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.statefulset.uid"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.pod.uid"),
@@ -118,6 +119,7 @@ func Test_K8SEvents(t *testing.T) {
 		err = plogtest.CompareLogs(expectedObjectsLogs, k8sObjectsLogs,
 			plogtest.IgnoreTimestamp(),
 			plogtest.IgnoreObservedTimestamp(),
+			plogtest.IgnoreResourceAttributeValue("host.name"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.object.uid"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.object.resource_version"),
 			plogtest.IgnoreResourceAttributeValue("com.splunk.index"), // this is flaky, the index can be the value from pod annotation due to the k8s_attributes processor in the pipeline or main

--- a/functional_tests/k8sevents/k8sevents_test.go
+++ b/functional_tests/k8sevents/k8sevents_test.go
@@ -91,7 +91,6 @@ func Test_K8SEvents(t *testing.T) {
 		err = plogtest.CompareLogs(expectedEventsLogs, k8sEventsLogs,
 			plogtest.IgnoreTimestamp(),
 			plogtest.IgnoreObservedTimestamp(),
-			plogtest.IgnoreResourceAttributeValue("host.name"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.object.uid"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.statefulset.uid"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.pod.uid"),
@@ -119,7 +118,6 @@ func Test_K8SEvents(t *testing.T) {
 		err = plogtest.CompareLogs(expectedObjectsLogs, k8sObjectsLogs,
 			plogtest.IgnoreTimestamp(),
 			plogtest.IgnoreObservedTimestamp(),
-			plogtest.IgnoreResourceAttributeValue("host.name"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.object.uid"),
 			plogtest.IgnoreLogRecordAttributeValue("k8s.object.resource_version"),
 			plogtest.IgnoreResourceAttributeValue("com.splunk.index"), // this is flaky, the index can be the value from pod annotation due to the k8s_attributes processor in the pipeline or main

--- a/functional_tests/k8sevents/testdata/expected_k8sevents.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sevents.yaml
@@ -1,6 +1,9 @@
 resourceLogs:
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: kind-control-plane
         - key: com.splunk.source
           value:
             stringValue: kubernetes

--- a/functional_tests/k8sevents/testdata/expected_k8sevents.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sevents.yaml
@@ -1,9 +1,6 @@
 resourceLogs:
   - resource:
       attributes:
-        - key: host.name
-          value:
-            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-7dd9dc4cf5d47n2
         - key: com.splunk.source
           value:
             stringValue: kubernetes
@@ -64,9 +61,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -125,9 +119,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -189,9 +180,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -253,9 +241,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -317,9 +302,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -381,9 +363,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -445,9 +424,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -509,9 +485,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -573,9 +546,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9
@@ -637,9 +607,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
               - key: otel.log.severity.number
                 value:
                   doubleValue: 9

--- a/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
@@ -1,6 +1,9 @@
 resourceLogs:
   - resource:
       attributes:
+        - key: host.name
+          value:
+            stringValue: kind-control-plane
         - key: com.splunk.source
           value:
             stringValue: kubernetes

--- a/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
+++ b/functional_tests/k8sevents/testdata/expected_k8sobjects.yaml
@@ -1,9 +1,6 @@
 resourceLogs:
   - resource:
       attributes:
-        - key: host.name
-          value:
-            stringValue: sock-splunk-otel-collector-k8s-cluster-receiver-6448fc5476mgbpr
         - key: com.splunk.source
           value:
             stringValue: kubernetes
@@ -37,9 +34,6 @@ resourceLogs:
               - key: metric_source
                 value:
                   stringValue: kubernetes
-              - key: os.type
-                value:
-                  stringValue: linux
             body:
               kvlistValue:
                 values:

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -367,7 +367,7 @@ Whether the clusterName configuration option is optional
 Whether the helm chart should detect the cluster name automatically
 */}}
 {{- define "splunk-otel-collector.autoDetectClusterName" -}}
-{{- and (include "splunk-otel-collector.clusterNameOptional" .) (not .Values.clusterName) }}
+{{- and (eq (include "splunk-otel-collector.clusterNameOptional" .) "true") (not .Values.clusterName) }}
 {{- end -}}
 
 {{/*

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -247,6 +247,17 @@ processors:
         value: "{{ .Values.environment }}"
   {{- end }}
 
+  # Set host.name for the Splunk HEC "host" indexed field, which Splunk
+  # defines as "the network host from which the event originated"
+  # (https://docs.splunk.com/Documentation/Splunk/latest/Data/Aboutdefaultfields).
+  # Cluster-scoped data has no originating host; use the node running
+  # the cluster receiver as the closest physical device.
+  resource/add_cluster_host:
+    attributes:
+      - action: insert
+        key: host.name
+        value: "${K8S_NODE_NAME}"
+
   # The following processor is used to add "otelcol.service.mode" attribute to the internal metrics
   resource/add_mode:
     attributes:
@@ -422,6 +433,7 @@ service:
         - resourcedetection/k8s_cluster_name
         {{- end }}
         - resource
+        - resource/add_cluster_host
         {{- if .Values.environment }}
         - resource/add_environment
         {{- end }}
@@ -446,6 +458,7 @@ service:
         - resourcedetection/k8s_cluster_name
         {{- end }}
         - resource
+        - resource/add_cluster_host
         - transform/add_sourcetype
         {{- if .Values.environment }}
         - resource/add_environment
@@ -470,6 +483,7 @@ service:
         - resourcedetection/k8s_cluster_name
         {{- end }}
         - resource
+        - resource/add_cluster_host
         {{- if .Values.clusterName }}
         - resource/add_event_k8s
         {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -418,7 +418,9 @@ service:
         - memory_limiter
         - batch
         - attributes/drop_event_attrs
-        - resourcedetection
+        {{- if eq (include "splunk-otel-collector.autoDetectClusterName" .) "true" }}
+        - resourcedetection/k8s_cluster_name
+        {{- end }}
         - resource
         {{- if .Values.environment }}
         - resource/add_environment
@@ -440,7 +442,9 @@ service:
       processors:
         - memory_limiter
         - batch
-        - resourcedetection
+        {{- if eq (include "splunk-otel-collector.autoDetectClusterName" .) "true" }}
+        - resourcedetection/k8s_cluster_name
+        {{- end }}
         - resource
         - transform/add_sourcetype
         {{- if .Values.environment }}
@@ -462,7 +466,9 @@ service:
       processors:
         - memory_limiter
         - batch
-        - resourcedetection
+        {{- if eq (include "splunk-otel-collector.autoDetectClusterName" .) "true" }}
+        - resourcedetection/k8s_cluster_name
+        {{- end }}
         - resource
         {{- if .Values.clusterName }}
         - resource/add_event_k8s

--- a/unittests/resource_detection_test.yaml
+++ b/unittests/resource_detection_test.yaml
@@ -278,10 +278,11 @@ tests:
           path: data["relay"]
           pattern: "metrics/collector:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "cluster receiver — logs/objects pipeline includes resourcedetection"
+  - it: "cluster receiver — logs/objects pipeline has only k8s_cluster_name, not full resourcedetection (cluster-scoped data)"
     set:
       distribution: openshift
       cloudProvider: aws
+      clusterName: ""
       clusterReceiver:
         k8sObjects:
           - name: pods
@@ -289,33 +290,63 @@ tests:
             interval: 60s
     template: configmap-cluster-receiver.yaml
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: data["relay"]
           pattern: "logs/objects:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs/objects:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "cluster receiver — logs (k8s_events) pipeline includes resourcedetection"
+  - it: "cluster receiver — logs (k8s_events) pipeline has only k8s_cluster_name, not full resourcedetection (cluster-scoped data)"
     set:
       distribution: openshift
       cloudProvider: aws
+      clusterName: ""
       clusterReceiver:
         eventsEnabled: true
     template: configmap-cluster-receiver.yaml
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: data["relay"]
           pattern: "logs:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "cluster receiver — logs/events (smartagent) pipeline includes resourcedetection"
+  - it: "cluster receiver — logs/events (smartagent) pipeline has only k8s_cluster_name, not full resourcedetection (cluster-scoped data)"
     set:
       distribution: openshift
       cloudProvider: aws
+      clusterName: ""
       splunkObservability:
         infrastructureMonitoringEventsEnabled: true
     template: configmap-cluster-receiver.yaml
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: data["relay"]
           pattern: "logs/events:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs/events:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "cluster receiver — logs/objects with explicit clusterName has neither resourcedetection nor resourcedetection/k8s_cluster_name"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: my-cluster
+      clusterReceiver:
+        k8sObjects:
+          - name: pods
+            mode: pull
+            interval: 60s
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/objects:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/objects:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
   - it: "gateway — metrics/collector pipeline includes resourcedetection"
     set:
@@ -371,3 +402,230 @@ tests:
       - notMatchRegex:
           path: data["relay"]
           pattern: "logs/entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "cluster receiver — metrics/histograms (EKS apiserver) has only k8s_cluster_name, not full resourcedetection"
+    set:
+      distribution: eks
+      cloudProvider: aws
+      clusterName: ""
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metrics/histograms:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "metrics/histograms:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "cluster receiver — logs/k8s_entities pipeline has only k8s_cluster_name, not full resourcedetection"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+      featureGates:
+        enableK8sEntities: true
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/k8s_entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs/k8s_entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "agent — logs/secureapp pipeline has no resourcedetection"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      splunkObservability:
+        secureAppEnabled: true
+    template: configmap-agent.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "gateway — logs/secureapp pipeline has no resourcedetection"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      gateway.enabled: true
+      splunkObservability:
+        secureAppEnabled: true
+    template: configmap-gateway.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  # ============================================================================
+  # Pipeline inventory guards
+  #
+  # These tests use yq to extract the exact set of pipeline names from the
+  # rendered configmap and assert an exact match. Any new, removed, or renamed
+  # pipeline will cause a failure. If you add a new pipeline:
+  #   1. Add an explicit resourcedetection test for the new pipeline above.
+  #   2. Add the new pipeline name to the appropriate guard test below.
+  # ============================================================================
+
+  - it: "GUARD — agent pipeline names"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+      gateway.enabled: false
+      logsCollection:
+        journald:
+          enabled: true
+    template: configmap-agent.yaml
+    postRenderer:
+      cmd: yq
+      args:
+        - eval
+        - '.data.relay = (.data.relay | from_yaml | .service.pipelines | keys | sort | join(","))'
+        - "-"
+    asserts:
+      - equal:
+          path: data.relay
+          value: "logs,logs/entities,logs/host,metrics,metrics/agent,metrics/histograms,traces"
+
+  - it: "GUARD — agent pipeline names with secureAppEnabled"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+      gateway.enabled: false
+      splunkObservability:
+        secureAppEnabled: true
+      logsCollection:
+        journald:
+          enabled: true
+    template: configmap-agent.yaml
+    postRenderer:
+      cmd: yq
+      args:
+        - eval
+        - '.data.relay = (.data.relay | from_yaml | .service.pipelines | keys | sort | join(","))'
+        - "-"
+    asserts:
+      - equal:
+          path: data.relay
+          value: "logs,logs/entities,logs/host,logs/secureapp,logs/split,metrics,metrics/agent,metrics/histograms,traces"
+
+  - it: "GUARD — cluster receiver pipeline names"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+      clusterReceiver:
+        eventsEnabled: true
+        k8sObjects:
+          - name: pods
+            mode: pull
+            interval: 60s
+      splunkObservability:
+        infrastructureMonitoringEventsEnabled: true
+    template: configmap-cluster-receiver.yaml
+    documentIndex: 0
+    postRenderer:
+      cmd: yq
+      args:
+        - eval
+        - '.data.relay = (.data.relay | from_yaml | .service.pipelines | keys | sort | join(","))'
+        - "-"
+    asserts:
+      - equal:
+          path: data.relay
+          value: "logs,logs/events,logs/objects,metrics,metrics/collector"
+
+  - it: "GUARD — cluster receiver EKS pipeline names"
+    set:
+      distribution: eks
+      cloudProvider: aws
+      clusterName: ""
+      clusterReceiver:
+        eventsEnabled: true
+        k8sObjects:
+          - name: pods
+            mode: pull
+            interval: 60s
+      splunkObservability:
+        infrastructureMonitoringEventsEnabled: true
+    template: configmap-cluster-receiver.yaml
+    documentIndex: 0
+    postRenderer:
+      cmd: yq
+      args:
+        - eval
+        - '.data.relay = (.data.relay | from_yaml | .service.pipelines | keys | sort | join(","))'
+        - "-"
+    asserts:
+      - equal:
+          path: data.relay
+          value: "logs,logs/events,logs/objects,metrics,metrics/collector,metrics/histograms"
+
+  - it: "GUARD — cluster receiver pipeline names with enableK8sEntities"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+      featureGates:
+        enableK8sEntities: true
+      clusterReceiver:
+        eventsEnabled: true
+        k8sObjects:
+          - name: pods
+            mode: pull
+            interval: 60s
+      splunkObservability:
+        infrastructureMonitoringEventsEnabled: true
+    template: configmap-cluster-receiver.yaml
+    documentIndex: 0
+    postRenderer:
+      cmd: yq
+      args:
+        - eval
+        - '.data.relay = (.data.relay | from_yaml | .service.pipelines | keys | sort | join(","))'
+        - "-"
+    asserts:
+      - equal:
+          path: data.relay
+          value: "logs,logs/events,logs/k8s_entities,logs/objects,metrics,metrics/collector"
+
+  - it: "GUARD — gateway pipeline names"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+      gateway.enabled: true
+    template: configmap-gateway.yaml
+    postRenderer:
+      cmd: yq
+      args:
+        - eval
+        - '.data.relay = (.data.relay | from_yaml | .service.pipelines | keys | sort | join(","))'
+        - "-"
+    asserts:
+      - equal:
+          path: data.relay
+          value: "logs,logs/entities,logs/split,metrics,metrics/collector,traces"
+
+  - it: "GUARD — gateway pipeline names with secureAppEnabled"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+      gateway.enabled: true
+      splunkObservability:
+        secureAppEnabled: true
+    template: configmap-gateway.yaml
+    postRenderer:
+      cmd: yq
+      args:
+        - eval
+        - '.data.relay = (.data.relay | from_yaml | .service.pipelines | keys | sort | join(","))'
+        - "-"
+    asserts:
+      - equal:
+          path: data.relay
+          value: "logs,logs/entities,logs/secureapp,logs/split,metrics,metrics/collector,traces"


### PR DESCRIPTION
**Description:**

The logs (k8s_events), logs/objects, and logs/events pipelines in the cluster receiver were using the full resourcedetection processor, which adds host-level attributes (host.id, host.name, cloud.provider, etc.). These pipelines carry cluster-scoped data where host identity is the cluster receiver pod, not the source of the event.

Align with the metrics pipeline which correctly uses only `resourcedetection/k8s_cluster_name` for auto-detect distributions.
