### PR TITLE
[chore] use ephemeral containers for file streaming

### DIFF
--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -64,9 +64,9 @@ const (
 	clusterReceiverLabelSelector           = "component=otel-k8s-cluster-receiver"
 	splunkOtelCollectorTAResourceName      = "splunk-otel-collector-ta"
 	taResourceName                         = "targetallocator-ta"
-	linuxPodMetricsPath                    = "/tmp/metrics.json"
+	linuxPodMetricsPath                    = "/splunk-metrics/metrics.json"
 	winPodMetricsPath                      = "C:\\metrics.json"
-	linuxPodK8sClusterMetricsPath          = "/tmp/k8s_cluster_metrics.json"
+	linuxPodK8sClusterMetricsPath          = "/splunk-metrics/k8s_cluster_metrics.json"
 	winPodK8sClusterMetricsPath            = "C:\\k8s_cluster_metrics.json"
 )
 

--- a/functional_tests/functional/testdata/values/aks_test_linux_values.yaml.tmpl
+++ b/functional_tests/functional/testdata/values/aks_test_linux_values.yaml.tmpl
@@ -10,6 +10,12 @@ splunkPlatform:
   endpoint: {{ .LogHecEndpoint }}
 
 agent:
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   resources:
     requests:
       cpu: 100m
@@ -20,7 +26,7 @@ agent:
   config:
     exporters:
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       otlp_grpc:
         endpoint: {{ .OtlpEndpoint }}
         tls:

--- a/functional_tests/functional/testdata/values/eks_auto_mode_test_values.yaml.tmpl
+++ b/functional_tests/functional/testdata/values/eks_auto_mode_test_values.yaml.tmpl
@@ -22,10 +22,16 @@ logsCollection:
     enabled: true
     directory: /run/log/journal
 agent:
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   config:
     exporters:
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       otlp_grpc:
         endpoint: {{ .OtlpEndpoint }}
         tls:
@@ -42,12 +48,18 @@ agent:
             - file
 clusterReceiver:
   eventsEnabled: true
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   config:
     exporters:
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       file/k8s_cluster:
-        path: /tmp/k8s_cluster_metrics.json
+        path: /splunk-metrics/k8s_cluster_metrics.json
       signalfx:
         ingest_url: {{ .K8sClusterEndpoint }}
         tls:

--- a/functional_tests/functional/testdata/values/eks_auto_mode_upgrade_from_previous_release_values.yaml
+++ b/functional_tests/functional/testdata/values/eks_auto_mode_upgrade_from_previous_release_values.yaml
@@ -13,5 +13,5 @@ operator:
 instrumentation:
   installationJob:
     enabled: true
-targetAllocator:
+targetallocator:
   enabled: true

--- a/functional_tests/functional/testdata/values/eks_fargate_upgrade_from_previous_release_values.yaml
+++ b/functional_tests/functional/testdata/values/eks_fargate_upgrade_from_previous_release_values.yaml
@@ -12,5 +12,5 @@ operator:
 instrumentation:
   installationJob:
     enabled: true
-targetAllocator:
+targetallocator:
   enabled: true

--- a/functional_tests/functional/testdata/values/eks_test_values.yaml.tmpl
+++ b/functional_tests/functional/testdata/values/eks_test_values.yaml.tmpl
@@ -36,11 +36,17 @@ logsCollection:
         priority: info
 
 agent:
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   config:
     exporters:
       {{ if (eq .KubeTestEnv "eks") }}
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       {{ end }}
       otlp_grpc:
         endpoint: {{ .OtlpEndpoint }}
@@ -61,13 +67,19 @@ agent:
 clusterReceiver:
   hostNetwork: true
   eventsEnabled: true
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   config:
     exporters:
       {{ if (eq .KubeTestEnv "eks") }}
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       file/k8s_cluster:
-        path: /tmp/k8s_cluster_metrics.json
+        path: /splunk-metrics/k8s_cluster_metrics.json
       {{ end }}
       signalfx:
         ingest_url: {{ .K8sClusterEndpoint }}

--- a/functional_tests/functional/testdata/values/eks_upgrade_from_previous_release_values.yaml
+++ b/functional_tests/functional/testdata/values/eks_upgrade_from_previous_release_values.yaml
@@ -13,5 +13,5 @@ operator:
 instrumentation:
   installationJob:
     enabled: true
-targetAllocator:
+targetallocator:
   enabled: true

--- a/functional_tests/functional/testdata/values/gce_test_values.yaml.tmpl
+++ b/functional_tests/functional/testdata/values/gce_test_values.yaml.tmpl
@@ -20,6 +20,12 @@ logsCollection:
     directory: /run/log/journal
 
 agent:
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   controlPlaneMetrics:
     scrapeInterval: 30s
     etcd:
@@ -31,7 +37,7 @@ agent:
   config:
     exporters:
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       otlp_grpc:
         endpoint: {{ .OtlpEndpoint }}
         tls:
@@ -48,12 +54,18 @@ agent:
             - otlp_grpc
 clusterReceiver:
   eventsEnabled: true
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   config:
     exporters:
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       file/k8s_cluster:
-        path: /tmp/k8s_cluster_metrics.json
+        path: /splunk-metrics/k8s_cluster_metrics.json
       signalfx:
         ingest_url: {{ .K8sClusterEndpoint }}
         tls:

--- a/functional_tests/functional/testdata/values/gke_autopilot_upgrade_from_previous_release_values.yaml
+++ b/functional_tests/functional/testdata/values/gke_autopilot_upgrade_from_previous_release_values.yaml
@@ -11,5 +11,5 @@ operator:
 instrumentation:
   installationJob:
     enabled: true
-targetAllocator:
+targetallocator:
   enabled: true

--- a/functional_tests/functional/testdata/values/gke_test_values.yaml.tmpl
+++ b/functional_tests/functional/testdata/values/gke_test_values.yaml.tmpl
@@ -10,6 +10,12 @@ splunkPlatform:
   endpoint: {{ .LogHecEndpoint }}
 
 agent:
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   config:
     exporters:
       otlp_grpc:
@@ -17,7 +23,7 @@ agent:
         tls:
           insecure: true
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
     service:
       pipelines:
         traces:
@@ -28,6 +34,12 @@ agent:
             - file
 clusterReceiver:
   eventsEnabled: true
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   config:
     exporters:
       signalfx:
@@ -35,9 +47,9 @@ clusterReceiver:
         tls:
           insecure: true
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       file/k8s_cluster:
-        path: /tmp/k8s_cluster_metrics.json
+        path: /splunk-metrics/k8s_cluster_metrics.json
     service:
       pipelines:
         metrics/collector:

--- a/functional_tests/functional/testdata/values/gke_upgrade_from_previous_release_values.yaml
+++ b/functional_tests/functional/testdata/values/gke_upgrade_from_previous_release_values.yaml
@@ -11,5 +11,5 @@ operator:
 instrumentation:
   installationJob:
     enabled: true
-targetAllocator:
+targetallocator:
   enabled: true

--- a/functional_tests/functional/testdata/values/kind_upgrade_from_previous_release_values.yaml
+++ b/functional_tests/functional/testdata/values/kind_upgrade_from_previous_release_values.yaml
@@ -10,5 +10,5 @@ operator:
 instrumentation:
   installationJob:
     enabled: true
-targetAllocator:
+targetallocator:
   enabled: true

--- a/functional_tests/functional/testdata/values/rosa_test_values.yaml.tmpl
+++ b/functional_tests/functional/testdata/values/rosa_test_values.yaml.tmpl
@@ -19,6 +19,12 @@ logsCollection:
     enabled: false
 
 agent:
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   resources:
     limits:
       memory: 1Gi
@@ -35,7 +41,7 @@ agent:
         insecure_skip_verify: true
     exporters:
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       otlp_grpc:
         endpoint: {{ .OtlpEndpoint }}
         tls:
@@ -52,12 +58,18 @@ agent:
             - otlp_grpc
 clusterReceiver:
   eventsEnabled: true
+  extraVolumes:
+    - name: metrics-output
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: metrics-output
+      mountPath: /splunk-metrics
   config:
     exporters:
       file:
-        path: /tmp/metrics.json
+        path: /splunk-metrics/metrics.json
       file/k8s_cluster:
-        path: /tmp/k8s_cluster_metrics.json
+        path: /splunk-metrics/k8s_cluster_metrics.json
       signalfx:
         ingest_url: {{ .K8sClusterEndpoint }}
         tls:

--- a/functional_tests/internal/common.go
+++ b/functional_tests/internal/common.go
@@ -4,11 +4,13 @@
 package internal
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -44,6 +46,7 @@ const (
 	TargetAllocatorContainerName = "targetallocator"
 	TargetAllocatorLabelSelector = "app.kubernetes.io/name=targetallocator"
 	waitTimeout                  = 3 * time.Minute
+	fileCopyHelperImage          = "busybox:1.38.0"
 )
 
 func HostEndpoint(t *testing.T) string {
@@ -190,81 +193,181 @@ func FormatAttributes(m pcommon.Map) string {
 	return b.String()
 }
 
-// CopyFileToPod streams the contents of a local file to a file inside a Kubernetes pod using `cat`,
-// since our collector container images do not include the `tar` utility.
+// CopyFileToPod streams the contents of a local file to a file inside a Kubernetes pod.
+// remoteFilePath must live under one of containerName's mounted volumes
 func CopyFileToPod(t *testing.T, clientset *kubernetes.Clientset, config *rest.Config,
 	namespace, podName, containerName, localFilePath, remoteFilePath string,
 ) {
-	localFile, err := os.Open(localFilePath)
-	require.NoError(t, err, "failed to open local file %s", localFilePath)
+	helper := startFileCopyHelper(t, clientset, namespace, podName, containerName, remoteFilePath)
+	command := []string{"sh", "-c", fmt.Sprintf("mkdir -p %q && cat > %q", path.Dir(remoteFilePath), remoteFilePath)}
 
-	defer localFile.Close()
-
-	req := clientset.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(podName).
-		Namespace(namespace).
-		SubResource("exec").
-		VersionedParams(&v1.PodExecOptions{
-			Container: containerName,
-			Command:   []string{"sh", "-c", "cat > " + remoteFilePath},
-			Stdin:     true,
-			Stdout:    true,
-			Stderr:    true,
-			TTY:       false,
-		}, scheme.ParameterCodec)
-
-	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
-	require.NoError(t, err, "failed to create SPDY executor")
-
-	err = exec.StreamWithContext(t.Context(), remotecommand.StreamOptions{
-		Stdin:  localFile,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-		Tty:    false,
-	})
-	require.NoError(t, err, "failed to stream file %s to pod", localFilePath)
+	require.Eventually(t, func() bool {
+		localFile, err := os.Open(localFilePath)
+		if err != nil {
+			t.Logf("failed to open local file %s: %v", localFilePath, err)
+			return false
+		}
+		defer localFile.Close()
+		if err = streamExec(t, config, clientset, namespace, podName, helper, command, localFile, io.Discard); err != nil {
+			t.Logf("retrying copy of %s to pod %s: %v", localFilePath, podName, err)
+			return false
+		}
+		return true
+	}, time.Minute, 3*time.Second, "failed to copy file %s to pod %s", localFilePath, podName)
 }
 
-// CopyFileFromPod streams the contents of a remote file inside a Kubernetes pod to a local file using `cat`,
-// since our collector container images do not include the `tar` utility.
+// CopyFileFromPod streams the contents of a remote file inside a Kubernetes pod to a local file.
+//
+// On Linux the file is read through a busybox ephemeral container that mounts the
+// volume backing podFilePath. Windows collector images still provide cmd.exe, so the
+// Windows path execs directly in the collector container.
 func CopyFileFromPod(t *testing.T, clientset *kubernetes.Clientset, config *rest.Config,
 	namespace, podName, containerName, podFilePath, localFilePath string,
 ) {
-	var command []string
+	execContainer := containerName
+	command := []string{"cmd.exe", "/c", "type", podFilePath}
 	if strings.HasPrefix(podFilePath, "/") {
+		execContainer = startFileCopyHelper(t, clientset, namespace, podName, containerName, podFilePath)
 		command = []string{"cat", podFilePath}
-	} else {
-		command = []string{"cmd.exe", "/c", "type", podFilePath}
 	}
+
+	require.Eventually(t, func() bool {
+		localFile, err := os.Create(localFilePath)
+		if err != nil {
+			t.Logf("failed to create local file %s: %v", localFilePath, err)
+			return false
+		}
+		defer localFile.Close()
+		if err = streamExec(t, config, clientset, namespace, podName, execContainer, command, nil, localFile); err != nil {
+			t.Logf("retrying copy of %s from pod %s: %v", podFilePath, podName, err)
+			return false
+		}
+		return true
+	}, time.Minute, 3*time.Second, "failed to copy file %s from pod %s", podFilePath, podName)
+}
+
+// startFileCopyHelper attaches a busybox ephemeral container to the pod and
+// blocks until it is running, returning its name for use as an exec target.
+// absPath must live under one of targetContainer's non-subPath volume mounts.
+func startFileCopyHelper(t *testing.T, clientset *kubernetes.Clientset, namespace, podName, targetContainer, absPath string) string {
+	pod, err := clientset.CoreV1().Pods(namespace).Get(t.Context(), podName, metav1.GetOptions{})
+	require.NoError(t, err, "failed to get pod %s", podName)
+
+	volumeName, mountPath := findVolumeMountForPath(t, pod, targetContainer, absPath)
+	helperName := fmt.Sprintf("file-copy-helper-%d", time.Now().UnixNano())
+
+	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, v1.EphemeralContainer{
+		EphemeralContainerCommon: v1.EphemeralContainerCommon{
+			Name:            helperName,
+			Image:           fileCopyHelperImage,
+			ImagePullPolicy: v1.PullIfNotPresent,
+			Command:         []string{"sleep", "600"},
+			VolumeMounts: []v1.VolumeMount{{
+				Name:      volumeName,
+				MountPath: mountPath,
+			}},
+			SecurityContext: &v1.SecurityContext{
+				AllowPrivilegeEscalation: boolPtr(false),
+				ReadOnlyRootFilesystem:   boolPtr(true),
+				Capabilities:             &v1.Capabilities{Drop: []v1.Capability{"ALL"}},
+				SeccompProfile:           &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault},
+			},
+		},
+	})
+
+	_, err = clientset.CoreV1().Pods(namespace).UpdateEphemeralContainers(t.Context(), podName, pod, metav1.UpdateOptions{})
+	require.NoError(t, err, "failed to add ephemeral helper container to pod %s", podName)
+
+	require.Eventually(t, func() bool {
+		p, getErr := clientset.CoreV1().Pods(namespace).Get(t.Context(), podName, metav1.GetOptions{})
+		if getErr != nil {
+			t.Logf("failed to get pod %s while waiting for helper: %v", podName, getErr)
+			return false
+		}
+		for _, st := range p.Status.EphemeralContainerStatuses {
+			if st.Name != helperName {
+				continue
+			}
+			if st.State.Terminated != nil {
+				require.Failf(t, "file copy helper terminated unexpectedly",
+					"helper %s in pod %s terminated: reason=%s message=%s",
+					helperName, podName, st.State.Terminated.Reason, st.State.Terminated.Message)
+			}
+			return st.State.Running != nil
+		}
+		return false
+	}, 2*time.Minute, 2*time.Second, "ephemeral helper %s did not start in pod %s", helperName, podName)
+
+	return helperName
+}
+
+// findVolumeMountForPath returns the name and mount path of the longest
+// non-subPath volume mount in containerName whose mount path contains absPath.
+// The file targeted by the ephemeral copy helper must live on such a volume.
+func findVolumeMountForPath(t *testing.T, pod *v1.Pod, containerName, absPath string) (string, string) {
+	clean := path.Clean(absPath)
+	var bestVolume, bestMount string
+	for i := range pod.Spec.Containers {
+		c := pod.Spec.Containers[i]
+		if c.Name != containerName {
+			continue
+		}
+		for _, vm := range c.VolumeMounts {
+			if vm.SubPath != "" || vm.SubPathExpr != "" {
+				continue
+			}
+			mp := path.Clean(vm.MountPath)
+			if clean != mp && !strings.HasPrefix(clean, mp+"/") {
+				continue
+			}
+			if len(mp) > len(bestMount) {
+				bestMount = mp
+				bestVolume = vm.Name
+			}
+		}
+	}
+	require.NotEmptyf(t, bestVolume,
+		"no volume mount in container %s backs path %s; the file must live on a mounted volume so the ephemeral copy helper can reach it",
+		containerName, absPath)
+	return bestVolume, bestMount
+}
+
+// streamExec runs command in the given pod/container, wiring optional stdin and
+// stdout. stderr is captured and folded into the returned error for debugging.
+func streamExec(t *testing.T, config *rest.Config, clientset *kubernetes.Clientset,
+	namespace, podName, containerName string, command []string, stdin io.Reader, stdout io.Writer,
+) error {
 	req := clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(podName).
 		Namespace(namespace).
-		SubResource("exec").
-		VersionedParams(&v1.PodExecOptions{
-			Command:   command,
-			Container: containerName,
-			Stdin:     false,
-			Stdout:    true,
-			Stderr:    true,
-			TTY:       false,
-		}, scheme.ParameterCodec)
+		SubResource("exec").VersionedParams(&v1.PodExecOptions{
+		Container: containerName,
+		Command:   command,
+		Stdin:     stdin != nil,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
-	require.NoError(t, err, "failed to create SPDY executor")
+	if err != nil {
+		return fmt.Errorf("failed to create SPDY executor: %w", err)
+	}
 
-	localFile, err := os.Create(localFilePath)
-	require.NoError(t, err, "failed to create local file %s", localFilePath)
-	defer localFile.Close()
-
-	err = exec.StreamWithContext(t.Context(), remotecommand.StreamOptions{
-		Stdout: localFile,
-		Stderr: os.Stderr, // Direct stderr to local stderr for debugging
+	var stderr bytes.Buffer
+	if err = exec.StreamWithContext(t.Context(), remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: &stderr,
 		Tty:    false,
-	})
-	require.NoError(t, err, "failed to stream file %s from pod", podFilePath)
+	}); err != nil {
+		return fmt.Errorf("exec %v failed: %w (stderr: %s)", command, err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
 }
+
+func boolPtr(b bool) *bool { return &b }
 
 func GetPodLogs(t *testing.T, clientset *kubernetes.Clientset, namespace, podName, containerName string, tailLines int64) (string, error) {
 	podLogOptions := v1.PodLogOptions{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Use an ephemeral container to stream files in and out of collector pods in the functional tests. The collector images are being hardened (no shell/tar), so exec-ing cat into /tmp inside the collector container is no longer usable. The tests now attach a short-lived `busybox` ephemeral container that mounts the same volume backing the target file path and does the read/write there. The file exporter output also moves from `/tmp` to a dedicated metrics-output `emptyDir` mounted at `/splunk-metrics`.

Upgrade-from-previous-release values: use the `targetallocator` key (new in latest release) so the previous-release base install passes schema validation.
