### PR TITLE
[chore] pin to helm v4 in workflows

### DIFF
--- a/.github/workflows/release_drafter.yaml
+++ b/.github/workflows/release_drafter.yaml
@@ -48,6 +48,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 #v4
+        with:
+          version: v4.1.4
+
       - name: Install chloggen
         run: make install-chloggen
 

--- a/.github/workflows/update_docker_images.yaml
+++ b/.github/workflows/update_docker_images.yaml
@@ -48,6 +48,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 #v4
+        with:
+          version: v4.1.4
+
       - name: Check for Version Updates
         id: check_for_update
         run: |


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Pin Helm to `v4.1.4` in `update_docker_images.yaml` and `release_drafter.yaml`. Both workflows commit rendered manifests via `make render` (-> `helm template`) but they were silently falling back to the runner's pre-installed Helm 3.
The result is a render-flap loop:  `update_docker_images` / `release_drafter` open a PR with manifests rendered by Helm 3 ([example](https://github.com/signalfx/splunk-otel-collector-chart/pull/2377/changes#diff-257c616f3c13f35cf8e2e5ab1ea113b0b684a067b5ea151f1cef962d257590bc)). Next time anything Helm-4-pinned runs `make render`, it reverts/rewrites those manifests.



