### PR TITLE
[chore] add check for deps in eksaddon release

### DIFF
--- a/.github/workflows/eks-addon-tests.yaml
+++ b/.github/workflows/eks-addon-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # TODO: Use ci-matrix.json instead
-        k8s_version: ["1.28", "1.29", "1.30", "1.31", "1.32", "1.33"]
+        k8s_version: ["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35"]
 
     steps:
       - name: Checkout repository

--- a/eks_addon/common.sh
+++ b/eks_addon/common.sh
@@ -28,8 +28,8 @@ prepare_chart() {
   mkdir -p "${BUILD_DIR}"
   cp -R "${CHART_DIR}" "${BUILD_DIR}/"
 
-  echo "⏳ Removing subcharts ..."
-  rm -rf "${EKS_CHART_DIR}/charts"
+  echo "⏳ Removing Helm dependency artifacts ..."
+  rm -rf "${EKS_CHART_DIR}/charts" "${EKS_CHART_DIR}/Chart.lock"
 
   echo "⏳ Modifying Helm chart in ${EKS_CHART_DIR} using overrides from ${EKS_CHART_OVERRIDES_DIR} ..."
   for override in "${EKS_CHART_OVERRIDES_DIR}"/*.yaml; do

--- a/eks_addon/release.sh
+++ b/eks_addon/release.sh
@@ -105,8 +105,8 @@ print_summary() {
   echo "  - ${ECR_OTELCOL_REPO}:${CHART_APPVERSION}"
 }
 
-prepare_chart
 aws_okta_auth
 copy_docker_image_to_ecr
+prepare_chart
 push_chart
 print_summary

--- a/eks_addon/release.sh
+++ b/eks_addon/release.sh
@@ -8,7 +8,7 @@
 # Note: This script requires OKTA_AWS_ROLE_ARN to be set in the environment.
 
 # Check required tools
-for tool in "okta-aws-login" "aws" "yq" "helm" "docker"; do
+for tool in "okta-aws-login" "aws" "yq" "jq" "helm" "docker"; do
   command -v "${tool}" &>/dev/null || { echo "❌ Required command '${tool}' is not installed or not in PATH"; exit 1; }
 done
 
@@ -91,7 +91,7 @@ push_chart() {
   echo "⏳ Packaging and pushing Helm chart ${ecr_chart_release} ..."
   helm package "${EKS_CHART_DIR}" -d "${BUILD_DIR}"
   local package_file="${BUILD_DIR}/splunk-otel-collector-${CHART_VERSION}.tgz"
-  ${DRY_RUN_PREFIX} helm push ${package_file} oci://${ECR_HELM_NAMESPACE}
+  ${DRY_RUN_PREFIX} helm push "${package_file}" oci://${ECR_HELM_NAMESPACE}
 
   echo "✅ Successfully pushed Helm chart to ${ecr_chart_release}"
 }
@@ -105,8 +105,8 @@ print_summary() {
   echo "  - ${ECR_OTELCOL_REPO}:${CHART_APPVERSION}"
 }
 
+prepare_chart
 aws_okta_auth
 copy_docker_image_to_ecr
-prepare_chart
 push_chart
 print_summary

--- a/eks_addon/run_tests.sh
+++ b/eks_addon/run_tests.sh
@@ -50,6 +50,27 @@ test_schema_validation() {
   fi
 }
 
+test_no_chart_dependencies() {
+  echo "⏳ Running test_no_chart_dependencies ..."
+
+  if [[ -f "${EKS_CHART_DIR}/Chart.lock" ]]; then
+    echo "❌ Chart dependency test failed: Chart.lock must not be included in the EKS Add-on chart"
+    return 1
+  fi
+
+  if [[ -d "${EKS_CHART_DIR}/charts" ]]; then
+    echo "❌ Chart dependency test failed: charts/ must not be included in the EKS Add-on chart"
+    return 1
+  fi
+
+  local dependency_count
+  dependency_count=$(yq e '(.dependencies // []) | length' "${EKS_CHART_DIR}/Chart.yaml")
+  if [[ "${dependency_count}" != "0" ]]; then
+    echo "❌ Chart dependency test failed: Chart.yaml dependencies must be empty"
+    return 1
+  fi
+}
+
 test_images() {
   echo "⏳ Running test_images ..."
 
@@ -91,6 +112,7 @@ prepare_chart
 test_helm_lint
 test_helm_template
 test_schema_validation
+test_no_chart_dependencies
 test_images
 test_release_properties
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fix EKS Add-on chart preparation so local deps do not leak into the packaged add-on chart. The prepared EKS chart now removes `Chart.lock` along with bundled `charts/`, and the EKS add-on tests assert that the generated chart has no lockfile, no bundled subcharts, and no `Chart.yaml` dependencies.

Also extend the EKS add-on test matrix to cover Kubernetes 1.34 and 1.35.