### PR TITLE
[chore] throw proper error on index-out-of-range panic

### DIFF
--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -567,6 +567,7 @@ func validateResourceAttributes(t *testing.T, clientset *kubernetes.Clientset, k
 func readAndNormalizeMetrics(t *testing.T, filePath string, skipKeys ...string) pmetric.Metrics {
 	metrics, err := golden.ReadMetrics(filePath)
 	require.NoError(t, err)
+	require.Positive(t, metrics.ResourceMetrics().Len(), "metrics file %s contains no ResourceMetrics", filePath)
 	internal.NormalizeAttributes(metrics.ResourceMetrics().At(0).Resource().Attributes(), skipKeys...)
 	return metrics
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Display proper error instead of [panic](https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/24587549741/job/72175386990?pr=2386#step:9:200) when file has no resources.