### PR TITLE
[chart] Disable k8s.node.condition_ready in clusterReceiver

### DIFF
--- a/.chloggen/disable-k8s-node-condition-ready.yaml
+++ b/.chloggen/disable-k8s-node-condition-ready.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Disable redundant `k8s.node.condition_ready` metric by setting `node_conditions_to_report: []` in the default k8s_cluster receiver config."
+# One or more tracking issues related to the change
+issues: [2442]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `k8s.node.condition` metric (enabled in https://github.com/signalfx/splunk-otel-collector-chart/pull/2151)
+  already covers node conditions via a `condition` attribute, making `k8s.node.condition_ready`
+  redundant. Removing it reduces unnecessary MTS/cardinality.

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -168,6 +168,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aeba01bb107ca2f6016bdffcc44db0f79e5c6853d8e0208997d527c218815e33
+        checksum/config: 4a65fe583f4309680cada58d623285a7d436bc499e7acdc0907f63bca67cb6f8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -168,6 +168,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aeba01bb107ca2f6016bdffcc44db0f79e5c6853d8e0208997d527c218815e33
+        checksum/config: 4a65fe583f4309680cada58d623285a7d436bc499e7acdc0907f63bca67cb6f8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
@@ -168,6 +168,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: aeba01bb107ca2f6016bdffcc44db0f79e5c6853d8e0208997d527c218815e33
+        checksum/config: 4a65fe583f4309680cada58d623285a7d436bc499e7acdc0907f63bca67cb6f8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -168,6 +168,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: aeba01bb107ca2f6016bdffcc44db0f79e5c6853d8e0208997d527c218815e33
+        checksum/config: 4a65fe583f4309680cada58d623285a7d436bc499e7acdc0907f63bca67cb6f8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b6cbefe45c3c554879e98a0eff6703d2c6b0c0b2d3d69b9d05dfb3a36756b612
+        checksum/config: 9901e4171be1a880240306bddc953aa72c505ed591acc58f670ea5eba9db8112
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -109,6 +109,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9b46e343f1aea394bf91a91b5a792970580929b8b9f7f17b8514e03faec0e26d
+        checksum/config: 9c1c2ead031a9c820850723618383174d9138c83b6ae6d5fb70f6e746832116b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
@@ -145,6 +145,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2d2f11720ac785e073a06f762ca1b2131ec7f3d41ee5510da507dcb070c2b6b1
+        checksum/config: a363c3cca9cce9c773f5ae6ae90bd42b2eca6d8fba08f577654eb7e51408aafc
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -122,6 +122,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 831fe071ea69b628838d3d791a79dc13adf515adb8d713c203f8455c07a765c0
+        checksum/config: fca61523edbe0691cf610dda22675a6ea2b1122f164b4516b66228e348976251
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -132,6 +132,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3750015d91571dcf6a0093136237a4aae5e1f5d33d2f5a1eaf95ee1a2976dd28
+        checksum/config: c625861bad65d3fe99c05a6e1108c6f6778b24990d02a59b4c366f4be0a8ee09
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -148,6 +148,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14ff1124382d9162946b4bacff6c70fd3796231e49fbf1ab624a7d3f6e276e53
+        checksum/config: e8d51f5670fe0db4662b0aeebace790aefa7eafa7dcfcf8e1708e8c4947c1a96
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -148,6 +148,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 14ff1124382d9162946b4bacff6c70fd3796231e49fbf1ab624a7d3f6e276e53
+        checksum/config: e8d51f5670fe0db4662b0aeebace790aefa7eafa7dcfcf8e1708e8c4947c1a96
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -109,6 +109,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 979765889a145c05737d79beeb06841afba01af0b22efbbb8dad6277559c9cc7
+        checksum/config: 0fe4e0d704e08dbd682ab4e7a27e647f3eb0b1f145abb409ff799bd9acf83bc9
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/ebpf-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -173,6 +173,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 32214107e1fdbc8c6420e1bbb9a76cbfdc6846c84191ef0eac5d6182581485bf
+        checksum/config: ea56fd3e201f7b72d2d153ca419c91fb5f431e6d6296af873043f17285655330
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -229,6 +229,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7e95498ca48757965760dfd72f8ea338dc7c70367f3e45fede6fa44b91555895
+        checksum/config: b08cbacd961059a62cd9ac04cea63ff156e70db7c4ea46c570d96f066800fee6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
@@ -148,6 +148,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e084a76206c0819568505ec77f6c749e7a89872089780c23c05a59037df6680d
+        checksum/config: bb64feb8935cd79de10e42d302b34c917bc38afdbbc468220bfc323aae51f089
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -168,6 +168,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aeba01bb107ca2f6016bdffcc44db0f79e5c6853d8e0208997d527c218815e33
+        checksum/config: 4a65fe583f4309680cada58d623285a7d436bc499e7acdc0907f63bca67cb6f8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b6cbefe45c3c554879e98a0eff6703d2c6b0c0b2d3d69b9d05dfb3a36756b612
+        checksum/config: 9901e4171be1a880240306bddc953aa72c505ed591acc58f670ea5eba9db8112
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 277db0e8e3044a2e8aba994d7ce091927e40a83a7b93f2a009054d34b63572d1
+        checksum/config: 031aabda3b8caef4e22d3603db892ae4f11c79026084dcd0a4825f6c56375373
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -107,6 +107,7 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+        node_conditions_to_report: []
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 788ccec8359471447993e29a57d5d4cad4c12b125a6d421abbc3a535d1ac2244
+        checksum/config: 9d17ea722f2a0b081a95c3c9448638794c7b2eca3fbd9d1957d5c8be019341d0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/functional_tests/functional/testdata/expected_kind_values/expected_cluster_receiver.yaml
+++ b/functional_tests/functional/testdata/expected_kind_values/expected_cluster_receiver.yaml
@@ -10043,37 +10043,4 @@ resourceMetrics:
                         stringValue: k8scluster
                   timeUnixNano: "1000000"
             name: k8s.daemonset.ready_nodes
-          - gauge:
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: cluster_name
-                      value:
-                        stringValue: ci-k8s-cluster
-                    - key: customfield1
-                      value:
-                        stringValue: customvalue1
-                    - key: customfield2
-                      value:
-                        stringValue: customvalue2
-                    - key: k8s.cluster.name
-                      value:
-                        stringValue: dev-operator
-                    - key: k8s.kubelet.version
-                      value:
-                        stringValue: v1.33.2
-                    - key: k8s.node.name
-                      value:
-                        stringValue: kind-control-plane
-                    - key: k8s.node.uid
-                      value:
-                        stringValue: f9f9659c-82bb-4f37-ac46-335f9b49535f
-                    - key: metric_source
-                      value:
-                        stringValue: kubernetes
-                    - key: receiver
-                      value:
-                        stringValue: k8scluster
-                  timeUnixNano: "1000000"
-            name: k8s.node.condition_ready
         scope: {}

--- a/functional_tests/k8sentities/testdata/expected_k8sentities.yaml
+++ b/functional_tests/k8sentities/testdata/expected_k8sentities.yaml
@@ -864,7 +864,9 @@ resourceLogs:
                       - key: k8s.node.condition_pid_pressure
                         value:
                           stringValue: "false"
-
+                      - key: k8s.node.condition_ready
+                        value:
+                          stringValue: "true"
                       - key: beta.kubernetes.io/arch
                         value:
                           stringValue: arm64

--- a/functional_tests/k8sentities/testdata/expected_k8sentities.yaml
+++ b/functional_tests/k8sentities/testdata/expected_k8sentities.yaml
@@ -864,9 +864,7 @@ resourceLogs:
                       - key: k8s.node.condition_pid_pressure
                         value:
                           stringValue: "false"
-                      - key: k8s.node.condition_ready
-                        value:
-                          stringValue: "true"
+
                       - key: beta.kubernetes.io/arch
                         value:
                           stringValue: arm64

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -27,6 +27,7 @@ receivers:
     {{- if not $useEntityEventsForK8sProperties }}
     metadata_exporters: [signalfx]
     {{- end }}
+    node_conditions_to_report: []
     resource_attributes:
       k8s.hpa.scaletargetref.kind:
         enabled: true


### PR DESCRIPTION
Set `node_conditions_to_report: []` in the default `k8s_cluster` receiver config to stop emitting the legacy `k8s.node.condition_ready` metric. The `k8s.node.condition` metric (enabled in #2151) already covers node conditions via a `condition` attribute, making `k8s.node.condition_ready` redundant and adding avoidable MTS/cardinality.

Updates expected test data and all rendered example manifests.

Resolves OTL-4324

**Description:** Before this change, the collector emitted two overlapping metrics for the node `Ready` condition — the legacy `k8s.node.condition_ready` (standalone gauge, no attributes) alongside the newer `k8s.node.condition` (attribute-based gauge covering all conditions). This PR disables the legacy metric by setting `node_conditions_to_report: []` in the default cluster receiver config, eliminating the duplicate MTS while keeping full node condition coverage via `k8s.node.condition{condition="Ready|MemoryPressure|DiskPressure|PIDPressure"}`.

**Link to Splunk idea:** N/A

**Testing:** Verified locally with an E2E test on minikube using a `debug` exporter to inspect emitted metrics directly from the collector logs.

- `k8s.node.condition` IS emitted with the `condition` attribute covering all node conditions:

  ```
  Name: k8s.node.condition
    condition=MemoryPressure  →  Value: 0
    condition=DiskPressure    →  Value: 0
    condition=PIDPressure     →  Value: 0
    condition=Ready           →  Value: 1
  ```

- `k8s.node.condition_ready` is **NOT** emitted (grep returns empty):

  ```bash
  $ kubectl logs <cluster-receiver-pod> | grep "condition_ready"
  # (no output)
  ```

- Rendered ConfigMap confirms the setting:

  ```yaml
  k8s_cluster:
    node_conditions_to_report: []   # disables legacy metric
    metrics:
      k8s.node.condition:
        enabled: true               # new metric still active
  ```

**Documentation:** No user-facing documentation changes needed. The `k8s.node.condition` metric was already documented in #2151. The removal of `k8s.node.condition_ready` is captured in `.chloggen/disable-k8s-node-condition-ready.yaml`.