### PR TITLE
feat(clusterReceiver): enable NetworkPolicy and CRD collection via k8s_objects receiver

### DIFF
--- a/.chloggen/otl-4323-enable-networkpolicy-crd-collection.yaml
+++ b/.chloggen/otl-4323-enable-networkpolicy-crd-collection.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable collection of NetworkPolicy and CustomResourceDefinition objects via k8s_objects receiver, routed to /v3/event endpoint.
+# One or more tracking issues related to the change
+issues: [4323]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds NetworkPolicy (networking.k8s.io/v1) and CustomResourceDefinition (apiextensions.k8s.io/v1) to the default
+  k8sObjects list using watch mode. Also adds the required RBAC rules to the ClusterRole so the collector can
+  query these API groups.

--- a/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
+++ b/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/add-sampler/rendered_manifests/clusterRole.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/default/rendered_manifests/clusterRole.yaml
+++ b/examples/default/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -194,6 +194,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/discovery-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/discovery-mode/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-aks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-eks-auto-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/clusterRole.yaml
@@ -97,3 +97,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
@@ -103,3 +103,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-eks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRole.yaml
@@ -97,3 +97,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
@@ -90,6 +90,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes/pods

--- a/examples/distribution-gke/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
@@ -106,3 +106,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/ebpf-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -171,6 +171,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -194,6 +194,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/histograms-disabled/rendered_manifests/clusterRole.yaml
+++ b/examples/histograms-disabled/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -227,6 +227,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -203,6 +203,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/host-journalctl-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/clusterRole.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
@@ -146,6 +146,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/multi-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/multi-metrics/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -194,6 +194,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/multiline-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/multiline-logs/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/only-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/only-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/otlp-token-passthrough/rendered_manifests/clusterRole.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/secret-validation/rendered_manifests/clusterRole.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/secureapp-agent-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/secureapp-gateway-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-connect-for-otlp/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-connect-for-otlp/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -199,6 +199,12 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          mode: watch
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          mode: watch
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/target-allocator/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/use-proxy/rendered_manifests/clusterRole.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -121,6 +121,22 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 {{- if eq .Values.distribution "gke/autopilot" }}
 - apiGroups:
   - ""

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -611,6 +611,12 @@ clusterReceiver:
     - name: pods
       mode: pull
       interval: 6h
+    - name: networkpolicies
+      mode: watch
+      group: networking.k8s.io
+    - name: customresourcedefinitions
+      mode: watch
+      group: apiextensions.k8s.io
 
   # hostNetwork schedules the pod with the host's network namespace.
   # The default value depends on distribution option: true for eks/auto-mode, otherwise false.


### PR DESCRIPTION
**Description:**
Adds NetworkPolicy (networking.k8s.io/v1) and CustomResourceDefinition (apiextensions.k8s.io/v1) to the default k8sObjects list in the cluster receiver. Both use watch mode so changes are captured in real-time. Also adds the required RBAC rules to the ClusterRole so the collector has permission to query these API groups. Data flows through the existing logs/objects pipeline to the /v3/event endpoint when sendK8sEventsToSplunkO11y is enabled.
Assisted-by: Claude Sonnet 4.6

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:**
Rendered example manifests updated manually to reflect new objects and RBAC rules

**Documentation:**
No doc changes needed. The existing values.yaml comment already notes that custom RBAC rules may be required for additional object types.
