### PR TITLE
Add entity events mode for k8s property updates

### DIFF
--- a/.chloggen/use-k8s-entity-events.yaml
+++ b/.chloggen/use-k8s-entity-events.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: clusterReceiver
+note: "Add `featureGates.useK8sEntityEvents` to send Kubernetes entity updates through the signalfx entity events path."
+issues: [2429]
+subtext:

--- a/.chloggen/use-k8s-entity-events.yaml
+++ b/.chloggen/use-k8s-entity-events.yaml
@@ -1,5 +1,5 @@
 change_type: enhancement
 component: clusterReceiver
-note: "Add `featureGates.useK8sEntityEvents` to send Kubernetes entity updates through the signalfx entity events path."
+note: "Add `featureGates.useEntityEventsForK8sProperties` to send Kubernetes entity updates through the signalfx entity events path."
 issues: [2429]
 subtext:

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -388,6 +388,19 @@ Sends k8s_cluster receiver data to Splunk Observability v3/event endpoint via ot
 {{- and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.featureGates.enableK8sEntities -}}
 {{- end -}}
 
+{{/*
+Build the collector feature gates string for cluster receiver.
+*/}}
+{{- define "splunk-otel-collector.clusterReceiverFeatureGates" -}}
+{{- $gates := list -}}
+{{- with .Values.clusterReceiver.featureGates -}}
+{{- $gates = append $gates . -}}
+{{- end -}}
+{{- if and (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") .Values.featureGates.useK8sEntityEvents -}}
+{{- $gates = append $gates "exporter.signalfx.consumeEntityEvents" -}}
+{{- end -}}
+{{- join "," $gates -}}
+{{- end -}}
 
 {{/*
 Whether clusterReceiver should be enabled

--- a/helm-charts/splunk-otel-collector/templates/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_helpers.tpl
@@ -396,7 +396,7 @@ Build the collector feature gates string for cluster receiver.
 {{- with .Values.clusterReceiver.featureGates -}}
 {{- $gates = append $gates . -}}
 {{- end -}}
-{{- if and (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") .Values.featureGates.useK8sEntityEvents -}}
+{{- if and (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") .Values.featureGates.useEntityEventsForK8sProperties -}}
 {{- $gates = append $gates "exporter.signalfx.consumeEntityEvents" -}}
 {{- end -}}
 {{- join "," $gates -}}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -3,7 +3,7 @@ Config for the otel-collector k8s cluster receiver deployment.
 The values can be overridden in .Values.clusterReceiver.config
 */}}
 {{- define "splunk-otel-collector.clusterReceiverConfig" -}}
-{{- $useK8sEntityEvents := and (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") .Values.featureGates.useK8sEntityEvents -}}
+{{- $useEntityEventsForK8sProperties := and (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") .Values.featureGates.useEntityEventsForK8sProperties -}}
 extensions:
   {{- include "splunk-otel-collector.opampExtension" . | nindent 2 }}
   health_check:
@@ -24,7 +24,7 @@ receivers:
   k8s_cluster:
     auth_type: serviceAccount
     {{- if eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true" }}
-    {{- if not $useK8sEntityEvents }}
+    {{- if not $useEntityEventsForK8sProperties }}
     metadata_exporters: [signalfx]
     {{- end }}
     resource_attributes:
@@ -310,7 +310,7 @@ exporters:
       "X-Splunk-Instrumentation-Library": o11yevents
   {{- end }}
 
-  {{- if and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.featureGates.enableK8sEntities }}
+  {{- if eq (include "splunk-otel-collector.k8sEntitiesEnabled" .) "true" }}
   otlp_http/o11y_entities:
     logs_endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v3/event
     headers:
@@ -540,7 +540,7 @@ service:
         - signalfx/histograms
     {{- end }}
 
-    {{- if and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") (or .Values.featureGates.enableK8sEntities $useK8sEntityEvents) }}
+    {{- if and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") (or .Values.featureGates.enableK8sEntities $useEntityEventsForK8sProperties) }}
     logs/k8s_entities:
       receivers:
         - k8s_cluster
@@ -555,7 +555,7 @@ service:
         {{- if .Values.featureGates.enableK8sEntities }}
         - otlp_http/o11y_entities
         {{- end }}
-        {{- if $useK8sEntityEvents }}
+        {{- if $useEntityEventsForK8sProperties }}
         - signalfx
         {{- end }}
     {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -3,6 +3,7 @@ Config for the otel-collector k8s cluster receiver deployment.
 The values can be overridden in .Values.clusterReceiver.config
 */}}
 {{- define "splunk-otel-collector.clusterReceiverConfig" -}}
+{{- $useK8sEntityEvents := and (eq (include "splunk-otel-collector.o11yMetricsEnabled" .) "true") .Values.featureGates.useK8sEntityEvents -}}
 extensions:
   {{- include "splunk-otel-collector.opampExtension" . | nindent 2 }}
   health_check:
@@ -23,7 +24,9 @@ receivers:
   k8s_cluster:
     auth_type: serviceAccount
     {{- if eq (include "splunk-otel-collector.o11yMetricsEnabled" $) "true" }}
+    {{- if not $useK8sEntityEvents }}
     metadata_exporters: [signalfx]
+    {{- end }}
     resource_attributes:
       k8s.hpa.scaletargetref.kind:
         enabled: true
@@ -307,7 +310,7 @@ exporters:
       "X-Splunk-Instrumentation-Library": o11yevents
   {{- end }}
 
-  {{- if eq (include "splunk-otel-collector.k8sEntitiesEnabled" .) "true" }}
+  {{- if and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") .Values.featureGates.enableK8sEntities }}
   otlp_http/o11y_entities:
     logs_endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}/v3/event
     headers:
@@ -537,8 +540,7 @@ service:
         - signalfx/histograms
     {{- end }}
 
-    {{- if eq (include "splunk-otel-collector.k8sEntitiesEnabled" .) "true" }}
-    # [EXPERIMENTAL] k8s entities pipeline: sends k8s_cluster receiver data to Splunk Observability v3/event endpoint.
+    {{- if and (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") (or .Values.featureGates.enableK8sEntities $useK8sEntityEvents) }}
     logs/k8s_entities:
       receivers:
         - k8s_cluster
@@ -550,7 +552,12 @@ service:
         {{- end }}
         - resource
       exporters:
+        {{- if .Values.featureGates.enableK8sEntities }}
         - otlp_http/o11y_entities
+        {{- end }}
+        {{- if $useK8sEntityEvents }}
+        - signalfx
+        {{- end }}
     {{- end }}
 
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/deployment-cluster-receiver.yaml
@@ -120,8 +120,8 @@ spec:
         {{- else }}
         - --config=/conf/relay.yaml
         {{- end }}
-        {{- if .Values.clusterReceiver.featureGates }}
-        - --feature-gates={{ .Values.clusterReceiver.featureGates }}
+        {{- with include "splunk-otel-collector.clusterReceiverFeatureGates" . }}
+        - --feature-gates={{ . }}
         {{- end }}
         {{- with .Values.clusterReceiver.containerSecurityContext }}
         securityContext:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1468,6 +1468,11 @@ featureGates:
   # Requires Splunk Observability to be configured (splunkObservability.realm or ingestUrl must be set).
   # This feature is experimental and may change or be removed in future releases.
   enableK8sEntities: false
+  # Enable entity events mode for Kubernetes property updates. When enabled, the k8s_cluster receiver
+  # skips metadata_exporters (PATCH mode) and routes entity events to the signalfx exporter using PUT semantics.
+  # Also enables the exporter.signalfx.consumeEntityEvents collector feature gate on the cluster receiver.
+  # Requires splunkObservability.metricsEnabled.
+  useK8sEntityEvents: false
   # Include "component: otel-collector-agent" in the agent DaemonSet's selector.matchLabels.
   # Because selector.matchLabels is immutable, enabling this on an existing installation
   # requires additional steps. See:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1472,7 +1472,7 @@ featureGates:
   # skips metadata_exporters (PATCH mode) and routes entity events to the signalfx exporter using PUT semantics.
   # Also enables the exporter.signalfx.consumeEntityEvents collector feature gate on the cluster receiver.
   # Requires splunkObservability.metricsEnabled.
-  useK8sEntityEvents: false
+  useEntityEventsForK8sProperties: false
   # Include "component: otel-collector-agent" in the agent DaemonSet's selector.matchLabels.
   # Because selector.matchLabels is immutable, enabling this on an existing installation
   # requires additional steps. See:

--- a/unittests/k8s_entity_events_test.yaml
+++ b/unittests/k8s_entity_events_test.yaml
@@ -19,10 +19,10 @@ tests:
           path: data["relay"]
           pattern: "logs/k8s_entities"
 
-  - it: should render k8s entities pipeline to signalfx when featureGates.useK8sEntityEvents is true
+  - it: should render k8s entities pipeline to signalfx when featureGates.useEntityEventsForK8sProperties is true
     set:
       featureGates:
-        useK8sEntityEvents: true
+        useEntityEventsForK8sProperties: true
     template: configmap-cluster-receiver.yaml
     asserts:
       - notMatchRegex:
@@ -38,7 +38,7 @@ tests:
   - it: should not render signalfx entity events when Observability metrics are disabled
     set:
       featureGates:
-        useK8sEntityEvents: true
+        useEntityEventsForK8sProperties: true
       splunkObservability:
         metricsEnabled: false
         tracesEnabled: true
@@ -54,7 +54,7 @@ tests:
   - it: should enable the collector entity events feature gate
     set:
       featureGates:
-        useK8sEntityEvents: true
+        useEntityEventsForK8sProperties: true
     template: deployment-cluster-receiver.yaml
     asserts:
       - contains:
@@ -64,7 +64,7 @@ tests:
   - it: should not enable the collector entity events feature gate when Observability metrics are disabled
     set:
       featureGates:
-        useK8sEntityEvents: true
+        useEntityEventsForK8sProperties: true
       splunkObservability:
         metricsEnabled: false
         tracesEnabled: true
@@ -77,7 +77,7 @@ tests:
   - it: should append the collector entity events feature gate to configured cluster receiver gates
     set:
       featureGates:
-        useK8sEntityEvents: true
+        useEntityEventsForK8sProperties: true
       clusterReceiver:
         featureGates: existing.gate
     template: deployment-cluster-receiver.yaml

--- a/unittests/k8s_entity_events_test.yaml
+++ b/unittests/k8s_entity_events_test.yaml
@@ -1,0 +1,87 @@
+suite: splunk-otel-collector.k8sEntityEvents
+values:
+  - ./values/basic.yaml
+release:
+  name: test-release
+  namespace: test-ns
+templates:
+  - configmap-cluster-receiver.yaml
+  - deployment-cluster-receiver.yaml
+
+tests:
+  - it: should use metadata_exporters by default
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: "metadata_exporters:\\n\\s+- signalfx"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/k8s_entities"
+
+  - it: should render k8s entities pipeline to signalfx when featureGates.useK8sEntityEvents is true
+    set:
+      featureGates:
+        useK8sEntityEvents: true
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metadata_exporters:\\n\\s+- signalfx"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs/k8s_entities:\\n\\s+exporters:\\n\\s+- signalfx"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "otlp_http/o11y_entities"
+
+  - it: should not render signalfx entity events when Observability metrics are disabled
+    set:
+      featureGates:
+        useK8sEntityEvents: true
+      splunkObservability:
+        metricsEnabled: false
+        tracesEnabled: true
+    template: configmap-cluster-receiver.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/k8s_entities:\\n\\s+exporters:\\n\\s+- signalfx"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "metadata_exporters:\\n\\s+- signalfx"
+
+  - it: should enable the collector entity events feature gate
+    set:
+      featureGates:
+        useK8sEntityEvents: true
+    template: deployment-cluster-receiver.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--feature-gates=exporter.signalfx.consumeEntityEvents"
+
+  - it: should not enable the collector entity events feature gate when Observability metrics are disabled
+    set:
+      featureGates:
+        useK8sEntityEvents: true
+      splunkObservability:
+        metricsEnabled: false
+        tracesEnabled: true
+    template: deployment-cluster-receiver.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--feature-gates=exporter.signalfx.consumeEntityEvents"
+
+  - it: should append the collector entity events feature gate to configured cluster receiver gates
+    set:
+      featureGates:
+        useK8sEntityEvents: true
+      clusterReceiver:
+        featureGates: existing.gate
+    template: deployment-cluster-receiver.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--feature-gates=existing.gate,exporter.signalfx.consumeEntityEvents"


### PR DESCRIPTION
Add a new chart-level feature gate splunkObservability.entityEventsEnabled (disabled by default) that switches the k8s_cluster receiver from PATCH to PUT (entity events) mode for property updates.

- When enabled, sets metadata_exporters to empty on k8s_cluster receiver
- Adds logs/entity_events pipeline routing k8s_cluster data through signalfx exporter with memory_limiter and resource processors
- Enables exporter.signalfx.consumeEntityEvents feature gate on the collector

This allows users to opt into entity events semantics while maintaining backward compatibility. When the gate is disabled (default), the chart produces identical output to today.