### PR TITLE
[chart] Deprecate cert-manager subchart and document migration

### DIFF
--- a/.chloggen/deprecate-cert-manager-subchart-migration-guide.yaml
+++ b/.chloggen/deprecate-cert-manager-subchart-migration-guide.yaml
@@ -3,4 +3,4 @@ component: chart
 note: Deprecate installing cert-manager as a subchart with `certmanager.enabled=true`
 issues: [2451]
 subtext: |
-  Installing cert-manager through this chart will be removed in a future release. See the [upgrade guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#01530-to-01540) for migration details.
+  Installing cert-manager through this chart will be removed in a future release. See the [upgrade guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#01540-to-01550) for migration details.

--- a/.chloggen/deprecate-cert-manager-subchart-migration-guide.yaml
+++ b/.chloggen/deprecate-cert-manager-subchart-migration-guide.yaml
@@ -1,6 +1,6 @@
 change_type: deprecation
 component: chart
 note: Deprecate installing cert-manager as a subchart with `certmanager.enabled=true`
-issues: []
+issues: [2451]
 subtext: |
   Installing cert-manager through this chart will be removed in a future release. See the [upgrade guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#01530-to-01540) for migration details.

--- a/.chloggen/deprecate-cert-manager-subchart-migration-guide.yaml
+++ b/.chloggen/deprecate-cert-manager-subchart-migration-guide.yaml
@@ -1,0 +1,6 @@
+change_type: deprecation
+component: chart
+note: Deprecate installing cert-manager as a subchart with `certmanager.enabled=true`
+issues: []
+subtext: |
+  Installing cert-manager through this chart will be removed in a future release. See the [upgrade guidelines](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#01530-to-01540) for migration details.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,6 @@
 # Upgrade guidelines
 
-## 0.153.0 to 0.154.0
+## 0.154.0 to 0.155.0
 
 ### cert-manager subchart is deprecated
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,76 +1,5 @@
 # Upgrade guidelines
 
-## 0.153.1 to 0.154.0
-
-### Target allocator functionality now uses upstream chart as subchart
-
-Instead of relying on local versioning and implementation of target allocator functionality, the
-chart has moved to using the
-[upstream Target Allocator helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-target-allocator)
-directly as a subchart. This will help keep up to date with upstream features and functionality.
-
-This resulted in breaking changes to the helm chart's configuration for the target allocator, as outlined below.
-
-| Old option                       | New option                                                                                                  |
-|----------------------------------|-------------------------------------------------------------------------------------------------------------|
-| `targetAllocator`                | `targetallocator`                                                                                           |
-| `image.imagePullSecrets`         | `targetallocator.targetAllocator.imagePullSecrets`                                           |
-| `targetAllocator.image`          | `targetallocator.targetAllocator.image.repository` + `targetallocator.targetAllocator.image.tag`           |
-| `targetAllocator.resources`      | `targetallocator.targetAllocator.resources`                                                                 |
-| `targetAllocator.serviceAccount` | `targetallocator.targetAllocator.serviceAccount`                                                            |
-| `targetAllocator.config`         | `targetallocator.targetAllocator.config`                                                                    |
-
-> [!NOTE]
-> The `image.imagePullSecrets` option is still valid for non-target allocator service accounts, but the
-> new option must ALSO be configured to attach secrets to the target allocator's service account.
-
-Example old config:
-```
-image:
-  imagePullSecrets:
-    - my-registry-secret
-
-targetAllocator:
-  enabled: true
-  image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.132.0
-  config:
-    allocation_strategy: per-node
-    prometheus_cr:
-      enabled: true
-    filter_strategy: relabel-config
-```
-
-New config equivalent:
-```
-image:
-  imagePullSecrets:
-    - my-registry-secret
-
-targetallocator:
-  enabled: true
-  targetAllocator:
-    imagePullSecrets:
-      - my-registry-secret
-    image:
-      repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
-      tag: v0.132.0
-    config:
-      allocation_strategy: per-node
-      prometheus_cr:
-        enabled: true
-      filter_strategy: relabel-config
-```
-
-Changed target allocator defaults (when enabled):
-
-| Old option default                                       | New option default                                                                     | Notes                                                                                                                                                                        |
-|----------------------------------------------------------|----------------------------------------------------------------------------------------| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| N/A                                                      | `targetallocator.targetAllocator.livenessProbe`                                        | [Reference](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/c738eda8d0bfa36513acdc9601165a308d9f506b/charts/opentelemetry-target-allocator/values.yaml#L77) |
-| N/A                                                      | `targetallocator.targetAllocator.readinessProbe`                                       | [Reference](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/c738eda8d0bfa36513acdc9601165a308d9f506b/charts/opentelemetry-target-allocator/values.yaml#L86) |
-
-Refer to the upstream target allocator helm chart's [values.yaml](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-target-allocator/values.yaml)
-for the full list of valid configuration options.
-
 ## 0.153.0 to 0.154.0
 
 ### cert-manager subchart is deprecated
@@ -274,6 +203,77 @@ If the standalone cert-manager install fails after the Splunk chart upgrade,
 restore cert-manager first. The operator may continue serving webhooks while the
 existing TLS Secret is valid, but certificate renewal will not work until
 cert-manager is healthy again.
+
+## 0.153.1 to 0.154.0
+
+### Target allocator functionality now uses upstream chart as subchart
+
+Instead of relying on local versioning and implementation of target allocator functionality, the
+chart has moved to using the
+[upstream Target Allocator helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-target-allocator)
+directly as a subchart. This will help keep up to date with upstream features and functionality.
+
+This resulted in breaking changes to the helm chart's configuration for the target allocator, as outlined below.
+
+| Old option                       | New option                                                                                                  |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `targetAllocator`                | `targetallocator`                                                                                           |
+| `image.imagePullSecrets`         | `targetallocator.targetAllocator.imagePullSecrets`                                           |
+| `targetAllocator.image`          | `targetallocator.targetAllocator.image.repository` + `targetallocator.targetAllocator.image.tag`           |
+| `targetAllocator.resources`      | `targetallocator.targetAllocator.resources`                                                                 |
+| `targetAllocator.serviceAccount` | `targetallocator.targetAllocator.serviceAccount`                                                            |
+| `targetAllocator.config`         | `targetallocator.targetAllocator.config`                                                                    |
+
+> [!NOTE]
+> The `image.imagePullSecrets` option is still valid for non-target allocator service accounts, but the
+> new option must ALSO be configured to attach secrets to the target allocator's service account.
+
+Example old config:
+```
+image:
+  imagePullSecrets:
+    - my-registry-secret
+
+targetAllocator:
+  enabled: true
+  image: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.132.0
+  config:
+    allocation_strategy: per-node
+    prometheus_cr:
+      enabled: true
+    filter_strategy: relabel-config
+```
+
+New config equivalent:
+```
+image:
+  imagePullSecrets:
+    - my-registry-secret
+
+targetallocator:
+  enabled: true
+  targetAllocator:
+    imagePullSecrets:
+      - my-registry-secret
+    image:
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+      tag: v0.132.0
+    config:
+      allocation_strategy: per-node
+      prometheus_cr:
+        enabled: true
+      filter_strategy: relabel-config
+```
+
+Changed target allocator defaults (when enabled):
+
+| Old option default                                       | New option default                                                                     | Notes                                                                                                                                                                        |
+|----------------------------------------------------------|----------------------------------------------------------------------------------------| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| N/A                                                      | `targetallocator.targetAllocator.livenessProbe`                                        | [Reference](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/c738eda8d0bfa36513acdc9601165a308d9f506b/charts/opentelemetry-target-allocator/values.yaml#L77) |
+| N/A                                                      | `targetallocator.targetAllocator.readinessProbe`                                       | [Reference](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/c738eda8d0bfa36513acdc9601165a308d9f506b/charts/opentelemetry-target-allocator/values.yaml#L86) |
+
+Refer to the upstream target allocator helm chart's [values.yaml](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-target-allocator/values.yaml)
+for the full list of valid configuration options.
 
 ## 0.151.0 to 0.152.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -71,6 +71,181 @@ Changed target allocator defaults (when enabled):
 Refer to the upstream target allocator helm chart's [values.yaml](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-target-allocator/values.yaml)
 for the full list of valid configuration options.
 
+## 0.153.0 to 0.154.0
+
+### cert-manager subchart is deprecated
+
+Installing cert-manager through the Splunk OpenTelemetry Collector chart by
+setting `certmanager.enabled=true` is deprecated and will be removed in a future
+release. Use a separately managed cert-manager installation instead.
+
+This affects deployments that use all of these settings:
+
+- `operator.enabled=true`
+- `operator.admissionWebhooks.certManager.enabled=true`
+- `certmanager.enabled=true`
+
+For new installs that use cert-manager for the operator webhook certificate,
+install cert-manager before installing this chart and leave
+`certmanager.enabled=false`. If you use the default Helm-generated webhook
+certificate, no cert-manager installation is required.
+
+```yaml
+operator:
+  enabled: true
+  admissionWebhooks:
+    autoGenerateCert:
+      enabled: false
+    certManager:
+      enabled: true
+certmanager:
+  enabled: false
+```
+
+The examples in this section show only the values related to cert-manager and the
+operator webhook certificate. Keep your existing required chart values, such as
+`clusterName` and your Splunk destination configuration, when running these
+commands.
+
+#### Why the migration uses a maintenance window
+
+It might seem possible to avoid downtime by first installing a standalone
+cert-manager release, adopting the existing subchart-managed cert-manager
+resources, and then disabling `certmanager.enabled` in the Splunk chart. That
+in-place handoff is not supported with normal Helm commands.
+
+Helm decides which resources to delete during an upgrade by comparing the new
+rendered manifest with the previous manifest stored for the same release. If the
+cert-manager subchart is disabled with `certmanager.enabled=false`, the
+cert-manager controller, cainjector, and webhook resources are removed from the
+Splunk chart's rendered manifest. Helm then prunes those resources from the old
+release, even if their live ownership annotations were changed beforehand.
+
+For that reason, `helm upgrade --install --take-ownership` does not provide a
+zero-downtime migration path for the cert-manager Deployments. `--take-ownership`
+is still useful later in the migration to let the standalone cert-manager release
+adopt retained CRDs, but it does not prevent Helm from deleting resources that
+were removed from the Splunk chart release.
+
+#### Migration steps
+
+Plan a maintenance window. The operator webhook Secret can keep the operator
+running for a short period, but cert-manager will not renew or issue certificates
+while the cert-manager controllers are absent. During this migration, disabling
+the subchart removes the old cert-manager controller, cainjector, and webhook
+Deployments before the standalone cert-manager release is installed.
+
+The examples below use `cert-manager` as the standalone cert-manager release name
+and namespace, which is the common namespace for a cluster-wide cert-manager
+installation. Replace `<release>` and `<namespace>` with the Splunk
+OpenTelemetry Collector Helm release name and namespace. If cert-manager is
+already managed separately in your cluster, use that installation instead of
+installing a second standalone cert-manager release. Adjust or skip the
+cert-manager Helm commands below if your cert-manager installation is not managed
+by Helm.
+
+Upgrade the Splunk chart with the cert-manager subchart disabled, while keeping
+the operator configured to use cert-manager:
+
+```bash
+helm upgrade <release> splunk-otel-collector-chart/splunk-otel-collector \
+  --namespace <namespace> \
+  --reuse-values \
+  --set certmanager.enabled=false \
+  --set operator.admissionWebhooks.autoGenerateCert.enabled=false \
+  --set operator.admissionWebhooks.certManager.enabled=true
+```
+
+Confirm that the old subchart cert-manager Deployments were removed:
+
+```bash
+kubectl get deployment -n <namespace> \
+  -l "app.kubernetes.io/instance=<release>,app.kubernetes.io/component in (controller,cainjector,webhook)"
+```
+
+The command should return no resources.
+
+Install cert-manager as a standalone release. Choose the cert-manager version
+explicitly. To minimize version changes during the migration, use the version
+from this chart's cert-manager dependency, or use the version approved for your
+cluster if cert-manager is managed by your platform team.
+
+If you customized the cert-manager subchart with values under `certmanager.*`,
+apply equivalent values to the standalone `jetstack/cert-manager` release. The
+migration adopts retained CRDs, but it does not copy cert-manager Deployment,
+Service, scheduling, image, monitoring, or security settings from the old
+subchart release:
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm repo update jetstack
+
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version <cert-manager-version> \
+  --take-ownership \
+  --set crds.enabled=true \
+  --set crds.keep=true \
+  --wait
+```
+
+`--take-ownership` lets the standalone release adopt cert-manager CRDs that were
+kept from the old subchart release. It is only for retained resources such as
+CRDs. Use a Helm version that supports `--take-ownership`. If cert-manager CRDs
+are managed separately in your cluster, do not adopt them into this standalone
+release. Install cert-manager with `crds.enabled=false` and follow your existing
+CRD management process instead.
+
+If your existing values use `certificateAnnotations` or `issuerAnnotations` with
+Helm hook annotations for the operator webhook certificate resources, keep those
+values during the migration. Remove them later only after testing a separate
+upgrade without the subchart.
+
+#### Validation
+
+After the migration:
+
+```bash
+helm status <release> -n <namespace>
+helm status cert-manager -n cert-manager
+
+kubectl wait --for=condition=Available deployment \
+  -n cert-manager \
+  -l "app.kubernetes.io/instance=cert-manager,app.kubernetes.io/component in (controller,cainjector,webhook)" \
+  --timeout=5m
+
+kubectl wait --for=condition=Available deployment \
+  -n <namespace> \
+  -l "app.kubernetes.io/instance=<release>,app.kubernetes.io/name=operator" \
+  --timeout=5m
+
+kubectl wait --for=condition=Ready certificate \
+  -n <namespace> \
+  -l "app.kubernetes.io/instance=<release>,app.kubernetes.io/component=webhook" \
+  --timeout=5m
+```
+
+Also verify that the old subchart cert-manager Deployments are still absent from
+the Splunk chart namespace:
+
+```bash
+kubectl get deployment -n <namespace> \
+  -l "app.kubernetes.io/instance=<release>,app.kubernetes.io/component in (controller,cainjector,webhook)"
+```
+
+The command should return no resources. The Splunk chart can still include
+cert-manager API resources such as `Certificate` and `Issuer` for the operator
+webhook certificate; the controller, cainjector, and webhook Deployments should
+come from the standalone cert-manager release.
+
+#### Rollback
+
+If the standalone cert-manager install fails after the Splunk chart upgrade,
+restore cert-manager first. The operator may continue serving webhooks while the
+existing TLS Secret is valid, but certificate renewal will not work until
+cert-manager is healthy again.
+
 ## 0.151.0 to 0.152.0
 
 ### Container log parsing now uses the `container` operator
@@ -114,7 +289,7 @@ logsCollection:
         expr: 'body matches "health_check"'
 ```
 
-If `attributes.log` is still referenced, no error is raised — the value silently evaluates to `null`.
+If `attributes.log` is still referenced, no error is raised â€” the value silently evaluates to `null`.
 
 #### `attributes.time` is no longer available in `extraOperators`, use field `timestamp` instead
 
@@ -133,7 +308,7 @@ log record's `Timestamp` field directly in stanza expressions. For example:
   expr: 'timestamp.Before(date("2026-01-01T00:00:00Z"))'
 ```
 
-If `attributes.time` is still referenced, no error is raised — the value silently evaluates to `null`.
+If `attributes.time` is still referenced, no error is raised â€” the value silently evaluates to `null`.
 
 #### `extraOperators` using old operator IDs as `output` targets
 
@@ -183,7 +358,7 @@ matching pod are left alone; any missing nodes get new pods scheduled.
 #### Option B: Delete the DaemonSet and upgrade (brief data-collection gap)
 
 Delete the agent DaemonSet (without `--cascade=orphan`) before upgrading.
-This is simpler than Option A but **terminates existing agent pods** — there
+This is simpler than Option A but **terminates existing agent pods** â€” there
 will be a brief data-collection gap on each node while new pods start:
 
 ```bash
@@ -334,7 +509,7 @@ For the `agent`: `--set agent.featureGates=-receiver.prometheusreceiver.RemoveLe
 
 For the `clusterReceiver`: `--set clusterReceiver.featureGates=-receiver.prometheusreceiver.RemoveLegacyResourceAttributes`
 
-**Note**: This feature gate will be removed in a future release. It’s recommended to migrate to the new attributes (server.address, server.port, url.scheme).
+**Note**: This feature gate will be removed in a future release. Itâ€™s recommended to migrate to the new attributes (server.address, server.port, url.scheme).
 
 ## 0.119.0 to 0.120.0
 
@@ -559,7 +734,7 @@ to update your custom dashboards, detectors, or alerts using Java application te
 ### Breaking Changes Overview
 - Runtime metrics will now be enabled by default, this can increase the number of metrics collected.
 - The default protocol changed from gRPC to http/protobuf. For custom Java exporter endpoint
-configurations, verify that you’re sending data to http/protobuf endpoints like this [example](https://github.com/signalfx/splunk-otel-collector-chart/blob/splunk-otel-collector-0.105.4/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml#L59).
+configurations, verify that youâ€™re sending data to http/protobuf endpoints like this [example](https://github.com/signalfx/splunk-otel-collector-chart/blob/splunk-otel-collector-0.105.4/examples/enable-operator-and-auto-instrumentation/rendered_manifests/operator/instrumentation.yaml#L59).
 - Span Attribute Name Changes:
 
 | Old Attribute (1.x)           | New Attribute (2.x)           |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -85,55 +85,37 @@ This affects deployments that use all of these settings:
 - `operator.admissionWebhooks.certManager.enabled=true`
 - `certmanager.enabled=true`
 
-For new installs that use cert-manager for the operator webhook certificate,
-install cert-manager before installing this chart and leave
-`certmanager.enabled=false`. If you use the default Helm-generated webhook
-certificate, no cert-manager installation is required.
-
-```yaml
-operator:
-  enabled: true
-  admissionWebhooks:
-    autoGenerateCert:
-      enabled: false
-    certManager:
-      enabled: true
-certmanager:
-  enabled: false
-```
+For new installs, follow the operator webhook certificate guidance in the
+[auto-instrumentation install guide](docs/auto-instrumentation-install.md#2-using-a-cert-manager-certificate).
+Do not enable the deprecated cert-manager subchart.
 
 The examples in this section show only the values related to cert-manager and the
 operator webhook certificate. Keep your existing required chart values, such as
 `clusterName` and your Splunk destination configuration, when running these
 commands.
 
-#### Why the migration uses a maintenance window
+#### Before you migrate
 
-It might seem possible to avoid downtime by first installing a standalone
-cert-manager release, adopting the existing subchart-managed cert-manager
-resources, and then disabling `certmanager.enabled` in the Splunk chart. That
-in-place handoff is not supported with normal Helm commands.
+The operator webhook keeps serving with its current certificate throughout the
+migration. cert-manager cannot issue or renew certificates in the short gap
+between disabling the subchart and installing standalone cert-manager, so only
+proceed if the webhook certificate is not close to expiry:
 
-Helm decides which resources to delete during an upgrade by comparing the new
-rendered manifest with the previous manifest stored for the same release. If the
-cert-manager subchart is disabled with `certmanager.enabled=false`, the
-cert-manager controller, cainjector, and webhook resources are removed from the
-Splunk chart's rendered manifest. Helm then prunes those resources from the old
-release, even if their live ownership annotations were changed beforehand.
+```bash
+kubectl get certificate -n <namespace> \
+  -l "app.kubernetes.io/instance=<release>,app.kubernetes.io/component=webhook" \
+  -o jsonpath='{.items[0].status.notAfter}'
+```
 
-For that reason, `helm upgrade --install --take-ownership` does not provide a
-zero-downtime migration path for the cert-manager Deployments. `--take-ownership`
-is still useful later in the migration to let the standalone cert-manager release
-adopt retained CRDs, but it does not prevent Helm from deleting resources that
-were removed from the Splunk chart release.
+An in-place handoff of the cert-manager Deployments is not supported with normal
+Helm commands. `--take-ownership` is still useful later in the migration to let
+the standalone cert-manager release adopt retained CRDs.
 
 #### Migration steps
 
-Plan a maintenance window. The operator webhook Secret can keep the operator
-running for a short period, but cert-manager will not renew or issue certificates
-while the cert-manager controllers are absent. During this migration, disabling
-the subchart removes the old cert-manager controller, cainjector, and webhook
-Deployments before the standalone cert-manager release is installed.
+During this migration, disabling the subchart removes the old cert-manager
+controller, cainjector, and webhook Deployments before the standalone
+cert-manager release is installed.
 
 The examples below use `cert-manager` as the standalone cert-manager release name
 and namespace, which is the common namespace for a cluster-wide cert-manager
@@ -197,10 +179,26 @@ are managed separately in your cluster, do not adopt them into this standalone
 release. Install cert-manager with `crds.enabled=false` and follow your existing
 CRD management process instead.
 
-If your existing values use `certificateAnnotations` or `issuerAnnotations` with
-Helm hook annotations for the operator webhook certificate resources, keep those
-values during the migration. Remove them later only after testing a separate
-upgrade without the subchart.
+This migration relies on the cert-manager CRDs being retained. Do not change
+`crds.keep=true` to `crds.keep=false` when installing the standalone
+cert-manager release. Deleting cert-manager CRDs also deletes cert-manager
+custom resources, including the operator webhook `Issuer` and `Certificate`.
+
+If your existing values use the deprecated
+[hook workaround](docs/auto-instrumentation-install.md#option-2-deploy-cert-manager-and-the-operator-together-deprecated)
+with `certificateAnnotations` or `issuerAnnotations`, the `--reuse-values`
+upgrade keeps those annotations during the migration. Helm may delete and
+recreate the operator webhook `Certificate` and `Issuer` during that upgrade.
+This is expected. The webhook serving Secret normally remains in place, and the
+delete does not normally wait for the cert-manager controller. The webhook keeps
+serving with the existing Secret and injected CA bundle until the recreated
+resources are reconciled by the standalone cert-manager release.
+
+If cert-manager was installed with `enableCertificateOwnerRef=true`, deleting
+the `Certificate` may also delete the serving Secret. The operator should
+continue serving the certificate it already loaded, but do not restart the
+operator pod until standalone cert-manager is running and has reissued the
+Secret.
 
 #### Validation
 
@@ -238,6 +236,37 @@ The command should return no resources. The Splunk chart can still include
 cert-manager API resources such as `Certificate` and `Issuer` for the operator
 webhook certificate; the controller, cainjector, and webhook Deployments should
 come from the standalone cert-manager release.
+
+#### Optional: remove the hook workaround
+
+After cert-manager is healthy, you can remove the deprecated Helm hook
+annotations from the operator webhook `Certificate` and `Issuer`. Hook-created
+resources do not have Helm's normal ownership annotations, so add those
+annotations before upgrading without the hook values:
+
+```bash
+kubectl annotate certificate,issuer -n <namespace> \
+  -l "app.kubernetes.io/instance=<release>,app.kubernetes.io/component=webhook" \
+  meta.helm.sh/release-name=<release> \
+  meta.helm.sh/release-namespace=<namespace> \
+  --overwrite
+
+kubectl label certificate,issuer -n <namespace> \
+  -l "app.kubernetes.io/instance=<release>,app.kubernetes.io/component=webhook" \
+  app.kubernetes.io/managed-by=Helm \
+  --overwrite
+```
+
+Then remove `certificateAnnotations` and `issuerAnnotations` from your values
+file, or override them with empty maps:
+
+```bash
+helm upgrade <release> splunk-otel-collector-chart/splunk-otel-collector \
+  --namespace <namespace> \
+  --reuse-values \
+  --set-json 'operator.admissionWebhooks.certManager.certificateAnnotations={}' \
+  --set-json 'operator.admissionWebhooks.certManager.issuerAnnotations={}'
+```
 
 #### Rollback
 

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -739,7 +739,7 @@ Using `cert-manager` offers more control over certificate management and is more
 
 ##### Option 1: **Pre-deploy cert-manager**
 
-If `cert-manager` is already deployed in your cluster, you can configure the operator to use it without enabling certificate generation by Helm.
+If `cert-manager` is already deployed in your cluster, you can configure the operator to use it without enabling certificate generation by Helm. If `cert-manager` is not already deployed, install it first by following the official [cert-manager installation documentation](https://cert-manager.io/docs/installation/helm/).
 
 **Configuration:**
 ```yaml

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -51,7 +51,7 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
 {{- if .Values.certmanager.enabled }}
 [WARNING] Installing cert-manager as a subchart with "certmanager.enabled=true" is deprecated and will be removed in a future release.
           Install cert-manager separately or use the default Helm-generated operator webhook certificate.
-          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#01530-to-01540
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#01540-to-01550
 {{ end }}
 {{- if not (eq (toString .Values.gateway.securityContext) "<nil>") }}
 [WARNING] "gateway.securityContext" parameter is deprecated. Please use "gateway.podSecurityContext" instead.

--- a/helm-charts/splunk-otel-collector/templates/NOTES.txt
+++ b/helm-charts/splunk-otel-collector/templates/NOTES.txt
@@ -48,6 +48,11 @@ Splunk OpenTelemetry Collector is installed and configured to send data to Splun
   https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/auto-instrumentation-install.md#troubleshooting-the-operator
 {{- end }}
 {{- end }}
+{{- if .Values.certmanager.enabled }}
+[WARNING] Installing cert-manager as a subchart with "certmanager.enabled=true" is deprecated and will be removed in a future release.
+          Install cert-manager separately or use the default Helm-generated operator webhook certificate.
+          Upgrade guidelines: https://github.com/signalfx/splunk-otel-collector-chart/blob/main/UPGRADING.md#01530-to-01540
+{{ end }}
 {{- if not (eq (toString .Values.gateway.securityContext) "<nil>") }}
 [WARNING] "gateway.securityContext" parameter is deprecated. Please use "gateway.podSecurityContext" instead.
 {{ end }}


### PR DESCRIPTION
Replaces https://github.com/signalfx/splunk-otel-collector-chart/pull/2444 since I shouldn't have PR-ed that from a fork.

**Description:** Adds documentation for migrating from the chart-managed cert-manager subchart to self-managed cert-manager ahead of the planned removal in https://github.com/signalfx/splunk-otel-collector-chart/pull/2049 . Also adds a Helm warning when the cert-manager subchart is enabled.

**Link to Splunk idea:** N/A

**Testing:** Manually verified the documented migration path on a local kind cluster.

**Documentation:** The changes are mainly documentation that is already described in description.

Resolves OTL-4265

Also addresses the request to add this to changelog from previous PR.