### PR TITLE
Use local action for creating PRs

### DIFF
--- a/.github/actions/create-pr/action.yaml
+++ b/.github/actions/create-pr/action.yaml
@@ -1,0 +1,50 @@
+name: Create PR
+description: Commit local changes, push a branch, and create or update a pull request with gh
+
+inputs:
+  branch:
+    description: Branch to push
+    required: true
+  commit-message:
+    description: Commit message
+    required: true
+  title:
+    description: Pull request title
+    required: true
+  body:
+    description: Pull request body
+    required: true
+  author-name:
+    description: Git author name
+    required: true
+  author-email:
+    description: Git author email
+    required: true
+
+outputs:
+  pull-request-number:
+    description: Created pull request number
+    value: ${{ steps.create.outputs.pull-request-number }}
+
+runs:
+  using: composite
+  steps:
+    - id: create
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        git config user.name "${{ inputs.author-name }}"
+        git config user.email "${{ inputs.author-email }}"
+        git checkout -B "${{ inputs.branch }}"
+        git add -A
+        git commit -m "${{ inputs.commit-message }}"
+        git push --force-with-lease --set-upstream origin "${{ inputs.branch }}"
+        pr_number="$(gh pr list --head "${{ inputs.branch }}" --base main --state open --json number --jq '.[0].number // empty')"
+        if [ -n "$pr_number" ]; then
+          gh pr edit "$pr_number" --title "${{ inputs.title }}" --body "${{ inputs.body }}"
+        else
+          gh pr create --base main --head "${{ inputs.branch }}" --title "${{ inputs.title }}" --body "${{ inputs.body }}"
+          pr_number="$(gh pr view "${{ inputs.branch }}" --json number --jq .number)"
+        fi
+        echo "pull-request-number=$pr_number" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release_drafter.yaml
+++ b/.github/workflows/release_drafter.yaml
@@ -92,15 +92,14 @@ jobs:
       - name: Open PR for Version Update
         id: open_pr
         if: ${{ steps.prepare_release.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 }}
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: ./.github/actions/create-pr
         with:
+          branch: update-release
           commit-message: Prepare release v${{ steps.prepare_release.outputs.LATEST_CHART_VERSION }}
           title: Prepare release v${{ steps.prepare_release.outputs.LATEST_CHART_VERSION }}
           body: |
             Description
             - Release Helm chart version ${{ steps.prepare_release.outputs.LATEST_CHART_VERSION }}
             - Includes collector version ${{ steps.prepare_release.outputs.LATEST_APP_VERSION }}
-          branch: update-release
-          base: main
-          delete-branch: true
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
+          author-name: ${{ github.event_name == 'schedule' && 'github-actions[bot]' || github.actor }}
+          author-email: ${{ github.event_name == 'schedule' && '41898282+github-actions[bot]@users.noreply.github.com' || format('{1}+{0}@users.noreply.github.com', github.actor, github.actor_id) }}

--- a/.github/workflows/update_chart_dependencies.yaml
+++ b/.github/workflows/update_chart_dependencies.yaml
@@ -126,22 +126,21 @@ jobs:
       - name: Open PR for Version Update
         id: open_pr
         if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 || steps.check_for_crd_update.outputs.CRDS_NEED_UPDATE == 1 }}
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: ./.github/actions/create-pr
         with:
+          branch: update-${{ matrix.name }}
           commit-message: ${{ steps.pr_messages.outputs.commit_message_open }}
           title: ${{ steps.pr_messages.outputs.title }}
           body: ${{ steps.pr_messages.outputs.body_open }}
-          branch: "update-${{ matrix.name }}"
-          base: main
-          delete-branch: true
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
+          author-name: ${{ github.event_name == 'schedule' && 'github-actions[bot]' || github.actor }}
+          author-email: ${{ github.event_name == 'schedule' && '41898282+github-actions[bot]@users.noreply.github.com' || format('{1}+{0}@users.noreply.github.com', github.actor, github.actor_id) }}
 
 
       - name: Apply Version Update and Generate Changelog
         if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 }}
         run: |
           # Apply the version update, update the rendered examples with the version update, and create a changelog entry
-          # We run `make update-chart-dep` again here because the open_pr peter-evans/create-pull-request step before clears out the update changes locally
+          # Re-run the update before rendering/changelog generation to keep derived files in sync.
           make update-chart-dep CHART_PATH=${{ matrix.yaml_file_path }} SUBCHART_NAME='${{ matrix.dependency_name }}' DEBUG_MODE="$DEBUG_MODE"
           make render
           make chlog-new FILENAME="update-${{ matrix.name }}" CHANGE_TYPE=enhancement COMPONENT=${{ matrix.component }} NOTE="${{ steps.pr_messages.outputs.chlog_note_chart }}" ISSUES="[${{ steps.open_pr.outputs.pull-request-number }}]"
@@ -171,12 +170,11 @@ jobs:
 
       - name: Finalize PR with updates
         if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 || steps.check_for_crd_update.outputs.CRDS_NEED_UPDATE == 1 }}
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: ./.github/actions/create-pr
         with:
+          branch: update-${{ matrix.name }}
           commit-message: ${{ steps.pr_messages.outputs.commit_message_finalize }}
           title: ${{ steps.pr_messages.outputs.title }}
           body: ${{ steps.pr_messages.outputs.body_finalize }}
-          branch: "update-${{ matrix.name }}"
-          base: main
-          delete-branch: true
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
+          author-name: ${{ github.event_name == 'schedule' && 'github-actions[bot]' || github.actor }}
+          author-email: ${{ github.event_name == 'schedule' && '41898282+github-actions[bot]@users.noreply.github.com' || format('{1}+{0}@users.noreply.github.com', github.actor, github.actor_id) }}

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -66,21 +66,20 @@ jobs:
       - name: Open PR for Version Update
         id: open_pr
         if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 }}
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: ./.github/actions/create-pr
         with:
+          branch: update-${{ matrix.name }}
           commit-message: Update ${{ matrix.name }} instrumentation version
           title: Bump ${{ matrix.name }} from ${{ steps.check_for_update.outputs.CURRENT_TAG }} to ${{ steps.check_for_update.outputs.LATEST_TAG }} in ${{ matrix.yaml_file_path }}
           body: Use the latest version of ${{ matrix.name }}
-          branch: "update-${{ matrix.name }}" # Same branch name for all PRs
-          base: main
-          delete-branch: true
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
+          author-name: ${{ github.event_name == 'schedule' && 'github-actions[bot]' || github.actor }}
+          author-email: ${{ github.event_name == 'schedule' && '41898282+github-actions[bot]@users.noreply.github.com' || format('{1}+{0}@users.noreply.github.com', github.actor, github.actor_id) }}
 
       - name: Apply Version Update and Generate Changelog
         if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 && steps.open_pr.outputs.pull-request-number != '' }}
         run: |
           # Apply the version update, update the rendered examples with the version update, and create a changelog entry
-          # We run `make update-docker-image` again here because the open_pr peter-evans/create-pull-request step before clears out the update changes locally
+          # Re-run the update before rendering/changelog generation to keep derived files in sync.
           make update-docker-image FILE_PATH=${{ matrix.yaml_file_path }} QUERY_STRING='${{ matrix.yaml_value_path }}' FILTER='${{ matrix.filter }}' DEBUG_MODE="$DEBUG_MODE"
           make render
           make chlog-new FILENAME="update-${{ matrix.name }}" CHANGE_TYPE=enhancement COMPONENT=${{ matrix.component }} NOTE="Bump ${{ matrix.name }} to ${{ steps.check_for_update.outputs.LATEST_TAG }} in ${{ matrix.yaml_file_path }}" ISSUES="[${{ steps.open_pr.outputs.pull-request-number }}]"
@@ -95,12 +94,11 @@ jobs:
 
       - name: Finalize PR with updates
         if: ${{ steps.check_for_update.outputs.NEED_UPDATE == 1 && steps.check_if_pr_open.outputs.PR_NEEDED == 1 && steps.open_pr.outputs.pull-request-number != '' }}
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: ./.github/actions/create-pr
         with:
+          branch: update-${{ matrix.name }}
           commit-message: Update ${{ matrix.name }} instrumentation version
           title: Bump ${{ matrix.name }} from ${{ steps.check_for_update.outputs.CURRENT_TAG }} to ${{ steps.check_for_update.outputs.LATEST_TAG }} in ${{ matrix.yaml_file_path }}
           body: Use the latest version of ${{ matrix.name }}
-          branch: "update-${{ matrix.name }}" # Same branch name for all PRs
-          base: main
-          delete-branch: true
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
+          author-name: ${{ github.event_name == 'schedule' && 'github-actions[bot]' || github.actor }}
+          author-email: ${{ github.event_name == 'schedule' && '41898282+github-actions[bot]@users.noreply.github.com' || format('{1}+{0}@users.noreply.github.com', github.actor, github.actor_id) }}

--- a/.github/workflows/update_k8s_versions.yaml
+++ b/.github/workflows/update_k8s_versions.yaml
@@ -41,12 +41,11 @@ jobs:
 
       - name: Open PR for matrix version update
         if: steps.git-check.outputs.changes == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        uses: ./.github/actions/create-pr
         with:
+          branch: update-matrix-test-versions
           commit-message: Update matrix test versions
           title: Update matrix versions used for testing
           body: Use latest supported matrix versions
-          branch: update-matrix-test-versions
-          base: main
-          delete-branch: true
-          author: ${{ github.event_name == 'schedule' && 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>' || format('{0} <{1}+{0}@users.noreply.github.com>', github.actor, github.actor_id) }}
+          author-name: ${{ github.event_name == 'schedule' && 'github-actions[bot]' || github.actor }}
+          author-email: ${{ github.event_name == 'schedule' && '41898282+github-actions[bot]@users.noreply.github.com' || format('{1}+{0}@users.noreply.github.com', github.actor, github.actor_id) }}


### PR DESCRIPTION
In our continued effort to reduce the number of 3rd party potentially risky github actions, this PR adds a local github action that simply uses the `gh` commandline tool to create PRs. There were at least 4 usages of the external action, and those sites have all been changed to use this new local action.

Spice level: 🌶️🌶️ 

If we are relying on some unknown side effects or artifacts or weird behavior, it might not be captured, so proper review is appreciated. Thanks!

_(Disclaimer: AI assisted, human scrutinized.)_