### PR TITLE
[chore][CI/CD] Split up functional tests to use reusable actions

### DIFF
--- a/.github/actions/aks-kube-context/action.yaml
+++ b/.github/actions/aks-kube-context/action.yaml
@@ -2,19 +2,15 @@ name: Configure AKS Kubernetes Context
 description: Configure kubeconfig for AKS cloud functional tests.
 
 inputs:
-  azure-credentials:
-    description: Azure credentials JSON.
+  aks-cluster-name:
+    description: AKS cluster name.
     required: true
   aks-resource-group:
     description: AKS resource group.
     required: true
-  aks-cluster-name:
-    description: AKS cluster name.
+  azure-credentials:
+    description: Azure credentials JSON.
     required: true
-  kubelogin-version:
-    description: kubelogin version for AKS authentication.
-    required: false
-    default: v0.0.24
 
 runs:
   using: composite
@@ -22,7 +18,7 @@ runs:
     - name: Set up kubelogin for non-interactive login
       uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
       with:
-        kubelogin-version: ${{ inputs.kubelogin-version }}
+        kubelogin-version: v0.0.24
 
     - name: Authenticate to Azure
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0

--- a/.github/actions/aks-kube-context/action.yaml
+++ b/.github/actions/aks-kube-context/action.yaml
@@ -1,0 +1,38 @@
+name: Configure AKS Kubernetes Context
+description: Configure kubeconfig for AKS cloud functional tests.
+
+inputs:
+  azure-credentials:
+    description: Azure credentials JSON.
+    required: true
+  aks-resource-group:
+    description: AKS resource group.
+    required: true
+  aks-cluster-name:
+    description: AKS cluster name.
+    required: true
+  kubelogin-version:
+    description: kubelogin version for AKS authentication.
+    required: false
+    default: v0.0.24
+
+runs:
+  using: composite
+  steps:
+    - name: Set up kubelogin for non-interactive login
+      uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
+      with:
+        kubelogin-version: ${{ inputs.kubelogin-version }}
+
+    - name: Authenticate to Azure
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+      with:
+        creds: ${{ inputs.azure-credentials }}
+
+    - name: Install AKS kubeconfig
+      uses: azure/aks-set-context@c7eb093e5a5d47caa333f64974d5fd1cd4bf069d # v4
+      with:
+        resource-group: ${{ inputs.aks-resource-group }}
+        cluster-name: ${{ inputs.aks-cluster-name }}
+        admin: false
+        use-kubelogin: true

--- a/.github/actions/cloud-functional-test/action.yaml
+++ b/.github/actions/cloud-functional-test/action.yaml
@@ -1,0 +1,67 @@
+name: Run Cloud Functional Tests
+description: Run install or upgrade functional tests against an existing cloud Kubernetes cluster.
+
+inputs:
+  go-version:
+    description: Go version to install.
+    required: true
+  mode:
+    description: 'Test mode: install or upgrade.'
+    required: false
+    default: install
+  kube-test-env:
+    description: KUBE_TEST_ENV value for functional tests.
+    required: true
+  suite:
+    description: Test suite to run.
+    required: false
+    default: functional
+  otelcol-image:
+    description: Override for the collector image reference.
+    required: false
+    default: ''
+  skip-tests:
+    description: SKIP_TESTS value for environments that only validate install or upgrade wiring.
+    required: false
+    default: ''
+  upgrade-from-values:
+    description: UPGRADE_FROM_VALUES value for upgrade tests.
+    required: false
+    default: ''
+  upgrade-from-chart-dir:
+    description: UPGRADE_FROM_CHART_DIR value for upgrade tests.
+    required: false
+    default: base/splunk-otel-collector
+
+runs:
+  using: composite
+  steps:
+    - name: Download the latest published release to use as a base for the upgrade
+      if: inputs.mode == 'upgrade'
+      shell: bash
+      run: |
+        helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
+        helm repo update
+        helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache-dependency-path: '**/go.sum'
+
+    - name: Update dependencies
+      shell: bash
+      run: make dep-update
+
+    - name: Run functional tests
+      shell: bash
+      env:
+        HOST_ENDPOINT: 0.0.0.0
+        KUBE_TEST_ENV: ${{ inputs.kube-test-env }}
+        OTELCOL_IMAGE: ${{ inputs.otelcol-image }}
+        SKIP_TESTS: ${{ inputs.skip-tests }}
+        UPGRADE_FROM_VALUES: ${{ inputs.upgrade-from-values }}
+        UPGRADE_FROM_CHART_DIR: ${{ inputs.mode == 'upgrade' && inputs.upgrade-from-chart-dir || '' }}
+        SUITE: ${{ inputs.suite }}
+      run: TEARDOWN_BEFORE_SETUP=true make functionaltest

--- a/.github/actions/cloud-functional-test/action.yaml
+++ b/.github/actions/cloud-functional-test/action.yaml
@@ -2,20 +2,13 @@ name: Run Cloud Functional Tests
 description: Run install or upgrade functional tests against an existing cloud Kubernetes cluster.
 
 inputs:
-  go-version:
-    description: Go version to install.
+  kube-test-env:
+    description: KUBE_TEST_ENV value for functional tests.
     required: true
   mode:
     description: 'Test mode: install or upgrade.'
     required: false
     default: install
-  kube-test-env:
-    description: KUBE_TEST_ENV value for functional tests.
-    required: true
-  suite:
-    description: Test suite to run.
-    required: false
-    default: functional
   otelcol-image:
     description: Override for the collector image reference.
     required: false
@@ -28,10 +21,6 @@ inputs:
     description: UPGRADE_FROM_VALUES value for upgrade tests.
     required: false
     default: ''
-  upgrade-from-chart-dir:
-    description: UPGRADE_FROM_CHART_DIR value for upgrade tests.
-    required: false
-    default: base/splunk-otel-collector
 
 runs:
   using: composite
@@ -47,7 +36,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: ${{ inputs.go-version }}
+        go-version: 1.26.2
         cache-dependency-path: '**/go.sum'
 
     - name: Update dependencies
@@ -62,6 +51,6 @@ runs:
         OTELCOL_IMAGE: ${{ inputs.otelcol-image }}
         SKIP_TESTS: ${{ inputs.skip-tests }}
         UPGRADE_FROM_VALUES: ${{ inputs.upgrade-from-values }}
-        UPGRADE_FROM_CHART_DIR: ${{ inputs.mode == 'upgrade' && inputs.upgrade-from-chart-dir || '' }}
-        SUITE: ${{ inputs.suite }}
+        UPGRADE_FROM_CHART_DIR: ${{ inputs.mode == 'upgrade' && 'base/splunk-otel-collector' || '' }}
+        SUITE: functional
       run: TEARDOWN_BEFORE_SETUP=true make functionaltest

--- a/.github/actions/cloud-functional-test/action.yaml
+++ b/.github/actions/cloud-functional-test/action.yaml
@@ -2,6 +2,9 @@ name: Run Cloud Functional Tests
 description: Run install or upgrade functional tests against an existing cloud Kubernetes cluster.
 
 inputs:
+  go-version:
+    description: Go version to install for functional tests.
+    required: true
   kube-test-env:
     description: KUBE_TEST_ENV value for functional tests.
     required: true
@@ -36,7 +39,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: 1.26.2
+        go-version: ${{ inputs.go-version }}
         cache-dependency-path: '**/go.sum'
 
     - name: Update dependencies

--- a/.github/actions/create-pr/action.yaml
+++ b/.github/actions/create-pr/action.yaml
@@ -2,6 +2,15 @@ name: Create PR
 description: Commit local changes, push a branch, and create or update a pull request with gh
 
 inputs:
+  author-email:
+    description: Git author email
+    required: true
+  author-name:
+    description: Git author name
+    required: true
+  body:
+    description: Pull request body
+    required: true
   branch:
     description: Branch to push
     required: true
@@ -10,15 +19,6 @@ inputs:
     required: true
   title:
     description: Pull request title
-    required: true
-  body:
-    description: Pull request body
-    required: true
-  author-name:
-    description: Git author name
-    required: true
-  author-email:
-    description: Git author email
     required: true
 
 outputs:

--- a/.github/actions/eks-kube-context/action.yaml
+++ b/.github/actions/eks-kube-context/action.yaml
@@ -1,0 +1,38 @@
+name: Configure EKS Kubernetes Context
+description: Configure kubeconfig for EKS cloud functional tests.
+
+inputs:
+  kubeconfig-path:
+    description: Kubeconfig path to export as KUBECONFIG.
+    required: true
+  aws-access-key-id:
+    description: AWS access key ID.
+    required: true
+  aws-secret-access-key:
+    description: AWS secret access key.
+    required: true
+  aws-region:
+    description: AWS region.
+    required: true
+  aws-cluster-name:
+    description: EKS cluster name.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Export kubeconfig path
+      shell: bash
+      run: echo "KUBECONFIG=${{ inputs.kubeconfig-path }}" >> "$GITHUB_ENV"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-region }}
+        mask-aws-account-id: true
+
+    - name: Install EKS kubeconfig
+      shell: bash
+      run: aws eks update-kubeconfig --name "${{ inputs.aws-cluster-name }}" --region "${{ inputs.aws-region }}"

--- a/.github/actions/eks-kube-context/action.yaml
+++ b/.github/actions/eks-kube-context/action.yaml
@@ -2,20 +2,20 @@ name: Configure EKS Kubernetes Context
 description: Configure kubeconfig for EKS cloud functional tests.
 
 inputs:
-  kubeconfig-path:
-    description: Kubeconfig path to export as KUBECONFIG.
-    required: true
   aws-access-key-id:
     description: AWS access key ID.
     required: true
-  aws-secret-access-key:
-    description: AWS secret access key.
+  aws-cluster-name:
+    description: EKS cluster name.
     required: true
   aws-region:
     description: AWS region.
     required: true
-  aws-cluster-name:
-    description: EKS cluster name.
+  aws-secret-access-key:
+    description: AWS secret access key.
+    required: true
+  kubeconfig-path:
+    description: Kubeconfig path to export as KUBECONFIG.
     required: true
 
 runs:

--- a/.github/actions/eks-kube-context/action.yaml
+++ b/.github/actions/eks-kube-context/action.yaml
@@ -34,5 +34,8 @@ runs:
         mask-aws-account-id: true
 
     - name: Install EKS kubeconfig
+      env:
+        AWS_CLUSTER_NAME: ${{ inputs.aws-cluster-name }}
+        AWS_REGION: ${{ inputs.aws-region }}
       shell: bash
-      run: aws eks update-kubeconfig --name "${{ inputs.aws-cluster-name }}" --region "${{ inputs.aws-region }}"
+      run: aws eks update-kubeconfig --name "$AWS_CLUSTER_NAME" --region "$AWS_REGION"

--- a/.github/actions/functional-test/action.yaml
+++ b/.github/actions/functional-test/action.yaml
@@ -4,12 +4,14 @@ description: >
   suite. Optionally overrides the collector image and uploads debug artifacts.
 
 inputs:
-  k8s-version:
-    description: 'Kubernetes version for the kind cluster (e.g. v1.34.3)'
-    required: true
-  suite:
-    description: 'Test suite to run (passed as SUITE= to make functionaltest)'
-    required: true
+  artifact-suffix:
+    description: 'Suffix for the k8s debug info artifact name'
+    required: false
+    default: ''
+  build-test-images:
+    description: 'Whether to build and load test images into kind'
+    required: false
+    default: 'true'
   go-version:
     description: 'Go version to install'
     required: false
@@ -18,26 +20,24 @@ inputs:
     description: 'Path to go.mod to determine Go version (used when go-version is not set)'
     required: false
     default: ''
-  build-test-images:
-    description: 'Whether to build and load test images into kind'
-    required: false
-    default: 'true'
-  update-expected-results:
-    description: 'Whether to update golden file expected test results'
-    required: false
-    default: 'false'
+  k8s-version:
+    description: 'Kubernetes version for the kind cluster (e.g. v1.34.3)'
+    required: true
   kubernetes-debug-info:
     description: 'Whether to collect and upload k8s debug info'
     required: false
     default: 'false'
-  artifact-suffix:
-    description: 'Suffix for the k8s debug info artifact name'
-    required: false
-    default: ''
   otelcol-image:
     description: 'Override for the collector image reference (repository[:tag])'
     required: false
     default: ''
+  suite:
+    description: 'Test suite to run (passed as SUITE= to make functionaltest)'
+    required: true
+  update-expected-results:
+    description: 'Whether to update golden file expected test results'
+    required: false
+    default: 'false'
 
 runs:
   using: composite

--- a/.github/actions/gke-kube-context/action.yaml
+++ b/.github/actions/gke-kube-context/action.yaml
@@ -1,0 +1,37 @@
+name: Configure GKE Kubernetes Context
+description: Configure kubeconfig for GKE cloud functional tests.
+
+inputs:
+  gke-project-id:
+    description: GKE project ID.
+    required: true
+  gke-credentials-json:
+    description: GKE service account credentials JSON.
+    required: true
+  gke-cluster-name:
+    description: GKE cluster name.
+    required: true
+  gke-location:
+    description: GKE cluster location.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+      with:
+        project_id: ${{ inputs.gke-project-id }}
+        credentials_json: ${{ inputs.gke-credentials-json }}
+
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+      with:
+        project_id: ${{ inputs.gke-project-id }}
+
+    - name: Install GKE kubeconfig
+      uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
+      with:
+        cluster_name: ${{ inputs.gke-cluster-name }}
+        location: ${{ inputs.gke-location }}
+        project_id: ${{ inputs.gke-project-id }}

--- a/.github/actions/gke-kube-context/action.yaml
+++ b/.github/actions/gke-kube-context/action.yaml
@@ -2,17 +2,17 @@ name: Configure GKE Kubernetes Context
 description: Configure kubeconfig for GKE cloud functional tests.
 
 inputs:
-  gke-project-id:
-    description: GKE project ID.
+  gke-cluster-name:
+    description: GKE cluster name.
     required: true
   gke-credentials-json:
     description: GKE service account credentials JSON.
     required: true
-  gke-cluster-name:
-    description: GKE cluster name.
-    required: true
   gke-location:
     description: GKE cluster location.
+    required: true
+  gke-project-id:
+    description: GKE project ID.
     required: true
 
 runs:

--- a/.github/actions/kubeconfig-secret-context/action.yaml
+++ b/.github/actions/kubeconfig-secret-context/action.yaml
@@ -1,0 +1,25 @@
+name: Configure Kubernetes Context from Secret
+description: Configure kubeconfig from secret content for cloud functional tests.
+
+inputs:
+  kubeconfig-path:
+    description: Kubeconfig path to export as KUBECONFIG.
+    required: true
+  kubeconfig-content:
+    description: Raw kubeconfig content.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Export kubeconfig path
+      shell: bash
+      run: echo "KUBECONFIG=${{ inputs.kubeconfig-path }}" >> "$GITHUB_ENV"
+
+    - name: Install kubeconfig from secret
+      shell: bash
+      env:
+        KUBECONFIG_CONTENT: ${{ inputs.kubeconfig-content }}
+      run: |
+        echo "$KUBECONFIG_CONTENT" > "${{ inputs.kubeconfig-path }}"
+        chmod 600 "${{ inputs.kubeconfig-path }}"

--- a/.github/actions/kubeconfig-secret-context/action.yaml
+++ b/.github/actions/kubeconfig-secret-context/action.yaml
@@ -2,11 +2,11 @@ name: Configure Kubernetes Context from Secret
 description: Configure kubeconfig from secret content for cloud functional tests.
 
 inputs:
-  kubeconfig-path:
-    description: Kubeconfig path to export as KUBECONFIG.
-    required: true
   kubeconfig-content:
     description: Raw kubeconfig content.
+    required: true
+  kubeconfig-path:
+    description: Kubeconfig path to export as KUBECONFIG.
     required: true
 
 runs:

--- a/.github/actions/kubeconfig-secret-context/action.yaml
+++ b/.github/actions/kubeconfig-secret-context/action.yaml
@@ -20,6 +20,7 @@ runs:
       shell: bash
       env:
         KUBECONFIG_CONTENT: ${{ inputs.kubeconfig-content }}
+        KUBECONFIG_PATH: ${{ inputs.kubeconfig-path }}
       run: |
-        echo "$KUBECONFIG_CONTENT" > "${{ inputs.kubeconfig-path }}"
-        chmod 600 "${{ inputs.kubeconfig-path }}"
+        printf '%s' "$KUBECONFIG_CONTENT" > "$KUBECONFIG_PATH"
+        chmod 600 "$KUBECONFIG_PATH"

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -142,569 +142,343 @@ jobs:
     name: Test helm install in EKS - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks
-      KUBE_TEST_ENV: eks
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/eks-kube-context
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
-        with:
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks
           aws-access-key-id: ${{ secrets.AWS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET }}
           aws-region: us-west-1
-          mask-aws-account-id: true
-      - name: Install kubeconfig
-        run: |
-          aws eks update-kubeconfig --name rotel-eks --region us-west-1
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          aws-cluster-name: rotel-eks
+
+      - uses: ./.github/actions/cloud-functional-test
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          kube-test-env: eks
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   eks-upgrade-test:
     name: Test helm upgrade in EKS - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks
-      KUBE_TEST_ENV: eks
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Download the latest published release to use as a base for the upgrade
-        run: |
-          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
-          helm repo update
-          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/eks-kube-context
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
-        with:
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks
           aws-access-key-id: ${{ secrets.AWS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET }}
           aws-region: us-west-1
-          mask-aws-account-id: true
-      - name: Install kubeconfig
-        run: |
-          aws eks update-kubeconfig --name rotel-eks --region us-west-1
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          UPGRADE_FROM_VALUES: eks_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          aws-cluster-name: rotel-eks
+
+      - uses: ./.github/actions/cloud-functional-test
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          mode: upgrade
+          kube-test-env: eks
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
+          upgrade-from-values: eks_upgrade_from_previous_release_values.yaml
 
   gke-autopilot-test:
     name: Test helm install in GKE/Autopilot - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' && needs.collector-image-config.outputs.gke-autopilot-allowed == 'true' }}
-    env:
-      KUBE_TEST_ENV: gke/autopilot
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/gke-kube-context
+        with:
+          gke-project-id: ${{ secrets.GKE_PROJECT }}
+          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
+          gke-cluster-name: ${{ secrets.GKE_AUTOPILOT_CLUSTER }}
+          gke-location: ${{ secrets.GKE_REGION }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          project_id: ${{ secrets.GKE_PROJECT }}
-          credentials_json: ${{ secrets.GKE_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-        with:
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
-        with:
-          cluster_name: ${{ secrets.GKE_AUTOPILOT_CLUSTER }}
-          location: ${{ secrets.GKE_REGION }}
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          kube-test-env: gke/autopilot
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   gke-autopilot-upgrade-test:
     name: Test helm upgrade in GKE/Autopilot - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' && needs.collector-image-config.outputs.gke-autopilot-allowed == 'true' }}
-    env:
-      KUBE_TEST_ENV: gke/autopilot
-      SKIP_TESTS: "true"
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Download the latest published release to use as a base for the upgrade
-        run: |
-          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
-          helm repo update
-          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/gke-kube-context
+        with:
+          gke-project-id: ${{ secrets.GKE_PROJECT }}
+          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
+          gke-cluster-name: ${{ secrets.GKE_AUTOPILOT_CLUSTER }}
+          gke-location: ${{ secrets.GKE_REGION }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          project_id: ${{ secrets.GKE_PROJECT }}
-          credentials_json: ${{ secrets.GKE_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-        with:
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
-        with:
-          cluster_name: ${{ secrets.GKE_AUTOPILOT_CLUSTER }}
-          location: ${{ secrets.GKE_REGION }}
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          UPGRADE_FROM_VALUES: gke_autopilot_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          mode: upgrade
+          kube-test-env: gke/autopilot
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
+          skip-tests: "true"
+          upgrade-from-values: gke_autopilot_upgrade_from_previous_release_values.yaml
 
   aks-windows-test:
     name: Test helm install in AKS - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBE_TEST_ENV: aks
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/aks-kube-context
+        with:
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          aks-resource-group: ${{ secrets.AKS_RESOURCE_GROUP }}
+          aks-cluster-name: ${{ secrets.AKS_CLUSTER_NAME }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Set up kubelogin for non-interactive login
-        uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
-        with:
-          kubelogin-version: "v0.0.24"
-      - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: azure/aks-set-context@c7eb093e5a5d47caa333f64974d5fd1cd4bf069d # v4
-        with:
-          resource-group: ${{ secrets.AKS_RESOURCE_GROUP }}
-          cluster-name: ${{ secrets.AKS_CLUSTER_NAME }}
-          admin: false
-          use-kubelogin: true
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          kube-test-env: aks
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   aks-windows-upgrade-test:
     name: Test helm upgrade in AKS - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBE_TEST_ENV: aks
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Download the latest published release to use as a base for the upgrade
-        run: |
-          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
-          helm repo update
-          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/aks-kube-context
+        with:
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          aks-resource-group: ${{ secrets.AKS_RESOURCE_GROUP }}
+          aks-cluster-name: ${{ secrets.AKS_CLUSTER_NAME }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Set up kubelogin for non-interactive login
-        uses: azure/use-kubelogin@76597ae0fcbaace21b05e13a2cbf8daee2c6e820 # v1.2
-        with:
-          kubelogin-version: "v0.0.24"
-      - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: azure/aks-set-context@c7eb093e5a5d47caa333f64974d5fd1cd4bf069d # v4
-        with:
-          resource-group: ${{ secrets.AKS_RESOURCE_GROUP }}
-          cluster-name: ${{ secrets.AKS_CLUSTER_NAME }}
-          admin: false
-          use-kubelogin: true
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          mode: upgrade
+          kube-test-env: aks
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   gce-autopilot-test:
     name: Test helm install in GCE (kops) - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBE_TEST_ENV: gce
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/kubeconfig-secret-context
+        with:
+          kubeconfig-path: /tmp/kubeconfig
+          kubeconfig-content: ${{ secrets.GCE_KUBECONFIG }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: Set kubeconfig
-        run: echo "$GCE_KUBECONFIG" > /tmp/kubeconfig
-        env:
-          GCE_KUBECONFIG: ${{ secrets.GCE_KUBECONFIG }}
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          KUBECONFIG: /tmp/kubeconfig
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          kube-test-env: gce
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   eks-fargate-test:
     name: Test helm install in EKS Fargate - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-fargate
-      KUBE_TEST_ENV: "eks/fargate"
-      SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/eks-kube-context
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
-        with:
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-fargate
           aws-access-key-id: ${{ secrets.AWS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET }}
           aws-region: us-west-2
-          mask-aws-account-id: true
-      - name: Install kubeconfig
-        run: |
-          aws eks update-kubeconfig --name gdi-github-eks-fargate --region us-west-2
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          aws-cluster-name: gdi-github-eks-fargate
+
+      - uses: ./.github/actions/cloud-functional-test
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          kube-test-env: eks/fargate
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
+          skip-tests: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
 
   eks-fargate-upgrade-test:
     name: Test helm upgrade in EKS Fargate - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-fargate
-      KUBE_TEST_ENV: "eks/fargate"
-      SKIP_TESTS: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Download the latest published release to use as a base for the upgrade
-        run: |
-          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
-          helm repo update
-          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/eks-kube-context
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
-        with:
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-fargate
           aws-access-key-id: ${{ secrets.AWS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET }}
           aws-region: us-west-2
-          mask-aws-account-id: true
-      - name: Install kubeconfig
-        run: |
-          aws eks update-kubeconfig --name gdi-github-eks-fargate --region us-west-2
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          UPGRADE_FROM_VALUES: eks_fargate_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          aws-cluster-name: gdi-github-eks-fargate
+
+      - uses: ./.github/actions/cloud-functional-test
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          mode: upgrade
+          kube-test-env: eks/fargate
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
+          skip-tests: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
+          upgrade-from-values: eks_fargate_upgrade_from_previous_release_values.yaml
 
   eks-auto-mode-test:
     name: Test helm install in EKS Auto Mode - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
-      KUBE_TEST_ENV: eks/auto-mode
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/eks-kube-context
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
-        with:
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
           aws-access-key-id: ${{ secrets.AWS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET }}
           aws-region: us-west-2
-          mask-aws-account-id: true
-      - name: Install kubeconfig
-        run: |
-          aws eks update-kubeconfig --name rotel-eks-autotest --region us-west-2
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          aws-cluster-name: rotel-eks-autotest
+
+      - uses: ./.github/actions/cloud-functional-test
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          kube-test-env: eks/auto-mode
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   eks-auto-mode-upgrade-test:
     name: Test helm upgrade in EKS Auto Mode - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
-      KUBE_TEST_ENV: eks/auto-mode
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Download the latest published release to use as a base for the upgrade
-        run: |
-          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
-          helm repo update
-          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/eks-kube-context
         with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
-        with:
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
           aws-access-key-id: ${{ secrets.AWS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET }}
           aws-region: us-west-2
-          mask-aws-account-id: true
-      - name: Install kubeconfig
-        run: |
-          aws eks update-kubeconfig --name rotel-eks-autotest --region us-west-2
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          UPGRADE_FROM_VALUES: eks_auto_mode_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          aws-cluster-name: rotel-eks-autotest
+
+      - uses: ./.github/actions/cloud-functional-test
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          mode: upgrade
+          kube-test-env: eks/auto-mode
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
+          upgrade-from-values: eks_auto_mode_upgrade_from_previous_release_values.yaml
 
   rosa-test:
     name: Test helm install in ROSA - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
-      KUBE_TEST_ENV: rosa
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/kubeconfig-secret-context
+        with:
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
+          kubeconfig-content: ${{ secrets.ROSA_KUBECONFIG }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Set kubeconfig
-        run: |
-          echo "$ROSA_KUBECONFIG" > ${{ env.KUBECONFIG }}
-          chmod 600 ${{ env.KUBECONFIG }}
-        env:
-          ROSA_KUBECONFIG: ${{ secrets.ROSA_KUBECONFIG }}
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          kube-test-env: rosa
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   rosa-upgrade-test:
     name: Test helm upgrade in ROSA - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBECONFIG: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
-      KUBE_TEST_ENV: rosa
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Download the latest published release to use as a base for the upgrade
-        run: |
-          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
-          helm repo update
-          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/kubeconfig-secret-context
+        with:
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
+          kubeconfig-content: ${{ secrets.ROSA_KUBECONFIG }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - name: Set kubeconfig
-        run: |
-          echo "$ROSA_KUBECONFIG" > ${{ env.KUBECONFIG }}
-          chmod 600 ${{ env.KUBECONFIG }}
-        env:
-          ROSA_KUBECONFIG: ${{ secrets.ROSA_KUBECONFIG }}
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          UPGRADE_FROM_VALUES: rosa_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          mode: upgrade
+          kube-test-env: rosa
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
+          upgrade-from-values: rosa_upgrade_from_previous_release_values.yaml
 
   gke-test:
     name: Test helm install in GKE - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBE_TEST_ENV: gke
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/gke-kube-context
+        with:
+          gke-project-id: ${{ secrets.GKE_PROJECT }}
+          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
+          gke-cluster-name: ${{ secrets.GKE_CLUSTER }}
+          gke-location: ${{ secrets.GKE_REGION }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          project_id: ${{ secrets.GKE_PROJECT }}
-          credentials_json: ${{ secrets.GKE_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-        with:
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER }}
-          location: ${{ secrets.GKE_REGION }}
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          kube-test-env: gke
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   gke-upgrade-test:
     name: Test helm upgrade in GKE - credentials needed
     needs: collector-image-config
     if: ${{ needs.collector-image-config.outputs.cloud-tests-enabled == 'true' }}
-    env:
-      KUBE_TEST_ENV: gke
-      SKIP_TESTS: "true"
-      OTELCOL_IMAGE: ${{ needs.collector-image-config.outputs.otelcol-image }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'Ignore Tests') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Download the latest published release to use as a base for the upgrade
-        run: |
-          helm repo add splunk-otel-collector-chart https://signalfx.github.io/splunk-otel-collector-chart
-          helm repo update
-          helm pull splunk-otel-collector-chart/splunk-otel-collector --untar --untardir base
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+
+      - uses: ./.github/actions/gke-kube-context
+        with:
+          gke-project-id: ${{ secrets.GKE_PROJECT }}
+          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
+          gke-cluster-name: ${{ secrets.GKE_CLUSTER }}
+          gke-location: ${{ secrets.GKE_REGION }}
+
+      - uses: ./.github/actions/cloud-functional-test
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: '**/go.sum'
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        with:
-          project_id: ${{ secrets.GKE_PROJECT }}
-          credentials_json: ${{ secrets.GKE_SA_KEY }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
-        with:
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER }}
-          location: ${{ secrets.GKE_REGION }}
-          project_id: ${{ secrets.GKE_PROJECT }}
-      - name: Update dependencies
-        run: |
-          make dep-update
-      - name: run functional tests
-        env:
-          HOST_ENDPOINT: 0.0.0.0
-          UPGRADE_FROM_VALUES: gke_upgrade_from_previous_release_values.yaml
-          UPGRADE_FROM_CHART_DIR: base/splunk-otel-collector
-        run: |
-          TEARDOWN_BEFORE_SETUP=true SUITE=functional make functionaltest
+          mode: upgrade
+          kube-test-env: gke
+          otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
+          skip-tests: "true"
+          upgrade-from-values: gke_upgrade_from_previous_release_values.yaml

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -130,13 +130,13 @@ jobs:
 
       - uses: ./.github/actions/functional-test
         with:
-          k8s-version: ${{ matrix.k8s-kind-version }}
-          suite: ${{ matrix.test-job }}
-          go-version: ${{ env.GO_VERSION }}
-          update-expected-results: ${{ env.UPDATE_EXPECTED_RESULTS }}
-          kubernetes-debug-info: ${{ env.KUBERNETES_DEBUG_INFO }}
           artifact-suffix: ${{ matrix.test-job }}-${{ matrix.k8s-kind-version }}
+          go-version: ${{ env.GO_VERSION }}
+          k8s-version: ${{ matrix.k8s-kind-version }}
+          kubernetes-debug-info: ${{ env.KUBERNETES_DEBUG_INFO }}
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
+          suite: ${{ matrix.test-job }}
+          update-expected-results: ${{ env.UPDATE_EXPECTED_RESULTS }}
 
   eks-test:
     name: Test helm install in EKS - credentials needed
@@ -149,15 +149,14 @@ jobs:
 
       - uses: ./.github/actions/eks-kube-context
         with:
-          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks
           aws-access-key-id: ${{ secrets.AWS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-          aws-region: us-west-1
           aws-cluster-name: rotel-eks
+          aws-region: us-west-1
+          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -172,17 +171,16 @@ jobs:
 
       - uses: ./.github/actions/eks-kube-context
         with:
-          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks
           aws-access-key-id: ${{ secrets.AWS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-          aws-region: us-west-1
           aws-cluster-name: rotel-eks
+          aws-region: us-west-1
+          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
-          mode: upgrade
           kube-test-env: eks
+          mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
           upgrade-from-values: eks_upgrade_from_previous_release_values.yaml
 
@@ -197,14 +195,13 @@ jobs:
 
       - uses: ./.github/actions/gke-kube-context
         with:
-          gke-project-id: ${{ secrets.GKE_PROJECT }}
-          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
           gke-cluster-name: ${{ secrets.GKE_AUTOPILOT_CLUSTER }}
+          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
           gke-location: ${{ secrets.GKE_REGION }}
+          gke-project-id: ${{ secrets.GKE_PROJECT }}
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
           kube-test-env: gke/autopilot
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -219,16 +216,15 @@ jobs:
 
       - uses: ./.github/actions/gke-kube-context
         with:
-          gke-project-id: ${{ secrets.GKE_PROJECT }}
-          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
           gke-cluster-name: ${{ secrets.GKE_AUTOPILOT_CLUSTER }}
+          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
           gke-location: ${{ secrets.GKE_REGION }}
+          gke-project-id: ${{ secrets.GKE_PROJECT }}
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
-          mode: upgrade
           kube-test-env: gke/autopilot
+          mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
           skip-tests: "true"
           upgrade-from-values: gke_autopilot_upgrade_from_previous_release_values.yaml
@@ -244,13 +240,12 @@ jobs:
 
       - uses: ./.github/actions/aks-kube-context
         with:
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          aks-resource-group: ${{ secrets.AKS_RESOURCE_GROUP }}
           aks-cluster-name: ${{ secrets.AKS_CLUSTER_NAME }}
+          aks-resource-group: ${{ secrets.AKS_RESOURCE_GROUP }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
           kube-test-env: aks
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -265,15 +260,14 @@ jobs:
 
       - uses: ./.github/actions/aks-kube-context
         with:
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          aks-resource-group: ${{ secrets.AKS_RESOURCE_GROUP }}
           aks-cluster-name: ${{ secrets.AKS_CLUSTER_NAME }}
+          aks-resource-group: ${{ secrets.AKS_RESOURCE_GROUP }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
-          mode: upgrade
           kube-test-env: aks
+          mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
   gce-autopilot-test:
@@ -287,12 +281,11 @@ jobs:
 
       - uses: ./.github/actions/kubeconfig-secret-context
         with:
-          kubeconfig-path: /tmp/kubeconfig
           kubeconfig-content: ${{ secrets.GCE_KUBECONFIG }}
+          kubeconfig-path: /tmp/kubeconfig
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
           kube-test-env: gce
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -307,15 +300,14 @@ jobs:
 
       - uses: ./.github/actions/eks-kube-context
         with:
-          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-fargate
           aws-access-key-id: ${{ secrets.AWS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-          aws-region: us-west-2
           aws-cluster-name: gdi-github-eks-fargate
+          aws-region: us-west-2
+          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-fargate
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks/fargate
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
           skip-tests: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
@@ -331,17 +323,16 @@ jobs:
 
       - uses: ./.github/actions/eks-kube-context
         with:
-          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-fargate
           aws-access-key-id: ${{ secrets.AWS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-          aws-region: us-west-2
           aws-cluster-name: gdi-github-eks-fargate
+          aws-region: us-west-2
+          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-fargate
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
-          mode: upgrade
           kube-test-env: eks/fargate
+          mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
           skip-tests: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
           upgrade-from-values: eks_fargate_upgrade_from_previous_release_values.yaml
@@ -357,15 +348,14 @@ jobs:
 
       - uses: ./.github/actions/eks-kube-context
         with:
-          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
           aws-access-key-id: ${{ secrets.AWS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-          aws-region: us-west-2
           aws-cluster-name: rotel-eks-autotest
+          aws-region: us-west-2
+          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks/auto-mode
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -380,17 +370,16 @@ jobs:
 
       - uses: ./.github/actions/eks-kube-context
         with:
-          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
           aws-access-key-id: ${{ secrets.AWS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
-          aws-region: us-west-2
           aws-cluster-name: rotel-eks-autotest
+          aws-region: us-west-2
+          aws-secret-access-key: ${{ secrets.AWS_SECRET }}
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-eks-auto-mode
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
-          mode: upgrade
           kube-test-env: eks/auto-mode
+          mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
           upgrade-from-values: eks_auto_mode_upgrade_from_previous_release_values.yaml
 
@@ -405,12 +394,11 @@ jobs:
 
       - uses: ./.github/actions/kubeconfig-secret-context
         with:
-          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
           kubeconfig-content: ${{ secrets.ROSA_KUBECONFIG }}
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
           kube-test-env: rosa
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -425,14 +413,13 @@ jobs:
 
       - uses: ./.github/actions/kubeconfig-secret-context
         with:
-          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
           kubeconfig-content: ${{ secrets.ROSA_KUBECONFIG }}
+          kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
-          mode: upgrade
           kube-test-env: rosa
+          mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
           upgrade-from-values: rosa_upgrade_from_previous_release_values.yaml
 
@@ -447,14 +434,13 @@ jobs:
 
       - uses: ./.github/actions/gke-kube-context
         with:
-          gke-project-id: ${{ secrets.GKE_PROJECT }}
-          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
           gke-cluster-name: ${{ secrets.GKE_CLUSTER }}
+          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
           gke-location: ${{ secrets.GKE_REGION }}
+          gke-project-id: ${{ secrets.GKE_PROJECT }}
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
           kube-test-env: gke
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -469,16 +455,15 @@ jobs:
 
       - uses: ./.github/actions/gke-kube-context
         with:
-          gke-project-id: ${{ secrets.GKE_PROJECT }}
-          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
           gke-cluster-name: ${{ secrets.GKE_CLUSTER }}
+          gke-credentials-json: ${{ secrets.GKE_SA_KEY }}
           gke-location: ${{ secrets.GKE_REGION }}
+          gke-project-id: ${{ secrets.GKE_PROJECT }}
 
       - uses: ./.github/actions/cloud-functional-test
         with:
-          go-version: ${{ env.GO_VERSION }}
-          mode: upgrade
           kube-test-env: gke
+          mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
           skip-tests: "true"
           upgrade-from-values: gke_upgrade_from_previous_release_values.yaml

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -157,6 +157,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -179,6 +180,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks
           mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
@@ -202,6 +204,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: gke/autopilot
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -223,6 +226,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: gke/autopilot
           mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
@@ -246,6 +250,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: aks
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -266,6 +271,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: aks
           mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
@@ -286,6 +292,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: gce
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -308,6 +315,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks/fargate
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
           skip-tests: "true" # we need to skip functional tests as we have not set probes to listen to the traffic.
@@ -331,6 +339,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks/fargate
           mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
@@ -356,6 +365,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks/auto-mode
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -378,6 +388,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: eks/auto-mode
           mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
@@ -399,6 +410,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: rosa
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -418,6 +430,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: rosa
           mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
@@ -441,6 +454,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: gke
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}
 
@@ -462,6 +476,7 @@ jobs:
 
       - uses: ./.github/actions/cloud-functional-test
         with:
+          go-version: ${{ env.GO_VERSION }}
           kube-test-env: gke
           mode: upgrade
           otelcol-image: ${{ needs.collector-image-config.outputs.otelcol-image }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Most of the functional tests have two tests for each cluster - install and upgrade. This attempts to simplify the workflow by moving to re-used composite actions instead of duplicate workflow job logic.

There are now composite actions for:
1. Setting up each cluster for the test - Each cloud environment has its own composite action here
2. Running the functional tests - All tests use the same composite action

_Also, alphabetized order of variables being defined and referenced in lists._