### PR TITLE
set disableCompression to `false` by default

### DIFF
--- a/.chloggen/disable-compression-default.yaml
+++ b/.chloggen/disable-compression-default.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: agent, clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change default of `splunkPlatform.disableCompression` from `true` to `false`, enabling gzip compression by default for HEC exporters.
+# One or more tracking issues related to the change
+issues: [2491]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/ci_scripts/sck_otel_values.yaml
+++ b/ci_scripts/sck_otel_values.yaml
@@ -18,8 +18,8 @@ splunkPlatform:
   sourcetype:
   # Maximum HTTP connections to use simultaneously when sending data. Defaults to 200.
   maxConnections: 200
-  # Whether to disable gzip compression over HTTP. Defaults to true.
-  disableCompression: true
+  # Whether to disable gzip compression over HTTP. Defaults to false.
+  disableCompression: false
   # HTTP timeout when sending data. Defaults to 10s.
   timeout: 10s
   # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to true.

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -39,7 +39,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         send_otlp_histograms: true
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -24,7 +24,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         timeout: 10s
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3f0a09cd6ffd8dda96b869901a196cd33edb928c8eaa6482a65eed5ee6409268
+        checksum/config: 4d3939ad4c1fc4b63496f229ad6efbae95119cb7d701213b2bad08e11d874a59
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 75423addce65b6964bf956335a89ef389f0786fc894026b5ff037073c160a6b8
+        checksum/config: 2377e9866ff785830f5c5134549aa0b007f266a3786d7720ee783f9fccc17ed0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -39,7 +39,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         send_otlp_histograms: true
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -24,7 +24,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         timeout: 10s
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e4794255a07757568f78b15e36a96d658001d298543d785cfc13ee4fd69e3aac
+        checksum/config: 9808fbb6e941e817826091e828ee0c4e9642e9039fe13b06bf76e936851c6c29
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 75423addce65b6964bf956335a89ef389f0786fc894026b5ff037073c160a6b8
+        checksum/config: 2377e9866ff785830f5c5134549aa0b007f266a3786d7720ee783f9fccc17ed0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-agent.yaml
@@ -34,7 +34,7 @@ data:
         root_path: /hostfs
         sync_host_metadata: true
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
@@ -24,7 +24,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         timeout: 10s
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 07b15603843d89da8dc50485f62fce9428d2f2f721ddea968a345318050f7382
+        checksum/config: caf7d3eb8fafe8947be8dd68f708d4df5672f25b3a2ab72f83fa7525673a5939
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 75423addce65b6964bf956335a89ef389f0786fc894026b5ff037073c160a6b8
+        checksum/config: 2377e9866ff785830f5c5134549aa0b007f266a3786d7720ee783f9fccc17ed0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -39,7 +39,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         send_otlp_histograms: true
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -24,7 +24,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         timeout: 10s
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 82bd9906d54e5d5a18c64ff8b9d47844fcecedc2440a9e5aaac3794a35aa4581
+        checksum/config: f49f2b3d4185a11f97fe0c06445ecd6a0f81f530868889905e3a72ca658879ca
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 75423addce65b6964bf956335a89ef389f0786fc894026b5ff037073c160a6b8
+        checksum/config: 2377e9866ff785830f5c5134549aa0b007f266a3786d7720ee783f9fccc17ed0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fba90c1c4866fa59499b45575f03e77e5b5c0d6bd1e77e11dac7a9565bd4be37
+        checksum/config: 03cfffc54396c2abc405ead18fc3b717459a9275ac9b88ea6e1d237b13df07d6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -67,7 +67,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_traces:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: ""

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 96c33cea449749232acbbb49f2615cf448fe7d4c8d18d7673e738dab42f9c8bd
+        checksum/config: 78599f94625f875daa1925288f531106bae88a72531f2f2b7b5b3bd1c2a0eec5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7226485c1d3ac8424242b8c89d9c2e144f20815db65b24d081c3c47198ea4c59
+        checksum/config: 95d6c2de14bc72b88b253240af349b94cf245733b87733e3b6b4bb0d3b917f0b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -39,7 +39,7 @@ data:
         ingest_url: https://ingest.us0.observability.splunkcloud.com
         send_otlp_histograms: true
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -24,7 +24,7 @@ data:
         ingest_url: https://ingest.us0.observability.splunkcloud.com
         timeout: 10s
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e9c7edfa8b9ecd955c101eeb60a1a5226285f1fb1d8d7d27e91e75c1c223f08b
+        checksum/config: c512491d69d3c591e633180a60dceb64142747eeb09b0ab1edecf01dd90824bc
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9bb8244bc3cfc6813a2142c6a5f7bf38a3cf78ddb06f82d8746093f1a7059248
+        checksum/config: 14b3a398cd83bcad4b77b5b2734cbf1f57eaf5de357e61b11c951c51eee1ff29
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -67,7 +67,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_traces:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: ""

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 00bd97666ab332a77120236a7a96130428ec6025de9d03ddc4c1c4ff228f4b83
+        checksum/config: 8093d21b65aa1b1832ef2b3c0daba833ef630dbb1d80d8c83e11fb886b3664f6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7226485c1d3ac8424242b8c89d9c2e144f20815db65b24d081c3c47198ea4c59
+        checksum/config: 95d6c2de14bc72b88b253240af349b94cf245733b87733e3b6b4bb0d3b917f0b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-disabled/rendered_manifests/configmap-agent.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-agent.yaml
@@ -34,7 +34,7 @@ data:
         root_path: /hostfs
         sync_host_metadata: true
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main
@@ -58,7 +58,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -24,7 +24,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         timeout: 10s
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main
@@ -49,7 +49,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/histograms-disabled/rendered_manifests/daemonset.yaml
+++ b/examples/histograms-disabled/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 468c17756074daf54092bd729e0799b4b11392c5cbbe93e0c2f740fdbc202943
+        checksum/config: 60be0ad326b3fa63e67e7dc088b2347df0119f00df7c8f1e7fc13387b41381c4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 28aa2ee35a740d945a84288dde57c021cec3f5a6163631705f4dd3d6cdcf6025
+        checksum/config: 7b2d07570e9f98f30a8946368ddd024fc394c7e868a9cc798197f4c26a143c7a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-agent.yaml
@@ -37,7 +37,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         send_otlp_histograms: true
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main
@@ -61,7 +61,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/histograms-with-splunk-platform/rendered_manifests/daemonset.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c9dfb06e10b3cc09c04e60a94c8d82b30f44d362bed75ab19b821f1fc9d1b9f5
+        checksum/config: b7f89bd6c259eb962b8bcd3a0df89c4e02d592312db14348340cf15d3343c1a9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 0c29b02341f8cca03c5a9c0b0b95d69e86f4f6b0f2ead08336a6d354f856dcb3
+        checksum/config: 1ec0c20d9c74b15f2571e0e9bc9dd7e01188b09aa19c9cbd4191d7797d6683b3
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-agent.yaml
@@ -20,7 +20,7 @@ data:
       debug:
         verbosity: detailed
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/host-journalctl-logs/rendered_manifests/daemonset.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a34a050336268ce5b0b94f946a911dfef8763ca84821fa9a8aa2c82ccdf5f363
+        checksum/config: ecec3fb4d88c53546602d00ca96cc682ad04bf4629de12d7a5c25fa42f1930e5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d7f2d5c7f95a6fd2f0e0bd87aaebde25ea37d8b6f158e4fcd0c78008f78e8faa
+        checksum/config: ead967ccd64095ca7d3d6923b62ba652fa393dfa269749420f5aa6e7e9c35fd6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -38,7 +38,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         send_otlp_histograms: true
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -24,7 +24,7 @@ data:
         ingest_url: https://ingest.CHANGEME.observability.splunkcloud.com
         timeout: 10s
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cefe99565ffbe156929306ec243b58d9aca6ff5490979f983dc08e9e2cb9d5c4
+        checksum/config: bd608066839783616ff3ceac91763500bdceef05b135d3284b7234cd433a7735
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 75423addce65b6964bf956335a89ef389f0786fc894026b5ff037073c160a6b8
+        checksum/config: 2377e9866ff785830f5c5134549aa0b007f266a3786d7720ee783f9fccc17ed0
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main
@@ -42,7 +42,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3c43014e803f3ae57a504ee2fbed978feac95ab4820613fa2405be41aa96ac58
+        checksum/config: 484f46d9b04d37566eb17f68a4f681a2075b942a8d709486852e66d5f70f6bbf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b8b8d078a0b11be0c7e409a243d6b2057d817e6bca4286feb23f0869e8feed72
+        checksum/config: b36968e3e679a29c2910e52bed5d03c2938f6c4b7991b70782df24afdc079b5c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multiline-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/multiline-logs/rendered_manifests/daemonset.yaml
+++ b/examples/multiline-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3a8150d5279c8c9c113c0e332a93546caf819c2a15d604eac557ae5f733215f7
+        checksum/config: 09567348a351be4716dd358f90d63e4af54c6c98269db5b871906a95311d9595
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d7f2d5c7f95a6fd2f0e0bd87aaebde25ea37d8b6f158e4fcd0c78008f78e8faa
+        checksum/config: ead967ccd64095ca7d3d6923b62ba652fa393dfa269749420f5aa6e7e9c35fd6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 661345a22875e2cf6788ea39036a6e80dd7687be97952f732547e0e2db83a8e3
+        checksum/config: d5ad114eef02d3eedac565a94f0d4eb006143b63adcce4868a4c94ba29d38647
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d7f2d5c7f95a6fd2f0e0bd87aaebde25ea37d8b6f158e4fcd0c78008f78e8faa
+        checksum/config: ead967ccd64095ca7d3d6923b62ba652fa393dfa269749420f5aa6e7e9c35fd6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: CHANGEME

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 49c6c4ff84529191674bc9e203011ee054bcace5428fd87ce902f6d8b08e2e94
+        checksum/config: c80457b534b2cdd3040a66731b6b486b1c436216e184442da3b730514fe9f1d8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: fcf2490b548c0fcad15e94b40d432277892e67a29103a711e2fed65f54d256ee
+        checksum/config: 6eceeabb36d7624769b805379a481d11859146bd55592ad952d2e7a45f0e8e83
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: CHANGEME
         idle_conn_timeout: 10s
         index: main

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 79cbe630ce144c415498b343dccbb3b1c86423762464df3ca66ccb4cb11e91bb
+        checksum/config: ba58ac64b41a43bc7070004b152f0ae7ae017ec050c012d290ab902dfda1bb0d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d7f2d5c7f95a6fd2f0e0bd87aaebde25ea37d8b6f158e4fcd0c78008f78e8faa
+        checksum/config: ead967ccd64095ca7d3d6923b62ba652fa393dfa269749420f5aa6e7e9c35fd6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7b40ddad691645b20719cbf893979d8ed508b829169b8924fad8305b927f0b3d
+        checksum/config: 91756b1ef79d0a8e36d93abf18b87bbd9cf80a475a4e474e274e33db8a4ef78d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d12589df9efd4d3b2a8b27f21f8b5b55ebda669ef68016994efe503dfb9f384b
+        checksum/config: 30302c288f8deac92176f2b1c359cd430b81ddef58e733e7ba7e30fa9a821776
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main
@@ -42,7 +42,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: metrics

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -18,7 +18,7 @@ data:
   relay: |
     exporters:
       splunk_hec/platform_logs:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: main
@@ -43,7 +43,7 @@ data:
           insecure_skip_verify: false
         token: ${SPLUNK_PLATFORM_HEC_TOKEN}
       splunk_hec/platform_metrics:
-        disable_compression: true
+        disable_compression: false
         endpoint: http://localhost:8088/services/collector
         idle_conn_timeout: 10s
         index: metrics

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 4265255e76bb5a16ebfbc015702baee7520a79c742fa121af79868669aa13344
+        checksum/config: c06979a2704f409949f26a80e52e87801e346a8770587943802f1af6a67d9064
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 418d04542f63637c3170aaae8196745cc37a33d51dfa02933de811d435ae48bc
+        checksum/config: 69b2530178471062a943753eb5479ce1db71f1d95ff9c9aa24373321e403925a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -60,8 +60,8 @@ splunkPlatform:
   metricsSourcetype: ""
   # Maximum HTTP connections to use simultaneously when sending data.
   maxConnections: 200
-  # Whether to disable gzip compression over HTTP. Defaults to true.
-  disableCompression: true
+  # Whether to disable gzip compression over HTTP. Defaults to false.
+  disableCompression: false
   # HTTP timeout when sending data. Defaults to 10s.
   timeout: 10s
   # Idle connection timeout. defaults to 10s


### PR DESCRIPTION
**Description:** enable compression by default, recent tests showed up that we no longer have problems with degraded throughput mentioned in [this PR](https://github.com/signalfx/splunk-otel-collector-chart/pull/601)

These are results for large message throughput for both compression enabled and disabled:
<img width="595" height="805" alt="image" src="https://github.com/user-attachments/assets/213f7a85-654e-4754-9295-14552a4edf11" />


**Link to Splunk idea:** N/A

**Testing:** Manual tests, performance tests

**Documentation:** N/A
