### PR TITLE
Title: operator: add SecureApp auto-instrumentation support (Java, Node.js, Python)

### DIFF
--- a/.chloggen/secureapp-operator-image-injection.yaml
+++ b/.chloggen/secureapp-operator-image-injection.yaml
@@ -4,4 +4,4 @@ note: >
   When secureAppEnabled is set to true, the Instrumentation CR now activates
   SecureApp for Java (CSA image swap), Node.js (environment variable injection),
   and Python (secureapp variant image swap).
-issues: []
+issues: [2455]

--- a/.chloggen/secureapp-operator-image-injection.yaml
+++ b/.chloggen/secureapp-operator-image-injection.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: operator
+note: >
+  When secureAppEnabled is set to true, the Instrumentation CR now activates
+  SecureApp for Java (CSA image swap), Node.js (environment variable injection),
+  and Python (secureapp variant image swap).
+issues: []

--- a/docs/auto-instrumentation-install.md
+++ b/docs/auto-instrumentation-install.md
@@ -65,6 +65,27 @@ these frameworks often have pre-built instrumentation capabilities already avail
       - Automatically injects `SPLUNK_PROFILER_ENABLED=true` and `SPLUNK_PROFILER_MEMORY_ENABLED=true` into the Instrumentation CR's global `spec.env`, unless already defined there.
       - To disable profiling for specific languages, override these vars in the per-language env (e.g. `instrumentation.spec.java.env`). See the [partially enable profiling](../examples/enable-operator-and-auto-instrumentation/instrumentation/instrumentation-enable-profiling-partially.yaml) example.
       - To disable profiling globally while keeping the pipeline active, set `SPLUNK_PROFILER_ENABLED=false` and `SPLUNK_PROFILER_MEMORY_ENABLED=false` in `instrumentation.spec.env`.
+  - **SecureApp Activation (Optional)**
+    - Set `splunkObservability.secureAppEnabled: true` to activate SecureApp for instrumented workloads. When enabled, the chart modifies the Instrumentation CR per language:
+      - **Java**: swaps the init-container image to the CSA variant specified in `instrumentation.spec.java.secureAppImage`. The field is stripped before the CR is applied (the OTel Operator does not recognise it).
+      - **Node.js**: injects `SPLUNK_SECUREAPP_AGENT_ENABLED=true` into the pod environment. The SecureApp agent is pre-bundled in the standard Node.js image (`v4.7.0+`); no image change is required. The env var is not injected if already set by the user.
+      - **Python**: swaps the init-container image to the secureapp variant specified in `instrumentation.spec.python.secureAppImage`. The field is stripped before the CR is applied.
+
+    Example `values.yaml` snippet:
+    ```yaml
+    splunkObservability:
+      secureAppEnabled: true
+
+    instrumentation:
+      spec:
+        java:
+          secureAppImage: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java-csa:v2.28.0
+        python:
+          secureAppImage: quay.io/signalfx/splunk-otel-instrumentation-python:v2.11.0-secureapp
+    ```
+
+    No annotation changes are required — the same `instrumentation.opentelemetry.io/inject-{language}` annotations continue to apply.
+
   - **Customizing Instrumentation**
     - `instrumentation.spec`: Override values under this parameter to customize the deployed opentelemetry.io/v1alpha1 Instrumentation object.
       - **Examples**

--- a/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
+++ b/helm-charts/splunk-otel-collector/templates/operator/_helpers.tpl
@@ -129,6 +129,24 @@ Helper to build entries for instrumentation libraries
     {{- if and (eq (kindOf $.Values.instrumentation.spec) "map") (hasKey $.Values.instrumentation.spec $lib) -}}
       {{- $libSpec := get $.Values.instrumentation.spec $lib }}
 
+      {{- /* When secureAppEnabled=true, swap image to secureAppImage for languages that define it (java, python). */ -}}
+      {{- if and $.Values.splunkObservability.secureAppEnabled $libSpec.secureAppImage -}}
+        {{- $libSpec = merge (dict "image" $libSpec.secureAppImage) $libSpec -}}
+      {{- end -}}
+
+      {{- /* When secureAppEnabled=true and processing nodejs, inject the SecureApp activation env var. */ -}}
+      {{- /* The @splunk/secureapp-agent npm package is pre-bundled in the standard image (v4.7.0+); no image swap needed. */ -}}
+      {{- if and (eq $lib "nodejs") $.Values.splunkObservability.secureAppEnabled -}}
+        {{- if eq (include "splunk-otel-collector.operator.env-has" (dict "env" $libSpec.env "envName" "SPLUNK_SECUREAPP_AGENT_ENABLED")) "false" -}}
+          {{- $currentEnv := default list $libSpec.env -}}
+          {{- $newEnv := append $currentEnv (dict "name" "SPLUNK_SECUREAPP_AGENT_ENABLED" "value" "true") -}}
+          {{- $libSpec = merge (dict "env" $newEnv) $libSpec -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- /* Strip secureAppImage before rendering — OTel Operator does not recognise this field. */ -}}
+      {{- $libSpec = omit $libSpec "secureAppImage" -}}
+
       {{- /* Instead of including as a string, use a template function that returns proper data structure */ -}}
       {{- $envData := dict "endpoint" $endpoint "instLibName" $lib "env" $libSpec.env "image" $libSpec.image -}}
       {{- $envVars := include "splunk-otel-collector.operator.extract-instrumentation-env" $envData | fromYaml -}}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -276,6 +276,13 @@
               "const": true
             }
           }
+        },
+        {
+          "properties": {
+            "secureAppEnabled": {
+              "const": true
+            }
+          }
         }
       ]
     },

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -1137,6 +1137,7 @@ instrumentation:
       #     value: go_value
     java:
       image: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:v2.28.0
+      secureAppImage: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java-csa:v2.28.0
       env:
         - name: OTEL_RESOURCE_DISABLED_KEYS
           value: process.executable.path,process.command_args
@@ -1161,6 +1162,7 @@ instrumentation:
       #     value: nodejs_value
     python:
       image: quay.io/signalfx/splunk-otel-instrumentation-python:v2.7.0
+      secureAppImage: quay.io/signalfx/splunk-otel-instrumentation-python:v2.11.0-secureapp
       env:
         - name: OTEL_EXPERIMENTAL_RESOURCE_DETECTORS
           value: ""

--- a/unittests/operator_customized_test.yaml
+++ b/unittests/operator_customized_test.yaml
@@ -68,3 +68,163 @@ tests:
           content:
             name: SPLUNK_PROFILER_MEMORY_ENABLED
             value: "true"
+
+  # --------------------------------------------------------------------------
+  # secureAppEnabled — Java image swap
+  # --------------------------------------------------------------------------
+
+  - it: "secureAppEnabled=true — spec.java.image replaced with secureAppImage value"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+      instrumentation:
+        spec:
+          java:
+            image: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:v2.27.0
+            secureAppImage: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java-csa:v2.28.0
+    asserts:
+      - equal:
+          path: spec.java.image
+          value: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java-csa:v2.28.0
+      - isNull:
+          path: spec.java.secureAppImage
+
+  - it: "secureAppEnabled=false — spec.java.image is NOT replaced"
+    set:
+      splunkObservability:
+        secureAppEnabled: false
+      instrumentation:
+        spec:
+          java:
+            image: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:v2.27.0
+            secureAppImage: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java-csa:v2.28.0
+    asserts:
+      - equal:
+          path: spec.java.image
+          value: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:v2.27.0
+      - isNull:
+          path: spec.java.secureAppImage
+
+  # --------------------------------------------------------------------------
+  # secureAppEnabled — Node.js env var injection
+  # --------------------------------------------------------------------------
+
+  - it: "secureAppEnabled=true — spec.nodejs.env includes SPLUNK_SECUREAPP_AGENT_ENABLED=true"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+      instrumentation:
+        spec:
+          nodejs:
+            image: ghcr.io/signalfx/splunk-otel-js/splunk-otel-js:v4.7.2
+    asserts:
+      - contains:
+          path: spec.nodejs.env
+          content:
+            name: SPLUNK_SECUREAPP_AGENT_ENABLED
+            value: "true"
+
+  - it: "secureAppEnabled=false — spec.nodejs.env does NOT include SPLUNK_SECUREAPP_AGENT_ENABLED"
+    set:
+      splunkObservability:
+        secureAppEnabled: false
+      instrumentation:
+        spec:
+          nodejs:
+            image: ghcr.io/signalfx/splunk-otel-js/splunk-otel-js:v4.7.2
+    asserts:
+      - notContains:
+          path: spec.nodejs.env
+          content:
+            name: SPLUNK_SECUREAPP_AGENT_ENABLED
+            value: "true"
+
+  - it: "secureAppEnabled=true, customer sets SPLUNK_SECUREAPP_AGENT_ENABLED=false — must NOT be overridden"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+      instrumentation:
+        spec:
+          nodejs:
+            image: ghcr.io/signalfx/splunk-otel-js/splunk-otel-js:v4.7.2
+            env:
+              - name: SPLUNK_SECUREAPP_AGENT_ENABLED
+                value: "false"
+    asserts:
+      - contains:
+          path: spec.nodejs.env
+          content:
+            name: SPLUNK_SECUREAPP_AGENT_ENABLED
+            value: "false"
+      - notContains:
+          path: spec.nodejs.env
+          content:
+            name: SPLUNK_SECUREAPP_AGENT_ENABLED
+            value: "true"
+
+  - it: "secureAppEnabled=true — spec.java.env does NOT include SPLUNK_SECUREAPP_AGENT_ENABLED"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+      instrumentation:
+        spec:
+          java:
+            image: ghcr.io/signalfx/splunk-otel-java/splunk-otel-java:v2.27.0
+    asserts:
+      - notContains:
+          path: spec.java.env
+          content:
+            name: SPLUNK_SECUREAPP_AGENT_ENABLED
+            value: "true"
+
+  # --------------------------------------------------------------------------
+  # secureAppEnabled — Python image swap
+  # --------------------------------------------------------------------------
+
+  - it: "secureAppEnabled=true — spec.python.image replaced with secureAppImage value"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+      instrumentation:
+        spec:
+          python:
+            image: quay.io/signalfx/splunk-otel-instrumentation-python:v2.7.0
+            secureAppImage: quay.io/signalfx/splunk-otel-instrumentation-python:v2.11.0-secureapp
+    asserts:
+      - equal:
+          path: spec.python.image
+          value: quay.io/signalfx/splunk-otel-instrumentation-python:v2.11.0-secureapp
+      - isNull:
+          path: spec.python.secureAppImage
+
+  - it: "secureAppEnabled=false — spec.python.image is NOT replaced"
+    set:
+      splunkObservability:
+        secureAppEnabled: false
+      instrumentation:
+        spec:
+          python:
+            image: quay.io/signalfx/splunk-otel-instrumentation-python:v2.7.0
+            secureAppImage: quay.io/signalfx/splunk-otel-instrumentation-python:v2.11.0-secureapp
+    asserts:
+      - equal:
+          path: spec.python.image
+          value: quay.io/signalfx/splunk-otel-instrumentation-python:v2.7.0
+      - isNull:
+          path: spec.python.secureAppImage
+
+  - it: "secureAppEnabled=true, python — spec.python.env does NOT include SPLUNK_SECUREAPP_AGENT_ENABLED"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+      instrumentation:
+        spec:
+          python:
+            image: quay.io/signalfx/splunk-otel-instrumentation-python:v2.7.0
+            secureAppImage: quay.io/signalfx/splunk-otel-instrumentation-python:v2.11.0-secureapp
+    asserts:
+      - notContains:
+          path: spec.python.env
+          content:
+            name: SPLUNK_SECUREAPP_AGENT_ENABLED
+            value: "true"


### PR DESCRIPTION
### Summary
  
Adds secureAppEnabled support to the Instrumentation CR rendering path. When `splunkObservability.secureAppEnabled: true` is set, the chart activates SecureApp for each supported language without requiring any annotation changes:

  - Java — swaps the init-container image to `instrumentation.spec.java.secureAppImage` (defaults to the CSA-tagged variant). The `secureAppImage` field is stripped before the CR is applied — the OTel Operator does not recognise it.
  - Node.js — injects SPLUNK_SECUREAPP_AGENT_ENABLED=true into the pod environment. The SecureApp npm package is pre-bundled in the standard image (v4.7.0+); no image change is needed. The env var is not injected if already set by the user (dedup guard).
  - Python — swaps the init-container image to `instrumentation.spec.python.secureAppImage` (defaults to the secureapp-tagged variant). Same strip behaviour as Java.

The swap logic is generic — any language spec that carries a secureAppImage field gets the image replaced automatically.


#### Testing
  helm unittest --strict helm-charts/splunk-otel-collector
11/11 new tests pass, 0 regressions