### PR TITLE
feat(clusterReceiver): enable NetworkPolicy and CRD collection via k8s_objects receiver

### DIFF
--- a/.chloggen/otl-4323-enable-networkpolicy-crd-collection.yaml
+++ b/.chloggen/otl-4323-enable-networkpolicy-crd-collection.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable collection of NetworkPolicy and CustomResourceDefinition objects via k8s_objects receiver, routed to /v3/event endpoint.
+# One or more tracking issues related to the change
+issues: [4323]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds NetworkPolicy (networking.k8s.io/v1) and CustomResourceDefinition (apiextensions.k8s.io/v1) to the default
+  k8sObjects list using pull mode, consistent with the existing pods object. Also adds the required RBAC rules to
+  the ClusterRole so the collector can query these API groups.

--- a/.chloggen/otl-4323-enable-networkpolicy-crd-collection.yaml
+++ b/.chloggen/otl-4323-enable-networkpolicy-crd-collection.yaml
@@ -3,13 +3,16 @@ change_type: enhancement
 # The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
 component: clusterReceiver
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Enable collection of NetworkPolicy and CustomResourceDefinition objects via k8s_objects receiver, routed to /v3/event endpoint.
+note: Enable collection of NetworkPolicy and CustomResourceDefinition objects by default via k8s_objects pipeline.
 # One or more tracking issues related to the change
 issues: [4323]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Adds NetworkPolicy (networking.k8s.io/v1) and CustomResourceDefinition (apiextensions.k8s.io/v1) to the default
-  k8sObjects list using pull mode, consistent with the existing pods object. Also adds the required RBAC rules to
-  the ClusterRole so the collector can query these API groups.
+  Added to the default `clusterReceiver.k8sObjects` list in pull mode (6h interval), with the
+  required read permissions granted in the chart's ClusterRole.
+
+  Collected only when a destination is enabled: `splunkPlatform.logsEnabled` (Splunk Platform logs)
+  and/or `featureGates.sendK8sEventsToSplunkO11y` (Splunk Observability `/v3/event`); sent to each
+  that is enabled. To opt out, remove these entries from `clusterReceiver.k8sObjects`.

--- a/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
+++ b/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
+++ b/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f2f331a152efbc6e301fb2cd7f8bc831da7549b23fb08d23d048f9c3050fd8ad
+        checksum/config: d142ac2b5b6c629adeca88724e186ba8336d01a04c7326e0221f4d8ccd8c3a28
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f2f331a152efbc6e301fb2cd7f8bc831da7549b23fb08d23d048f9c3050fd8ad
+        checksum/config: d142ac2b5b6c629adeca88724e186ba8336d01a04c7326e0221f4d8ccd8c3a28
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/add-sampler/rendered_manifests/clusterRole.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/add-sampler/rendered_manifests/clusterRole.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: f2f331a152efbc6e301fb2cd7f8bc831da7549b23fb08d23d048f9c3050fd8ad
+        checksum/config: d142ac2b5b6c629adeca88724e186ba8336d01a04c7326e0221f4d8ccd8c3a28
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: f2f331a152efbc6e301fb2cd7f8bc831da7549b23fb08d23d048f9c3050fd8ad
+        checksum/config: d142ac2b5b6c629adeca88724e186ba8336d01a04c7326e0221f4d8ccd8c3a28
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/collector-gateway-statefulset-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-statefulset-only/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/collector-gateway-statefulset-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-statefulset-only/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/default/rendered_manifests/clusterRole.yaml
+++ b/examples/default/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/default/rendered_manifests/clusterRole.yaml
+++ b/examples/default/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -194,6 +194,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3995eaf0584587333ec4b5b6f4da31ad80772b6d11955ae943be9a9f9fdd5fb1
+        checksum/config: 67783db83f29618f364e266730bbbddedfc813082590fdbb2f98b3ad5dfa3639
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/discovery-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/discovery-mode/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/discovery-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/discovery-mode/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-aks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/distribution-aks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-eks-auto-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/clusterRole.yaml
@@ -97,3 +97,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-eks-auto-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/clusterRole.yaml
@@ -104,7 +104,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -112,4 +111,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
@@ -110,7 +110,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -118,4 +117,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
@@ -103,3 +103,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-eks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRole.yaml
@@ -97,3 +97,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-eks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRole.yaml
@@ -104,7 +104,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -112,4 +111,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,7 +103,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
@@ -90,6 +90,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes/pods

--- a/examples/distribution-gke/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/distribution-gke/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
@@ -106,3 +106,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
@@ -113,7 +113,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -121,4 +120,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/ebpf-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/ebpf-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -171,6 +171,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 94e485fa244687529f5a353b48a4bfbcfe44c081d3f7dca0aec0a03b14aa3b53
+        checksum/config: cc0868a85e925d7f3de62b3dbf709e26ca65523d3b9619e188018e2ed10d8ccf
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -194,6 +194,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3995eaf0584587333ec4b5b6f4da31ad80772b6d11955ae943be9a9f9fdd5fb1
+        checksum/config: 67783db83f29618f364e266730bbbddedfc813082590fdbb2f98b3ad5dfa3639
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/histograms-disabled/rendered_manifests/clusterRole.yaml
+++ b/examples/histograms-disabled/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/histograms-disabled/rendered_manifests/clusterRole.yaml
+++ b/examples/histograms-disabled/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -227,6 +227,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 4bdb42fb158c13412c4ec81b977cdf529251592f80bfc2b3030b68c9f4f3795a
+        checksum/config: 44514ea448e4aa5066d099615ebbcd89d6c22b3beb34bfe919116f8b287c1b3a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/histograms-with-splunk-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -203,6 +203,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a389f1ac37c3031adc6eecf57d5ac8e6788fe945777f84be71c664cac605e9b0
+        checksum/config: 9b8995fac992f2bda03a161dc23ff93830736bdcd680955b564c7f5cb3096d70
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/host-journalctl-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/host-journalctl-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0e6980d30cdc8dd70ba62311ce5e86f852bc5553950d0137c14da24518aa2c40
+        checksum/config: d74cd1fdc2964636f6f91945fe6fca17572b83a7401c28b516ea6254915598b8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/clusterRole.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/clusterRole.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
@@ -146,6 +146,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5e929e944de4c59d04b516841f3e326db0d750d41ea9c09576bd8eeb155820b6
+        checksum/config: d4b721f63fcc9387d519f8a32a62b52d5a555014351dee3d2b97523a9756892e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -166,6 +166,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f2f331a152efbc6e301fb2cd7f8bc831da7549b23fb08d23d048f9c3050fd8ad
+        checksum/config: d142ac2b5b6c629adeca88724e186ba8336d01a04c7326e0221f4d8ccd8c3a28
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/multi-metrics/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/multi-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/multi-metrics/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -194,6 +194,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: be53c9e0eb1b430a948188fe3d6915b27ec726acb78aed51655653cc6de887bc
+        checksum/config: dd94215b5ab38ae057efeea507b99e59e6a3049c35daa7dfe463c85668b82755
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multiline-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/multiline-logs/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/multiline-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/multiline-logs/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0e6980d30cdc8dd70ba62311ce5e86f852bc5553950d0137c14da24518aa2c40
+        checksum/config: d74cd1fdc2964636f6f91945fe6fca17572b83a7401c28b516ea6254915598b8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0e6980d30cdc8dd70ba62311ce5e86f852bc5553950d0137c14da24518aa2c40
+        checksum/config: d74cd1fdc2964636f6f91945fe6fca17572b83a7401c28b516ea6254915598b8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/only-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/only-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/only-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/only-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/otlp-token-passthrough/rendered_manifests/clusterRole.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/otlp-token-passthrough/rendered_manifests/clusterRole.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/secret-validation/rendered_manifests/clusterRole.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/secret-validation/rendered_manifests/clusterRole.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0e6980d30cdc8dd70ba62311ce5e86f852bc5553950d0137c14da24518aa2c40
+        checksum/config: d74cd1fdc2964636f6f91945fe6fca17572b83a7401c28b516ea6254915598b8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secureapp-agent-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/secureapp-agent-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/secureapp-gateway-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/secureapp-gateway-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-connect-for-otlp/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/splunk-connect-for-otlp/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-connect-for-otlp/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/splunk-connect-for-otlp/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b23d369eddc71ee3da627ccbdf89fc35754f6b581a1b8591b8bdc1732d52b34b
+        checksum/config: 6a30f21401c03aa07c4b416683295699950410b9364650e08a931a0645d7fb14
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -133,6 +133,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: ed45e3c53770f9d03d01f77fd58fc95f58935f4674bbebcde4bfe9ad750a22b9
+        checksum/config: 5c685e7780757fed75afff3a3e4b110683a9df30f272f4f651c92dcda5c8539f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -199,6 +199,14 @@ data:
         - interval: 6h
           mode: pull
           name: pods
+        - group: networking.k8s.io
+          interval: 6h
+          mode: pull
+          name: networkpolicies
+        - group: apiextensions.k8s.io
+          interval: 6h
+          mode: pull
+          name: customresourcedefinitions
       prometheus/k8s_cluster_receiver:
         config:
           scrape_configs:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 33fa1414a38d590478d970aac818eb390138a73315e4403f20dfa3af9ea20a54
+        checksum/config: 088b9599215fd4cd11a701e6d2a5072e903e14f6984815f58b9db43f86a9766d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/target-allocator/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/target-allocator/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/use-proxy/rendered_manifests/clusterRole.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/use-proxy/rendered_manifests/clusterRole.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
@@ -96,7 +96,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -104,4 +103,3 @@ rules:
   verbs:
   - get
   - list
-  - watch

--- a/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
@@ -89,3 +89,19 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -128,7 +128,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -136,7 +135,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 {{- if eq .Values.distribution "gke/autopilot" }}
 - apiGroups:
   - ""

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -121,6 +121,22 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 {{- if eq .Values.distribution "gke/autopilot" }}
 - apiGroups:
   - ""

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -615,6 +615,14 @@ clusterReceiver:
     - name: pods
       mode: pull
       interval: 6h
+    - name: networkpolicies
+      mode: pull
+      interval: 6h
+      group: networking.k8s.io
+    - name: customresourcedefinitions
+      mode: pull
+      interval: 6h
+      group: apiextensions.k8s.io
 
   # hostNetwork schedules the pod with the host's network namespace.
   # The default value depends on distribution option: true for eks/auto-mode, otherwise false.


### PR DESCRIPTION
**Description:**
Adds NetworkPolicy (`networking.k8s.io/v1`) and CustomResourceDefinition (`apiextensions.k8s.io/v1`) to the default `clusterReceiver.k8sObjects` list, collected via the `k8sobjects` receiver in **pull mode** (6h interval), consistent with the existing `pods` object. Also adds the required read permissions to the ClusterRole so the collector can list these API groups.

Data flows through the existing logs/objects pipeline and is sent to whichever destination is enabled:
- `splunkPlatform.logsEnabled` — Splunk Platform logs (HEC)
- `featureGates.sendK8sEventsToSplunkO11y` — Splunk Observability `/v3/event`

To opt out, remove these entries from `clusterReceiver.k8sObjects`.

Assisted-by: Claude Sonnet 4.6

**Link to Splunk idea:** <Link to Splunk idea, see https://ideas.splunk.com>

**Testing:**
Rendered example manifests updated via `make render` to reflect the new objects and RBAC rules.

**Documentation:**
No doc changes needed. The existing `values.yaml` comment already notes that custom RBAC rules may be required for additional object types.
