### PR TITLE
[chore][configuration switching] Fix expected source types in test

### DIFF
--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -174,28 +174,28 @@ func testIndexSwitch(t *testing.T) {
 		internal.WaitForMetrics(t, 3, hecMetricsConsumer)
 		internal.WaitForLogs(t, 3, agentLogsConsumer)
 
-		var sourceTypes, originalSourceTypes []string
+		var sourcetypes, originalSourcetypes []string
 		var indices []string
 		logs := agentLogsConsumer.AllLogs()
-		originalSourceTypes, indices = getLogsIndexAndSourceType(logs)
+		originalSourcetypes, indices = getLogsIndexAndSourceType(logs)
 
 		// This is to avoid flaky test failures as logs are also coming from cluster receiver events
 		eventPrefix := "kube:event"
-		for _, sourceType := range originalSourceTypes {
+		for _, sourceType := range originalSourcetypes {
 			if !strings.HasPrefix(sourceType, eventPrefix) {
-				sourceTypes = append(sourceTypes, sourceType)
+				sourcetypes = append(sourcetypes, sourceType)
 			}
 		}
 
-		assert.Greater(t, len(sourceTypes), 1) // we are receiving logs from different containers
+		assert.Greater(t, len(sourcetypes), 1) // we are receiving logs from different containers
 		// check sourcetypes have same prefix
-		containerPrefix := "kube:container:"
-		for _, element := range sourceTypes {
-			if !strings.HasPrefix(element, containerPrefix) {
-				t.Errorf("Element does not start with the prefix %q: %s", containerPrefix, element)
+		prefix := "kube:container:"
+		for _, element := range sourcetypes {
+			if !strings.HasPrefix(element, prefix) {
+				t.Errorf("Element does not start with the prefix %q: %s", prefix, element)
 			}
 		}
-		assert.NotContains(t, sourceTypes, nonDefaultSourcetype)
+		assert.NotContains(t, sourcetypes, nonDefaultSourcetype)
 		assert.Len(t, indices, 1)
 		assert.Equal(t, logsIndex, indices[0])
 

--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -180,10 +180,12 @@ func testIndexSwitch(t *testing.T) {
 		sourcetypes, indices = getLogsIndexAndSourceType(logs)
 		assert.Greater(t, len(sourcetypes), 1) // we are receiving logs from different containers
 		// check sourcetypes have same prefix
-		prefix := "kube:container:"
+		containerPrefix := "kube:container:"
+		// This is to avoid flaky test failures as logs are also coming from cluster receiver events
+		eventPrefix := "kube:event:"
 		for _, element := range sourcetypes {
-			if !strings.HasPrefix(element, prefix) {
-				t.Errorf("Element does not start with the prefix %q: %s", prefix, element)
+			if !strings.HasPrefix(element, containerPrefix) || !strings.HasPrefix(element, eventPrefix) {
+				t.Errorf("Element does not start with an expected prefix (%q or %q): %s", containerPrefix, eventPrefix, element)
 			}
 		}
 		assert.NotContains(t, sourcetypes, nonDefaultSourcetype)

--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -184,7 +184,7 @@ func testIndexSwitch(t *testing.T) {
 		// This is to avoid flaky test failures as logs are also coming from cluster receiver events
 		eventPrefix := "kube:event:"
 		for _, element := range sourcetypes {
-			if !strings.HasPrefix(element, containerPrefix) || !strings.HasPrefix(element, eventPrefix) {
+			if !strings.HasPrefix(element, containerPrefix) && !strings.HasPrefix(element, eventPrefix) {
 				t.Errorf("Element does not start with an expected prefix (%q or %q): %s", containerPrefix, eventPrefix, element)
 			}
 		}

--- a/functional_tests/configuration_switching/configuration_switching_test.go
+++ b/functional_tests/configuration_switching/configuration_switching_test.go
@@ -174,21 +174,28 @@ func testIndexSwitch(t *testing.T) {
 		internal.WaitForMetrics(t, 3, hecMetricsConsumer)
 		internal.WaitForLogs(t, 3, agentLogsConsumer)
 
-		var sourcetypes []string
+		var sourceTypes, originalSourceTypes []string
 		var indices []string
 		logs := agentLogsConsumer.AllLogs()
-		sourcetypes, indices = getLogsIndexAndSourceType(logs)
-		assert.Greater(t, len(sourcetypes), 1) // we are receiving logs from different containers
-		// check sourcetypes have same prefix
-		containerPrefix := "kube:container:"
+		originalSourceTypes, indices = getLogsIndexAndSourceType(logs)
+
 		// This is to avoid flaky test failures as logs are also coming from cluster receiver events
-		eventPrefix := "kube:event:"
-		for _, element := range sourcetypes {
-			if !strings.HasPrefix(element, containerPrefix) && !strings.HasPrefix(element, eventPrefix) {
-				t.Errorf("Element does not start with an expected prefix (%q or %q): %s", containerPrefix, eventPrefix, element)
+		eventPrefix := "kube:event"
+		for _, sourceType := range originalSourceTypes {
+			if !strings.HasPrefix(sourceType, eventPrefix) {
+				sourceTypes = append(sourceTypes, sourceType)
 			}
 		}
-		assert.NotContains(t, sourcetypes, nonDefaultSourcetype)
+
+		assert.Greater(t, len(sourceTypes), 1) // we are receiving logs from different containers
+		// check sourcetypes have same prefix
+		containerPrefix := "kube:container:"
+		for _, element := range sourceTypes {
+			if !strings.HasPrefix(element, containerPrefix) {
+				t.Errorf("Element does not start with the prefix %q: %s", containerPrefix, element)
+			}
+		}
+		assert.NotContains(t, sourceTypes, nonDefaultSourcetype)
 		assert.Len(t, indices, 1)
 		assert.Equal(t, logsIndex, indices[0])
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This test has been flaky with the following failure:
```
=== RUN   Test_Functions/logs_and_metrics_index_switch/default_source_type
    chart.go:122: Running helm install
    common.go:350: [CheckPodsReady] Pod: sock-splunk-otel-collector-agent-8trpr | Phase: Running | Ready: true
    common.go:350: [CheckPodsReady] Pod: sock-splunk-otel-collector-k8s-cluster-receiver-9b485958b-xdztw | Phase: Running | Ready: true
    common.go:358: [CheckPodsReady] All pods ready at: 2026-04-30T19:05:36Z
    common.go:360: [CheckPodsReady] All pods have been ready for: 5.831µs (minReadyTime: 0s)
    configuration_switching_test.go:186: Element does not start with the prefix "kube:container:": kube:events
    configuration_switching_test.go:65: Cleaning up cluster
    configuration_switching_test.go:71: Running teardown
    chart.go:236: Uninstalling release: sock (namespace: default)
    chart.go:190: Attempting to delete secret: sock-operator-controller-manager-service-cert in namespace: default
    chart.go:194: Secret sock-operator-controller-manager-service-cert not found in namespace: default, nothing to delete
    chart.go:351: No opentelemetry.io CRDs found to delete
```

[Events are enabled by default](https://github.com/signalfx/splunk-otel-collector-chart/blob/1321948190f5cfecdccf1919a416bd497a2c1293/helm-charts/splunk-otel-collector/values.yaml#L514) on the cluster receiver, which means that if any events occur while the given test is running, logs will also be sent to the sink with the [source type of `kube:event`.](https://github.com/signalfx/splunk-otel-collector-chart/blob/1321948190f5cfecdccf1919a416bd497a2c1293/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl#L311) This fails the test as it was only expecting the [agent's source type](https://github.com/signalfx/splunk-otel-collector-chart/blob/1321948190f5cfecdccf1919a416bd497a2c1293/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl#L763) that begins with `kube:container`. Note: The Splunk HEC exporter maps `sourcetype` -> `com.splunk.sourcetype`, which is why they appear mismatched from helm configs to resulting logs.

An alternative solution would be to disable events for this test, but in general I think we should stick to default behavior as much as possible in testing.

Examples of this being hit:
https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/25183971206/job/73836291549?pr=2405
https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/25095152189/job/73530077256#step:8:258