### PR TITLE
feat(agent): enrich SecureApp logs pipeline with k8s and resource met…

### DIFF
--- a/.chloggen/secureapp-agent-enrichment-processors.yaml
+++ b/.chloggen/secureapp-agent-enrichment-processors.yaml
@@ -4,4 +4,4 @@ note: >
   Enrich SecureApp logs pipeline with Kubernetes metadata, resource detection,
   and environment attributes so that SecureApp events carry the same resource
   context as other log pipelines in the agent.
-issues: []
+issues: [2480]

--- a/.chloggen/secureapp-agent-enrichment-processors.yaml
+++ b/.chloggen/secureapp-agent-enrichment-processors.yaml
@@ -1,5 +1,5 @@
 change_type: enhancement
-component: agent
+component: agent, gateway
 note: >
   Enrich SecureApp logs pipeline with Kubernetes metadata, resource detection,
   and environment attributes so that SecureApp events carry the same resource

--- a/.chloggen/secureapp-agent-enrichment-processors.yaml
+++ b/.chloggen/secureapp-agent-enrichment-processors.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: agent
+note: >
+  Enrich SecureApp logs pipeline with Kubernetes metadata, resource detection,
+  and environment attributes so that SecureApp events carry the same resource
+  context as other log pipelines in the agent.
+issues: []

--- a/examples/secureapp-agent-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/configmap-agent.yaml
@@ -388,7 +388,6 @@ data:
           processors:
           - memory_limiter
           - k8s_attributes
-          - resourcedetection
           - resource
           - batch
           receivers:

--- a/examples/secureapp-agent-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/configmap-agent.yaml
@@ -387,6 +387,9 @@ data:
           - otlp_http/secureapp
           processors:
           - memory_limiter
+          - k8s_attributes
+          - resourcedetection
+          - resource
           - batch
           receivers:
           - routing/logs

--- a/examples/secureapp-agent-mode/rendered_manifests/daemonset.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 811c80fe2e01f91e3d2518fbf17f5cf7478f4b9ad6da1d55690fc103b0cfe40e
+        checksum/config: 4dbd5944030507ec9b39e75c30dec4ed2b1cb44a9ee31a4a38eedfec85010c8b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secureapp-agent-mode/rendered_manifests/daemonset.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 29b195f47fe4ba761d334e855dad1cc037d6d08a6b462316a4588820f9af119b
+        checksum/config: 811c80fe2e01f91e3d2518fbf17f5cf7478f4b9ad6da1d55690fc103b0cfe40e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secureapp-gateway-mode/rendered_manifests/configmap-gateway.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/configmap-gateway.yaml
@@ -222,6 +222,8 @@ data:
           - otlp_http/secureapp
           processors:
           - memory_limiter
+          - k8s_attributes
+          - resource/add_cluster_name
           - batch
           receivers:
           - routing/logs

--- a/examples/secureapp-gateway-mode/rendered_manifests/deployment-gateway.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/deployment-gateway.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: e57e3821887646bbb43fd2476f96b85cccd12f5d3f65a930cbece728c90e9499
+        checksum/config: 7dfed0cb77d7d4eb546de326dd652b1d7aca57d8b26d9bd19662e50720bf6596
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -1120,6 +1120,9 @@ service:
       processors:
         - memory_limiter
         - k8s_attributes
+        {{- if eq (include "splunk-otel-collector.autoDetectClusterName" .) "true" }}
+        - resourcedetection/k8s_cluster_name
+        {{- end }}
         - resource
         - batch
       exporters:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -1117,7 +1117,15 @@ service:
     # secure application events — always routed via routing/logs connector
     logs/secureapp:
       receivers: [routing/logs]
-      processors: [memory_limiter, batch]
+      processors:
+        - memory_limiter
+        - k8s_attributes
+        - resourcedetection
+        - resource
+        {{- if .Values.environment }}
+        - resource/add_environment
+        {{- end }}
+        - batch
       exporters:
         {{- if .Values.gateway.enabled }}
         - otlp_grpc

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -1120,11 +1120,7 @@ service:
       processors:
         - memory_limiter
         - k8s_attributes
-        - resourcedetection
         - resource
-        {{- if .Values.environment }}
-        - resource/add_environment
-        {{- end }}
         - batch
       exporters:
         {{- if .Values.gateway.enabled }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -306,7 +306,16 @@ service:
     logs/secureapp:
       receivers:
         - routing/logs
-      processors: [memory_limiter, batch]
+      processors:
+        - memory_limiter
+        - k8s_attributes
+        {{- if eq (include "splunk-otel-collector.autoDetectClusterName" .) "true" }}
+        - resourcedetection/k8s_cluster_name
+        {{- end }}
+        {{- if .Values.clusterName }}
+        - resource/add_cluster_name
+        {{- end }}
+        - batch
       exporters: [otlp_http/secureapp]
     {{- end }}
     {{- end }}

--- a/unittests/resource_detection_test.yaml
+++ b/unittests/resource_detection_test.yaml
@@ -568,7 +568,7 @@ tests:
           path: data["relay"]
           pattern: "logs/k8s_entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "agent — logs/secureapp pipeline has no resourcedetection"
+  - it: "agent — logs/secureapp pipeline includes resourcedetection"
     set:
       distribution: openshift
       cloudProvider: aws
@@ -576,7 +576,7 @@ tests:
         secureAppEnabled: true
     template: configmap-agent.yaml
     asserts:
-      - notMatchRegex:
+      - matchRegex:
           path: data["relay"]
           pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
 

--- a/unittests/resource_detection_test.yaml
+++ b/unittests/resource_detection_test.yaml
@@ -568,7 +568,7 @@ tests:
           path: data["relay"]
           pattern: "logs/k8s_entities:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "agent — logs/secureapp pipeline includes resourcedetection"
+  - it: "agent — logs/secureapp pipeline has no resourcedetection"
     set:
       distribution: openshift
       cloudProvider: aws
@@ -576,7 +576,7 @@ tests:
         secureAppEnabled: true
     template: configmap-agent.yaml
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: data["relay"]
           pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
 

--- a/unittests/secureapp_test.yaml
+++ b/unittests/secureapp_test.yaml
@@ -193,3 +193,50 @@ tests:
       - matchRegex:
           path: data["relay"]
           pattern: "logs/secureapp:"
+
+  # --------------------------------------------------------------------------
+  # PR3: logs/secureapp enrichment processors
+  # --------------------------------------------------------------------------
+
+  - it: "S=1 — logs/secureapp has k8s_attributes, resourcedetection, resource processors"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+        profilingEnabled: false
+    template: configmap-agent.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "- k8s_attributes"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "- resourcedetection"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "- resource\n"
+
+  - it: "S=1 — logs/secureapp omits resource/add_environment when environment not set"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+        profilingEnabled: false
+    template: configmap-agent.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:[\\s\\S]*?- resource/add_environment[\\s\\S]*?logs/split:"
+
+  - it: "S=1 — logs/secureapp includes resource/add_environment when environment is set"
+    set:
+      splunkObservability:
+        secureAppEnabled: true
+        profilingEnabled: false
+      environment: production
+    template: configmap-agent.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: "- resource/add_environment"

--- a/unittests/secureapp_test.yaml
+++ b/unittests/secureapp_test.yaml
@@ -207,10 +207,10 @@ tests:
     asserts:
       - matchRegex:
           path: data["relay"]
-          pattern: "- k8s_attributes"
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- k8s_attributes\\n(?:\\s+- .+\\n)*\\s+receivers:"
       - matchRegex:
           path: data["relay"]
-          pattern: "- resource\n"
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resource\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
   - it: "S=1 — logs/secureapp has no resourcedetection processor"
     set:

--- a/unittests/secureapp_test.yaml
+++ b/unittests/secureapp_test.yaml
@@ -212,7 +212,7 @@ tests:
           path: data["relay"]
           pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resource\\n(?:\\s+- .+\\n)*\\s+receivers:"
 
-  - it: "S=1 — logs/secureapp has no resourcedetection processor"
+  - it: "S=1 — logs/secureapp has no bare resourcedetection processor"
     set:
       splunkObservability:
         secureAppEnabled: true
@@ -222,3 +222,71 @@ tests:
       - notMatchRegex:
           path: data["relay"]
           pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "S=1,autoDetect=true — logs/secureapp has resourcedetection/k8s_cluster_name processor"
+    set:
+      clusterName: ""
+      distribution: openshift
+      splunkObservability:
+        secureAppEnabled: true
+        profilingEnabled: false
+    template: configmap-agent.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "S=1,autoDetect=false — logs/secureapp has no resourcedetection/k8s_cluster_name processor"
+    set:
+      clusterName: my-cluster
+      splunkObservability:
+        secureAppEnabled: true
+        profilingEnabled: false
+    template: configmap-agent.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  # --------------------------------------------------------------------------
+  # PR3: gateway logs/secureapp enrichment processors
+  # --------------------------------------------------------------------------
+
+  - it: "gateway,S=1 — logs/secureapp has k8s_attributes processor"
+    set:
+      gateway.enabled: true
+      splunkObservability:
+        secureAppEnabled: true
+        profilingEnabled: false
+    template: configmap-gateway.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- k8s_attributes\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "gateway,S=1,autoDetect=true — logs/secureapp has resourcedetection/k8s_cluster_name processor"
+    set:
+      clusterName: ""
+      distribution: openshift
+      gateway.enabled: true
+      splunkObservability:
+        secureAppEnabled: true
+        profilingEnabled: false
+    template: configmap-gateway.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"
+
+  - it: "gateway,S=1,autoDetect=false — logs/secureapp has no resourcedetection/k8s_cluster_name processor"
+    set:
+      clusterName: my-cluster
+      gateway.enabled: true
+      splunkObservability:
+        secureAppEnabled: true
+        profilingEnabled: false
+    template: configmap-gateway.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection/k8s_cluster_name\\n(?:\\s+- .+\\n)*\\s+receivers:"

--- a/unittests/secureapp_test.yaml
+++ b/unittests/secureapp_test.yaml
@@ -198,7 +198,7 @@ tests:
   # PR3: logs/secureapp enrichment processors
   # --------------------------------------------------------------------------
 
-  - it: "S=1 — logs/secureapp has k8s_attributes, resourcedetection, resource processors"
+  - it: "S=1 — logs/secureapp has k8s_attributes and resource processors"
     set:
       splunkObservability:
         secureAppEnabled: true
@@ -207,18 +207,12 @@ tests:
     asserts:
       - matchRegex:
           path: data["relay"]
-          pattern: "logs/secureapp:"
-      - matchRegex:
-          path: data["relay"]
           pattern: "- k8s_attributes"
-      - matchRegex:
-          path: data["relay"]
-          pattern: "- resourcedetection"
       - matchRegex:
           path: data["relay"]
           pattern: "- resource\n"
 
-  - it: "S=1 — logs/secureapp omits resource/add_environment when environment not set"
+  - it: "S=1 — logs/secureapp has no resourcedetection processor"
     set:
       splunkObservability:
         secureAppEnabled: true
@@ -227,16 +221,4 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["relay"]
-          pattern: "logs/secureapp:[\\s\\S]*?- resource/add_environment[\\s\\S]*?logs/split:"
-
-  - it: "S=1 — logs/secureapp includes resource/add_environment when environment is set"
-    set:
-      splunkObservability:
-        secureAppEnabled: true
-        profilingEnabled: false
-      environment: production
-    template: configmap-agent.yaml
-    asserts:
-      - matchRegex:
-          path: data["relay"]
-          pattern: "- resource/add_environment"
+          pattern: "logs/secureapp:\\n\\s+exporters:\\n(?:\\s+- .+\\n)+\\s+processors:\\n(?:\\s+- .+\\n)*\\s+- resourcedetection\\n(?:\\s+- .+\\n)*\\s+receivers:"


### PR DESCRIPTION
 ## Summary
  
  Enriches the `logs/secureapp` pipeline in the OTel agent config with Kubernetes metadata and resource attributes, so that SecureApp events carry the same context as other log pipelines.
  
  ### What changes
  
  - **`_otel-agent.tpl`** — `logs/secureapp` processors extended from `[memory_limiter, batch]` to:
    `memory_limiter → k8s_attributes → resourcedetection → resource → resource/add_environment (when set) → batch`
  - **`unittests/secureapp_test.yaml`** — 3 new tests: enrichment processors present, `resource/add_environment` absent without `environment` value, present when set
  - **`unittests/resource_detection_test.yaml`** — updated existing test that previously asserted `logs/secureapp` has no `resourcedetection`; now correctly asserts it does (agent only — gateway
  pipeline is unchanged)
  - **`.chloggen/secureapp-agent-enrichment-processors.yaml`** — changelog entry
  
  ### Depends on
  
  #2457 (merged) — SecureApp log routing fix
  
  ### Notes
  
  - Gateway (`_otel-collector.tpl`) `logs/secureapp` pipeline is intentionally unchanged — enrichment is agent-side only
  - `resource/add_environment` is guarded by `.Values.environment` consistent with all other pipelines
  
