### PR TITLE
[chore] adding missing unit tests for resdetection

### DIFF
--- a/unittests/resource_detection_test.yaml
+++ b/unittests/resource_detection_test.yaml
@@ -258,15 +258,33 @@ tests:
           path: data["relay"]
           pattern: "metrics/histograms:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "cluster receiver — metrics pipeline has no resourcedetection"
+  - it: "cluster receiver — metrics pipeline has no full resourcedetection and no k8s_cluster_name when clusterName is set"
     set:
       distribution: openshift
       cloudProvider: aws
+      clusterName: my-cluster
     template: configmap-cluster-receiver.yaml
     asserts:
       - notMatchRegex:
           path: data["relay"]
           pattern: "metrics:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metrics:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "cluster receiver — metrics pipeline has k8s_cluster_name but no full resourcedetection when clusterName is unset"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metrics:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "metrics:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
   - it: "cluster receiver — metrics/collector pipeline includes resourcedetection"
     set:
@@ -313,6 +331,22 @@ tests:
           path: data["relay"]
           pattern: "logs:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
+  - it: "cluster receiver — logs (k8s_events) with explicit clusterName has neither resourcedetection nor k8s_cluster_name"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: my-cluster
+      clusterReceiver:
+        eventsEnabled: true
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
   - it: "cluster receiver — logs/events (smartagent) pipeline has only k8s_cluster_name, not full resourcedetection (cluster-scoped data)"
     set:
       distribution: openshift
@@ -326,6 +360,22 @@ tests:
           path: data["relay"]
           pattern: "logs/events:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
       - matchRegex:
+          path: data["relay"]
+          pattern: "logs/events:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "cluster receiver — logs/events (smartagent) with explicit clusterName has neither resourcedetection nor k8s_cluster_name"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: my-cluster
+      splunkObservability:
+        infrastructureMonitoringEventsEnabled: true
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/events:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - notMatchRegex:
           path: data["relay"]
           pattern: "logs/events:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
@@ -359,27 +409,65 @@ tests:
           path: data["relay"]
           pattern: "metrics/collector:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "gateway — forwarding traces pipeline has no resourcedetection"
+  - it: "gateway — forwarding traces pipeline has no full resourcedetection and no k8s_cluster_name when clusterName is set"
     set:
       distribution: openshift
       cloudProvider: aws
+      clusterName: my-cluster
       gateway.enabled: true
     template: configmap-gateway.yaml
     asserts:
       - notMatchRegex:
           path: data["relay"]
           pattern: "traces:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "traces:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "gateway — forwarding metrics pipeline has no resourcedetection"
+  - it: "gateway — forwarding traces pipeline has k8s_cluster_name but no full resourcedetection when clusterName is unset"
     set:
       distribution: openshift
       cloudProvider: aws
+      clusterName: ""
+      gateway.enabled: true
+    template: configmap-gateway.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "traces:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "traces:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "gateway — forwarding metrics pipeline has no full resourcedetection and no k8s_cluster_name when clusterName is set"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: my-cluster
       gateway.enabled: true
     template: configmap-gateway.yaml
     asserts:
       - notMatchRegex:
           path: data["relay"]
           pattern: "metrics:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metrics:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "gateway — forwarding metrics pipeline has k8s_cluster_name but no full resourcedetection when clusterName is unset"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: ""
+      gateway.enabled: true
+    template: configmap-gateway.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metrics:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "metrics:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
   - it: "gateway — forwarding logs pipeline has no resourcedetection"
     set:
@@ -417,6 +505,20 @@ tests:
           path: data["relay"]
           pattern: "metrics/histograms:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
+  - it: "cluster receiver — metrics/histograms (EKS apiserver) with explicit clusterName has no k8s_cluster_name"
+    set:
+      distribution: eks
+      cloudProvider: aws
+      clusterName: my-cluster
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metrics/histograms:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metrics/histograms:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
   - it: "cluster receiver — logs/k8s_entities pipeline has only k8s_cluster_name, not full resourcedetection"
     set:
       distribution: openshift
@@ -430,6 +532,22 @@ tests:
           path: data["relay"]
           pattern: "logs/k8s_entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
       - matchRegex:
+          path: data["relay"]
+          pattern: "logs/k8s_entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "cluster receiver — logs/k8s_entities with explicit clusterName has no k8s_cluster_name"
+    set:
+      distribution: openshift
+      cloudProvider: aws
+      clusterName: my-cluster
+      featureGates:
+        enableK8sEntities: true
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/k8s_entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+      - notMatchRegex:
           path: data["relay"]
           pattern: "logs/k8s_entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Adds some more unittest to cover gw/clusterReceiver pipelines usage of resourcedetection/k8s_cluster_name, testing both the clusterName-unset and clusterName-set cases.