### PR TITLE
[chore] scope image bumps to targeted line and fix quay.io tag filter

### DIFF
--- a/ci_scripts/base_util.sh
+++ b/ci_scripts/base_util.sh
@@ -300,7 +300,8 @@ get_latest_tag() {
         local repo_name="${BASH_REMATCH[2]}"
         local latest_api="https://quay.io/api/v1/repository/$owner/$repo_name/tag/?limit=1&onlyActiveTags=true"
         if [ -n "$filter" ]; then
-            latest_api+="&filter_tag_name=$filter"
+            # quay.io requires filter_tag_name in "<op>:<value>" form; a bare value is rejected.
+            latest_api+="&filter_tag_name=like:$filter"
         fi
         local tag_name=$(curl -sL "$latest_api" | jq -r '.tags[0].name')
         if [ -z "$tag_name" ]; then
@@ -387,8 +388,9 @@ update_version() {
 
     # TODO: use yq to update the tag after adapting the yq formatting requirements in values.yaml
     # This is a workaround to avoid reformatting the entire YAML file.
-    # We match the last segment of the yq query as the key, and the current value, then replace the tag part.
-    local key_name=$(basename "$yq_query_string" | sed 's/\..*//')
+    # Use the trailing path segment (e.g. "secureAppImage") as the key so the awk below
+    # scopes the edit to the targeted line instead of any line sharing the current tag.
+    local key_name="${yq_query_string##*.}"
     if awk -v KEY="$key_name" -v CURRENT_TAG="$current_tag" -v LATEST_TAG="$latest_tag" '
         {
             # Match lines with the key (e.g., image: or tag:) and the current tag value

--- a/ci_scripts/base_util.sh
+++ b/ci_scripts/base_util.sh
@@ -303,7 +303,7 @@ get_latest_tag() {
             # quay.io requires filter_tag_name in "<op>:<value>" form; a bare value is rejected.
             latest_api+="&filter_tag_name=like:$filter"
         fi
-        local tag_name=$(curl -sL "$latest_api" | jq -r '.tags[0].name')
+        local tag_name=$(curl -sL "$latest_api" | jq -r '.tags[0].name // empty')
         if [ -z "$tag_name" ]; then
             echo "Error: No tag found or failed to fetch tag from quay.io" >&2
             return 1
@@ -313,9 +313,9 @@ get_latest_tag() {
     elif [[ $repo_value =~ ^ghcr\.io/([^/]+/[^/]+) ]]; then
         local full_repo_name="${BASH_REMATCH[1]}"
         local latest_api="https://api.github.com/repos/${full_repo_name}/tags"
-        local tag_name=$(curl -sL -H 'Accept: application/vnd.github+json' "$latest_api" | jq -r '.[0].name')
+        local tag_name=$(curl -sL -H 'Accept: application/vnd.github+json' "$latest_api" | jq -r '.[0].name // empty')
         if [ -n "$filter" ]; then
-            tag_name=$(curl -sL -H 'Accept: application/vnd.github+json' "$latest_api" | jq -r --arg filter "$filter" 'first(.[] | select(.name | startswith($filter))).name')
+            tag_name=$(curl -sL -H 'Accept: application/vnd.github+json' "$latest_api" | jq -r --arg filter "$filter" 'first(.[] | select(.name | startswith($filter))).name // empty')
         fi
         if [ -z "$tag_name" ]; then
             echo "Error: No tag found or failed to fetch tag from ghcr.io" >&2
@@ -388,9 +388,20 @@ update_version() {
 
     # TODO: use yq to update the tag after adapting the yq formatting requirements in values.yaml
     # This is a workaround to avoid reformatting the entire YAML file.
-    # Use the trailing path segment (e.g. "secureAppImage") as the key so the awk below
-    # scopes the edit to the targeted line instead of any line sharing the current tag.
-    local key_name="${yq_query_string##*.}"
+    # Pick the key the awk below scopes the edit to, so it only touches the targeted line
+    # Map paths (repo/tag) carry the tag on a "tag:" line; string paths (e.g. ".spec.java.secureAppImage") carry it inline.
+    local value_type
+    if [[ "$yq_query_string" =~ ^select\(.*\) || "$yq_query_string" =~ ^\..* ]]; then
+        value_type="$(yq eval-all "${yq_query_string} | type" "${yaml_file_path}")"
+    else
+        value_type="$(yq eval-all ".${yq_query_string} | type" "${yaml_file_path}")"
+    fi
+    local key_name
+    if [[ "$value_type" == *'map'* ]]; then
+        key_name="tag"
+    else
+        key_name="${yq_query_string##*.}"
+    fi
     if awk -v KEY="$key_name" -v CURRENT_TAG="$current_tag" -v LATEST_TAG="$latest_tag" '
         {
             # Match lines with the key (e.g., image: or tag:) and the current tag value


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`update_version` derived an empty key from the yq path so the awk replacement matched any line sharing the current tag. With sibling images that use the same tag (e.g. java.image and java.secureAppImage both at the same
version), a single bump rewrote both lines, producing overlapping update PRs. Take the trailing path segment as the key so the edit is scoped to the targeted line.

Also fix the quay.io tag lookup.
