### PR TITLE
[chore] OTL-4425 Fix rosa test on chart repo

### DIFF
--- a/.github/actions/kubeconfig-secret-context/action.yaml
+++ b/.github/actions/kubeconfig-secret-context/action.yaml
@@ -8,6 +8,10 @@ inputs:
   kubeconfig-path:
     description: Kubeconfig path to export as KUBECONFIG.
     required: true
+  certificate-authority-file:
+    description: Optional CA bundle file to embed into the kubeconfig cluster entry.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -23,4 +27,33 @@ runs:
         KUBECONFIG_PATH: ${{ inputs.kubeconfig-path }}
       run: |
         printf '%s' "$KUBECONFIG_CONTENT" > "$KUBECONFIG_PATH"
+        chmod 600 "$KUBECONFIG_PATH"
+
+    - name: Update kubeconfig certificate authority
+      if: inputs.certificate-authority-file != ''
+      shell: bash
+      env:
+        CA_FILE: ${{ inputs.certificate-authority-file }}
+        KUBECONFIG_PATH: ${{ inputs.kubeconfig-path }}
+      run: |
+        if ! command -v kubectl >/dev/null 2>&1; then
+          echo "::error::kubectl is required to update kubeconfig certificate authority"
+          exit 1
+        fi
+
+        if [ ! -r "$CA_FILE" ]; then
+          echo "::error::certificate-authority-file '$CA_FILE' does not exist or is not readable"
+          exit 1
+        fi
+
+        cluster_name="$(KUBECONFIG="$KUBECONFIG_PATH" kubectl config view --raw --minify -o jsonpath='{.clusters[0].name}')"
+        if [ -z "$cluster_name" ]; then
+          echo "::error::Unable to determine the current cluster name from '$KUBECONFIG_PATH'"
+          exit 1
+        fi
+
+        KUBECONFIG="$KUBECONFIG_PATH" kubectl config set-cluster "$cluster_name" \
+          --certificate-authority="$CA_FILE" \
+          --embed-certs=true \
+          --insecure-skip-tls-verify=false >/dev/null
         chmod 600 "$KUBECONFIG_PATH"

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -421,6 +421,7 @@ jobs:
 
       - uses: ./.github/actions/kubeconfig-secret-context
         with:
+          certificate-authority-file: /etc/ssl/certs/ca-certificates.crt
           kubeconfig-content: ${{ secrets.ROSA_KUBECONFIG }}
           kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
 
@@ -441,6 +442,7 @@ jobs:
 
       - uses: ./.github/actions/kubeconfig-secret-context
         with:
+          certificate-authority-file: /etc/ssl/certs/ca-certificates.crt
           kubeconfig-content: ${{ secrets.ROSA_KUBECONFIG }}
           kubeconfig-path: /tmp/kube-config-splunk-otel-collector-chart-functional-testing-rosa
 

--- a/functional_tests/functional/testdata/values/rosa_test_values.yaml.tmpl
+++ b/functional_tests/functional/testdata/values/rosa_test_values.yaml.tmpl
@@ -27,7 +27,10 @@ agent:
       mountPath: /splunk-metrics
   resources:
     limits:
-      memory: 1Gi
+      # ROSA control-plane receiver checks scrape multiple OpenShift control-plane
+      # endpoints and file-export metrics in the same agent. Keep extra headroom
+      # so memory_limiter does not refuse scrape data during CI startup.
+      memory: 2Gi
   controlPlaneMetrics:
     scrapeInterval: 30s
     etcd:


### PR DESCRIPTION
**Description:** Fix ROSA functional test kubeconfig CA and memory pressure

Refresh the ROSA kubeconfig certificate authority at runtime by embedding the
runner CA bundle into kubeconfigs installed from secrets. This keeps TLS
verification enabled while avoiding stale certificate-authority-data in the
ROSA_KUBECONFIG secret after the ROSA API certificate chain rotated.

Also increase the ROSA functional test agent memory limit from 1Gi to 2Gi. The
control-plane receiver checks were failing because prometheus control-plane
scrapes were refused by the collector memory_limiter during CI startup, producing
receiver error logs even though the receivers had started.

**Link to Splunk idea:** 2499

**Testing:** CI pipeline for ROSA

