### PR TITLE
rename splunk_app_name parameter to be splunk-otel-collector-chart

### DIFF
--- a/.chloggen/change-splunk-hec-telemetry-label.yaml
+++ b/.chloggen/change-splunk-hec-telemetry-label.yaml
@@ -12,4 +12,3 @@ issues: [2426]
 subtext: |
   The `splunk_app_name` reported by the Splunk HEC exporters changed from `splunk-otel-collector` to be
   `splunk-otel-collector-chart`. This label serves for monitoring telemetry emitted by the chart.
-

--- a/.chloggen/change-splunk-hec-telemetry-label.yaml
+++ b/.chloggen/change-splunk-hec-telemetry-label.yaml
@@ -3,12 +3,12 @@ change_type: breaking
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: chart
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Change `splunk_app_name` in `splunk_hec` exporter to be `splunk-otel-collector-chart`
+note: Change `splunk_app_name` in the `splunk_hec` exporter to `splunk-otel-collector-chart`
 # One or more tracking issues related to the change
 issues: [2426]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  The `splunk_app_name` reported by the Splunk HEC exporters changed from `splunk-otel-collector` to be
+  The `splunk_app_name` reported by the Splunk HEC exporters changed from `splunk-otel-collector` to
   `splunk-otel-collector-chart`. This label serves for monitoring telemetry emitted by the chart.

--- a/.chloggen/change-splunk-hec-telemetry-label.yaml
+++ b/.chloggen/change-splunk-hec-telemetry-label.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change `splunk_app_name` in `splunk_hec` exporter to be `splunk-otel-collector-chart`
+# One or more tracking issues related to the change
+issues: [2426]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `splunk_app_name` reported by the Splunk HEC exporters changed from `splunk-otel-collector` to be
+  `splunk-otel-collector-chart`. This label serves for monitoring telemetry emitted by the chart.
+

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -56,7 +56,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -42,7 +42,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 533efdbbddb6509424eaa78588e6c531eaab7fd8daa6b5397f6da3cb5797b90d
+        checksum/config: 9e7f5dbf9d92db619454fe595f30df5142c09c404179b21651608890bcd8e87c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 27a7db7c9b75a048f76921ae7e84ca8bda61174a0788265579d1e446afc24014
+        checksum/config: 369e0d7d9e761fb3c31fcc0dca4a2549364b1e5b12d334d198c8237cea0f747d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -56,7 +56,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -42,7 +42,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 71d966347da9c72f127f110298af2d7d356288d81e59671beda3d8f1b981bd22
+        checksum/config: d9c9b73ed8f0a487ba8398c23114886fb5c99c9ba69dc94df5634e9e90894f14
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 27a7db7c9b75a048f76921ae7e84ca8bda61174a0788265579d1e446afc24014
+        checksum/config: 369e0d7d9e761fb3c31fcc0dca4a2549364b1e5b12d334d198c8237cea0f747d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-agent.yaml
@@ -51,7 +51,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
@@ -42,7 +42,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 63b4c35b628efdaa4d66a5e41f02f50f350005bda967951bfc07f8eb61635a57
+        checksum/config: 6340ab2acf1c173822a638f424bad914cc925d1c827134658317c81e6a52085c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 27a7db7c9b75a048f76921ae7e84ca8bda61174a0788265579d1e446afc24014
+        checksum/config: 369e0d7d9e761fb3c31fcc0dca4a2549364b1e5b12d334d198c8237cea0f747d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -56,7 +56,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -42,7 +42,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 191e27d57902c6c1fe3a4e270d56d6d4746f0ddb2c22143c17d86306ae10ed03
+        checksum/config: aac522da038992a288fd321fea6ef080db1a1de81c2cb6f2038ae811f4ec5f98
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 27a7db7c9b75a048f76921ae7e84ca8bda61174a0788265579d1e446afc24014
+        checksum/config: 369e0d7d9e761fb3c31fcc0dca4a2549364b1e5b12d334d198c8237cea0f747d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 52465da90569d6e5ded2dbb98403e17143443902193df4ba810e4a95266a22b8
+        checksum/config: 8df47d39805671caca34985ece48d55b726bc052455e18a9841004747c454178
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -84,7 +84,7 @@ data:
           queue_size: 1000
           storage: null
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
           storage: file_storage/persistent_queue
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -60,7 +60,7 @@ data:
           queue_size: 1000
           storage: file_storage/persistent_queue
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -59,7 +59,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 045190cf430c614d338d67d6ee047a91b9a40c6cf0b8afaa7fa9909f16a5c633
+        checksum/config: 8240d7746aba75d5d895a24bae9987a77395ae8e95e4053904327be9cfec935e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f835ecb594805840578190b3e0fb4bca9b18bdb6d5b9384843ec8bafa2171b7f
+        checksum/config: 045190cf430c614d338d67d6ee047a91b9a40c6cf0b8afaa7fa9909f16a5c633
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 404c4f4d7aea871d675e1e213d5c63378056e013cd41024ea64030ed7b37baba
+        checksum/config: e3d6f168f677ac308d8510ace994fe115713243fd4726d9c08d44bc493bfa2b4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -56,7 +56,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -42,7 +42,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 74cf6f9fc6f7c9429c3d8ca567825dfab1f9ca86acc72412626519b26bed7e4b
+        checksum/config: 52c96b62e384737b0dd6123266df41dc2a5cda94798937e163987328a112fd5b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7f594104b8819edd9c0cde14f5adbc976d54444e6fb4f6fb355beeb5cf6a4008
+        checksum/config: b3f26447a605776f10e68da77e082fbf00c0b14aaa5df1e8b4a32687f1b486ad
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
           storage: file_storage/persistent_queue
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -60,7 +60,7 @@ data:
           queue_size: 1000
           storage: file_storage/persistent_queue
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -84,7 +84,7 @@ data:
           queue_size: 1000
           storage: file_storage/persistent_queue
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -59,7 +59,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fabe4b43b6a06aa9814dbef728dedeca82de1b40589a6021493f41310cd9b7c3
+        checksum/config: 30289f855ca9a84406d0f5b4900e38ee7dce743189687c064f53dbd5a966acdd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8206bbce56235c932fec3dc01131098a8a15c6fc392530f69c006c6abcae4ef0
+        checksum/config: fabe4b43b6a06aa9814dbef728dedeca82de1b40589a6021493f41310cd9b7c3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 404c4f4d7aea871d675e1e213d5c63378056e013cd41024ea64030ed7b37baba
+        checksum/config: e3d6f168f677ac308d8510ace994fe115713243fd4726d9c08d44bc493bfa2b4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-disabled/rendered_manifests/configmap-agent.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-agent.yaml
@@ -51,7 +51,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -74,7 +74,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -42,7 +42,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -65,7 +65,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/histograms-disabled/rendered_manifests/daemonset.yaml
+++ b/examples/histograms-disabled/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e92019664eb69ee66ebd614732acb2755f00790160b9757c3f74389c184fed46
+        checksum/config: db784a245fe295b2000d7014d4117a42e6739a1a3ebbe3b375bbdece0273b071
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fbe35d9e57ef861642d8bb3a783dc0762e1846e901e713d40f2421a7b369a896
+        checksum/config: 3ddc018787144f36a09bd7b2a3258377d9aa03de0ed410a2666c282f8d4bc3b1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-agent.yaml
@@ -54,7 +54,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -77,7 +77,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -59,7 +59,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/daemonset.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d3d7ce8bad4bf2df9a06c298069db0fa02f3a36a32f6bfbcc76f89d180927aeb
+        checksum/config: 9f1001482a886d139cd77a0f06a9abeb2a88d8faebb7ae6cf84384bce87b57aa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0808c5ada4a5ea3cb4f2f7f1f3e7f3ecb527e0893c7fc45424f2fb10c92d1156
+        checksum/config: 804ecf47875d6d8ce5a0bdfd4a7aa48602e4f42b26ee8ce72c691d93616e2fb0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-agent.yaml
@@ -37,7 +37,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/host-journalctl-logs/rendered_manifests/daemonset.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ff0f54c5a748b5f12b6509c5cdabf9ee18c7edd04df33f9a90d76d039d22214d
+        checksum/config: a4a97667a35fbaf67c8b13532dc9dccbd2edd35d44d1d34c82d669c6251c3d9e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aa6ec69ca6de90d2c10edb7e6940a2faf107b09407534dd4200183cdde101f19
+        checksum/config: 7e4bd1efe2f1c45eed26cd82e7e092701dd188e29056b76b0ed8851d84553947
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -55,7 +55,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -42,7 +42,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a6c41eab4ecfc5cd6d5ab8c44576d3c6c03e78c95e15186920ba3140a324ebf3
+        checksum/config: e68790ecb8e626c78e8ff549bcc6df2064c7d8208b2ae44683e680687a5f66b1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 27a7db7c9b75a048f76921ae7e84ca8bda61174a0788265579d1e446afc24014
+        checksum/config: 369e0d7d9e761fb3c31fcc0dca4a2549364b1e5b12d334d198c8237cea0f747d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -35,7 +35,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -58,7 +58,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -59,7 +59,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: df11cbfd6178510ecdecd3ba8268d4b1c56c58cd76795b81da6f7254651044db
+        checksum/config: 006021fe14bc288270a18d88b98d568a538b39dc0126ef2f5e5ce7f4ac73bc84
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 08821e24bb19743f9fb1c6fe9ec055e715c5ab4c245ecbd451c2baba97efb056
+        checksum/config: 4c55e93a712bc2ddf249f04877101e15f0573540f82efd3740ada8fda71a92c4
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multiline-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-agent.yaml
@@ -35,7 +35,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/multiline-logs/rendered_manifests/daemonset.yaml
+++ b/examples/multiline-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 99c87c3001483c32bfaca49a65362903537a3e5344b1ad2a848fc8de68d953eb
+        checksum/config: b2673baf4eee28f1fcfd35c5d728bb30b189808042de7b2576b23f9a9d4f6a49
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aa6ec69ca6de90d2c10edb7e6940a2faf107b09407534dd4200183cdde101f19
+        checksum/config: 7e4bd1efe2f1c45eed26cd82e7e092701dd188e29056b76b0ed8851d84553947
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -35,7 +35,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b09c3439804171e212c709474dec83482c52d296863fbfd182de3589754844bc
+        checksum/config: 6b3306f91390da3a1c333cb44941e8e3f2526580a9c4a52bbdc446e175fbfc65
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aa6ec69ca6de90d2c10edb7e6940a2faf107b09407534dd4200183cdde101f19
+        checksum/config: 7e4bd1efe2f1c45eed26cd82e7e092701dd188e29056b76b0ed8851d84553947
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -34,7 +34,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -34,7 +34,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f6e76c9ea13ecbd254411b3459c165dc0e87adb60cdf8a751e4c1b6782029196
+        checksum/config: 41022e69eae957e6c6e130c6396ddb22c847d1cc7240c1f0b862ca0caa69aaa1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e23d650e9b8ca791ee301830a1670d9d32fd405fd342b21b4a8f58b7cb2680f9
+        checksum/config: fe8e726e44e4d6915f589567c07f4c68a135f4c81d79bd95de8e991605e9ff72
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -35,7 +35,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 5ad25e918500c0ff70ffea4d4be0a05dadcd127394be129c3d387135a01fa1f6
+        checksum/config: 0b5fa4f53c9d98abbd17f1a044fe53b2f97238d44dd33a41018984409c3068ab
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aa6ec69ca6de90d2c10edb7e6940a2faf107b09407534dd4200183cdde101f19
+        checksum/config: 7e4bd1efe2f1c45eed26cd82e7e092701dd188e29056b76b0ed8851d84553947
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -35,7 +35,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: af158f16adbaaf890ef0ba079c450ad7b7b0660aca778fe95447991707448033
+        checksum/config: 539f0edf833744a5297a95cc8096e929e133909b371322d3058c1728925f6155
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f03ceacf775055679a978726ad963e435c536bf54933fe70b3225fce1b1f8c5a
+        checksum/config: 1d81fa31d75d4444dd64ce39a275385a98f6b709b667da7b88924fb03d0f6a04
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
@@ -35,7 +35,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -58,7 +58,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -36,7 +36,7 @@ data:
           queue_size: 1000
         source: kubernetes
         sourcetype: kube:events
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:
@@ -59,7 +59,7 @@ data:
           num_consumers: 10
           queue_size: 1000
         source: kubernetes
-        splunk_app_name: splunk-otel-collector
+        splunk_app_name: splunk-otel-collector-chart
         splunk_app_version: 0.152.0
         timeout: 10s
         tls:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 41ea3719525cecc95bec2de4dc8a9a021f354f015c944c7f081bc6bce160369c
+        checksum/config: 9ce39c026c2a4be8e07e8696bd2bc1e1aa0b9b58c2950d3c45df3c194c17fac8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: ccf115172d552e77368629bd672ef4956e4aa46ea5636113774ae07a7134bf75
+        checksum/config: d8f1861bd89e460fbbca2544df0a04edeacf0348d5b148fe8fad5fb787426696
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -467,7 +467,7 @@ splunk_hec/platform_logs:
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
   idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}
-  splunk_app_name: {{ .Chart.Name }}
+  splunk_app_name: {{ .Chart.Name }}-chart
   splunk_app_version: {{ .Chart.Version }}
   profiling_data_enabled: false
   tls:
@@ -519,7 +519,7 @@ splunk_hec/platform_metrics:
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
   idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}
-  splunk_app_name: {{ .Chart.Name }}
+  splunk_app_name: {{ .Chart.Name }}-chart
   splunk_app_version: {{ .Chart.Version }}
   tls:
     insecure_skip_verify: {{ .Values.splunkPlatform.insecureSkipVerify }}

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -563,7 +563,7 @@ splunk_hec/platform_traces:
   disable_compression: {{ .Values.splunkPlatform.disableCompression }}
   timeout: {{ .Values.splunkPlatform.timeout }}
   idle_conn_timeout: {{ .Values.splunkPlatform.idleConnTimeout }}
-  splunk_app_name: {{ .Chart.Name }}
+  splunk_app_name: {{ .Chart.Name }}-chart
   splunk_app_version: {{ .Chart.Version }}
   tls:
     insecure_skip_verify: {{ .Values.splunkPlatform.insecureSkipVerify }}


### PR DESCRIPTION
**Description:** Rename `splunk_app_name` parameter in splunk hec exporter to be `splunk-otel-collector-chart` instead of `splunk-otel-collector`. The idea is that we want to collect telemetry from bare Splunk OTel Collector as well and we want to use `splunk-otel-collector` for this purpose.

**Testing:** N/A

**Documentation:** N/A
