### PR TITLE
[chore] fix create-pr composite action

### DIFF
--- a/.github/actions/create-pr/action.yaml
+++ b/.github/actions/create-pr/action.yaml
@@ -36,8 +36,15 @@ runs:
       run: |
         git config user.name "${{ inputs.author-name }}"
         git config user.email "${{ inputs.author-email }}"
+        # Fetch the remote branch (if it already exists from a previous run) so that
+        # --force-with-lease has an up-to-date remote-tracking ref to compare against.
+        git fetch origin "${{ inputs.branch }}" || true
         git checkout -B "${{ inputs.branch }}"
         git add -A
+        if git diff --cached --quiet; then
+          echo "No changes to commit; skipping PR creation."
+          exit 0
+        fi
         git commit -m "${{ inputs.commit-message }}"
         git push --force-with-lease --set-upstream origin "${{ inputs.branch }}"
         pr_number="$(gh pr list --head "${{ inputs.branch }}" --base main --state open --json number --jq '.[0].number // empty')"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fixes the `create-pr` composite action, which broke the scheduled dependency-update workflows (e.g. "Check for new chart dependency updates") with `! [rejected] ... (stale info)` on push.

`actions/checkout` only fetches the base branch, so there was no remote-tracking ref for the target branch (`update-operator`, etc.). When the branch already existed on the remote from a prior run, `git push --force-with-lease` couldn't establish a valid lease and was rejected.

The action now fetches the target branch first so `--force-with-lease` has an up-to-date base to compare against (keeping its safety), and skips committing/pushing when there's nothing staged instead of failing the step on an empty diff.
