### PR TITLE
[chore] Replace yq with sed in render-examples.sh redaction

### DIFF
--- a/ci_scripts/render-examples.sh
+++ b/ci_scripts/render-examples.sh
@@ -60,6 +60,15 @@ render_task() {
     {} +
   find "${rendered_manifests_dir}" -type f -name "*webhook.yaml.bak" -delete
 
+  # Fail loudly if any cert/key field slipped past the redaction regex.
+  # `|| true` keeps `set -e` from aborting when grep finds no matches.
+  leaks=$(find "${rendered_manifests_dir}" -type f -name "*webhook.yaml" \
+            -exec grep -lE "^[[:space:]]+(caBundle|tls\.crt|tls\.key|ca\.crt): [^']" {} + || true)
+  if [ -n "$leaks" ]; then
+    echo "[${example_name}] FAIL - redaction left raw cert/key content in: $leaks"
+    exit 1
+  fi
+
   # Move the chart renders
   cp -rp "${rendered_manifests_dir}/splunk-otel-collector/templates/"* "$rendered_manifests_dir"
   if [ $? -ne 0 ]; then

--- a/ci_scripts/render-examples.sh
+++ b/ci_scripts/render-examples.sh
@@ -60,15 +60,6 @@ render_task() {
     {} +
   find "${rendered_manifests_dir}" -type f -name "*webhook.yaml.bak" -delete
 
-  # Fail loudly if any cert/key field slipped past the redaction regex.
-  # `|| true` keeps `set -e` from aborting when grep finds no matches.
-  leaks=$(find "${rendered_manifests_dir}" -type f -name "*webhook.yaml" \
-            -exec grep -lE "^[[:space:]]+(caBundle|tls\.crt|tls\.key|ca\.crt): [^']" {} + || true)
-  if [ -n "$leaks" ]; then
-    echo "[${example_name}] FAIL - redaction left raw cert/key content in: $leaks"
-    exit 1
-  fi
-
   # Move the chart renders
   cp -rp "${rendered_manifests_dir}/splunk-otel-collector/templates/"* "$rendered_manifests_dir"
   if [ $? -ne 0 ]; then

--- a/ci_scripts/render-examples.sh
+++ b/ci_scripts/render-examples.sh
@@ -50,15 +50,15 @@ render_task() {
     exit 1
   fi
 
-  # Redact cert/key fields in webhook.yaml while preserving yaml structure
-  find "${rendered_manifests_dir}" -type f -name "*webhook.yaml" | while read -r webhook_file; do
-    yq -i '
-      (.. | select(has("caBundle"))) .caBundle |= "[REDACTED CABUNDLE]" |
-      (.. | select(has("data")) | .data | select(has("tls.crt"))) ."tls.crt" |= "[REDACTED CERTIFICATE]" |
-      (.. | select(has("data")) | .data | select(has("tls.key"))) ."tls.key" |= "[REDACTED PRIVATE KEY]" |
-      (.. | select(has("data")) | .data | select(has("ca.crt"))) ."ca.crt" |= "[REDACTED CA CERTIFICATE]"
-    ' "$webhook_file"
-  done
+  # Redact cert/key fields in webhook.yaml. Line-based on purpose: yq's
+  # version-dependent YAML emitter caused drift between local and CI renders.
+  find "${rendered_manifests_dir}" -type f -name "*webhook.yaml" -exec sed -i.bak -E \
+    -e "s/^([[:space:]]+caBundle): .*/\\1: '[REDACTED CABUNDLE]'/" \
+    -e "s/^([[:space:]]+tls\.crt): .*/\\1: '[REDACTED CERTIFICATE]'/" \
+    -e "s/^([[:space:]]+tls\.key): .*/\\1: '[REDACTED PRIVATE KEY]'/" \
+    -e "s/^([[:space:]]+ca\.crt): .*/\\1: '[REDACTED CA CERTIFICATE]'/" \
+    {} +
+  find "${rendered_manifests_dir}" -type f -name "*webhook.yaml.bak" -delete
 
   # Move the chart renders
   cp -rp "${rendered_manifests_dir}/splunk-otel-collector/templates/"* "$rendered_manifests_dir"

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/admission-webhooks/operator-webhook.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/admission-webhooks/operator-webhook.yaml
@@ -25,16 +25,16 @@ webhooks:
     failurePolicy: Fail
     name: minstrumentation.kb.io
     rules:
-      - apiGroups:
-          - opentelemetry.io
-        apiVersions:
-          - v1alpha1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - instrumentations
-        scope: Namespaced
+    - apiGroups:
+        - opentelemetry.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - instrumentations
+      scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
   - admissionReviewVersions:
@@ -108,19 +108,19 @@ webhooks:
         namespace: default
         path: /validate-opentelemetry-io-v1alpha1-instrumentation
         port: 443
-    failurePolicy: Fail
+    failurePolicy:  Fail
     name: vinstrumentationcreateupdate.kb.io
     rules:
-      - apiGroups:
-          - opentelemetry.io
-        apiVersions:
-          - v1alpha1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - instrumentations
-        scope: Namespaced
+    - apiGroups:
+        - opentelemetry.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - instrumentations
+      scope: Namespaced
     sideEffects: None
     timeoutSeconds: 10
   - admissionReviewVersions:
@@ -194,13 +194,11 @@ webhooks:
     sideEffects: None
     timeoutSeconds: 10
 ---
-
+# Source: splunk-otel-collector/charts/operator/templates/admission-webhooks/operator-webhook.yaml
 ---
-
 ---
-
+# Source: splunk-otel-collector/charts/operator/templates/admission-webhooks/operator-webhook.yaml
 ---
-
 ---
 # Source: splunk-otel-collector/charts/operator/templates/admission-webhooks/operator-webhook.yaml
 apiVersion: v1


### PR DESCRIPTION
`make render` was producing different output on developer machines vs CI because the yq-based cert/key redaction in `render-examples.sh` re-emits YAML through yq's parser. yq's emitter behavior is version-dependent — head-comments on empty docs, list-item indentation, and whitespace handling all changed across versions — and CI uses whatever yq ships on `ubuntu-latest`.

- Replace yq with sed for the four cert/key field substitutions; sed is line-based and version-stable
- Regenerate the affected webhook manifest to match helm's raw output (re-running `make render` is now idempotent)