### PR TITLE
feat(chart): default X-SF-Token header on OpAMP forwarder egress

### DIFF
--- a/.chloggen/otl-4437-opamp-forwarder-token.yaml
+++ b/.chloggen/otl-4437-opamp-forwarder-token.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the Splunk access token header to the default OpAMP HTTP forwarder egress config.
+# One or more tracking issues related to the change
+issues: [4437]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -76,6 +76,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a859e755cde76fb7bf1739167f0999991bec473e0a2f672a6d43d21ab6c0b877
+        checksum/config: e5849680c863fc37ac5b82a83a8207b87fa51e5ec6a80261975d7a97e0a032f9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -76,6 +76,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f28939a8d1259f32c386736c6eb407aea8027301153ead20bdb1e26096f37015
+        checksum/config: d19106f5305a78a7473a58abb8d6159529b284692799a311240ebe03022aa7a1
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a937b1b1a2f7cd1277dee5f4fdf8c961bdbe08df04c4029e651d672b8e58c950
+        checksum/config: f7d8b29d1d36a1301fbb59073928e263fd7a83b7aeb8784c765659d04fcc4b31
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: b88648c996a51ec697b63fb0c87ce839f35434d1290a6bb4bf2de97e01602fd1
+        checksum/config: f25e342eda50660b5f0d9e71691737e18147c8e2bdc9f9228dee63ef5d4f57ef
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-agent.yaml
@@ -71,6 +71,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 2078a29683199b9050a33f29c855cf986b48a4f963b8b3732a7703d252ae7fff
+        checksum/config: cb7db12b2d92df91bb9714ec16d4fad597853185a0c494fdce256f1fd8dcb8f0
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -76,6 +76,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 0f5b0d20a962f9029686567fc697af25ee5cbcf7e3d6a288d33a580158b4eef3
+        checksum/config: 39dffdfc1983201131208f3e2258597feb7e13013037a3746b3bd05b05cd8922
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d9beed3f8bdef6e82f7f7562813665152e87f7009e89e30551c4506deb1c904d
+        checksum/config: 39b8951307555974bab70c682256b72b21f38f914caa6bdc52750d96ab84bd5d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -60,6 +60,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: http://default-splunk-otel-collector:4320
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -49,6 +49,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: cb749675ace69f7e945508c9d5cbae0e8e8acf6c9f44273893a8facf1e597a1d
+        checksum/config: 0ad611c595c2c073bdafe6feeaf31651a504eaba121764650bd3207d91c37348
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/gateway-workload.yaml
+++ b/examples/collector-all-modes/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6b6052060d1351d95fbd2ac3732865feaf8c576b452660ab286bd271c689ee9a
+        checksum/config: 37ed571cfa2c160f63da47cf6301fa4343d6d59fe7898d474b0fcf01a909baf6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -49,6 +49,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/collector-gateway-only/rendered_manifests/gateway-workload.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6b6052060d1351d95fbd2ac3732865feaf8c576b452660ab286bd271c689ee9a
+        checksum/config: 37ed571cfa2c160f63da47cf6301fa4343d6d59fe7898d474b0fcf01a909baf6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-statefulset-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-statefulset-only/rendered_manifests/configmap-gateway.yaml
@@ -49,6 +49,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/collector-gateway-statefulset-only/rendered_manifests/gateway-workload.yaml
+++ b/examples/collector-gateway-statefulset-only/rendered_manifests/gateway-workload.yaml
@@ -45,7 +45,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6b6052060d1351d95fbd2ac3732865feaf8c576b452660ab286bd271c689ee9a
+        checksum/config: 37ed571cfa2c160f63da47cf6301fa4343d6d59fe7898d474b0fcf01a909baf6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d2bf4610af0861675904c02c747897f5880dc636d6fb4bc939296aa2090494a5
+        checksum/config: 09776c02ef8b3d558b891189235bbb8cfaecc563a362200066ee473b96d43b52
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d9beed3f8bdef6e82f7f7562813665152e87f7009e89e30551c4506deb1c904d
+        checksum/config: 39b8951307555974bab70c682256b72b21f38f914caa6bdc52750d96ab84bd5d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6fb7dacdfe55c2c3864b3b2a1ced3f2bb74f24e869e8c5627dd8068a4997e64a
+        checksum/config: 6c60b6f5ff013db6950e5d1974c44ac762e78abf7f1faa41681e422fabee75ae
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 83980805ab8341573e93828b60ae9a1c3a9afe01ecee1b834a940b2d684c3842
+        checksum/config: 194b7640ee378ea97414989e571d47eec15d734767b24af2fd338797d4c62a48
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-agent.yaml
@@ -60,6 +60,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: http://default-splunk-otel-collector:4320
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-gateway.yaml
@@ -49,6 +49,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 09a8d9a79543983b55d553cbb7e7f22e7626cb2866d0fcdc4aacd9cc3b3c99fe
+        checksum/config: 2bcb3c02d6bebaf9602e2a2cf82f8056816d10fe2b0215864047ac7ad702f7f8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks-auto-mode/rendered_manifests/gateway-workload.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6c51c45f2f50d27fec8895f0108618b0487701e39b6ec3731e49223e76f6782e
+        checksum/config: 0467c0f415f3c5837d813905b2eba677f8110200dcfb5531bb73ff79ae3be4c6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -49,6 +49,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/distribution-eks-fargate/rendered_manifests/gateway-workload.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6b6052060d1351d95fbd2ac3732865feaf8c576b452660ab286bd271c689ee9a
+        checksum/config: 37ed571cfa2c160f63da47cf6301fa4343d6d59fe7898d474b0fcf01a909baf6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d23772b0bc44a0c046d96c77ad9b4531b3da18ba56c8864b68b30e7527fc0805
+        checksum/config: 65752122f9fef491859ed16ebff26ee5c1305c3fae5820311125e4b18191893f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: af6e658a0b843e6dacf7ec1a78bef25d806996816c9a739f41810e3dbeaacf46
+        checksum/config: f2c0fa3b9161b48fb055673970b1bc65381899f2ba6a3d812cd984d6e7735437
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 245420091ddced23159225758d19e7195bfd25edffceca96f74f294574c42b35
+        checksum/config: 0111c75eeeafaf79ab28bcb45e403c8cfc0ebfb6b6d14893201cc1c09c45706c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 60ca8f6237d54d895808586cc707e1f15e1c6ee6034c0c5a5803692d1cb66973
+        checksum/config: bcd402c3b54d634e06f9b1128848434def343adbeea60bb7b5e39b8c7af4af50
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/ebpf-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/ebpf-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d9beed3f8bdef6e82f7f7562813665152e87f7009e89e30551c4506deb1c904d
+        checksum/config: 39b8951307555974bab70c682256b72b21f38f914caa6bdc52750d96ab84bd5d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -76,6 +76,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.us0.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 82ffc2d0f6390ca3ef5660026a23d94617fcbe55fcbddd03bf2ebf38401a2bea
+        checksum/config: 8f31b2c0adacfa589d17c2dc04a4a471062e27943ece7b5f6065639824445f89
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -48,6 +48,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 956c328497a9a9c4aacb39bd4931c82d6102b6e33392fe7e8949dac4050cc65a
+        checksum/config: a1bbbfacb7ac62d642f84ee3027d21798832641c6f37e27c85f9d97f4b232ec9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: df65440f0810ff1554f1f020fb341acdda18eb9e49c4b4cb6d4413716abadd09
+        checksum/config: 9d8f4b61b995b6ecd7c44fb046e9d1c1e7c7ee7ce37e48925955993859138caf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/histograms-disabled/rendered_manifests/configmap-agent.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-agent.yaml
@@ -94,6 +94,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/histograms-disabled/rendered_manifests/daemonset.yaml
+++ b/examples/histograms-disabled/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 3c6dc0c4677bd63fe471052154d993b10a18b9725785d548d3e088668543eac5
+        checksum/config: 0983fb8139a1893e5bfdaf1457f75edfcea7f0cf2f4678fe95ffb4eda3fbf6cd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-agent.yaml
@@ -97,6 +97,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/daemonset.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 09053421d8d91b2ba39d7a92f038a222e2fceac872ab8f614b8a81abf5bbf406
+        checksum/config: a1e5029c279a217ebfc42317d2022285be6af9704af5522d4e7bc11e07202b3c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -75,6 +75,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8620318b9b8a1f3dbe22faf34ece518cf750d479841c81df6032cf9ec0db3781
+        checksum/config: fb0ca18115ec79302c87faed6bf89b63213cfebdf5ee66c2001ed85dc2b16730
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -45,6 +45,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ecb600b0dda36eca21c1bb1c10d0620a260c1114465cda81497cdd4a7010b3a3
+        checksum/config: 9662987f956e540d9aa2a0c37a77364b59a2297d0ac8b8a544ab45233bed7804
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -48,6 +48,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c64b6d306ef00efcf3fd05756317522470e6b4b91ecf88a93adbc3eb753e0b96
+        checksum/config: c6d72a40e425661ebd393729983a01695db04b2db802d5c48b641fcd3624ab4e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-agent.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-agent.yaml
@@ -60,6 +60,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: http://default-splunk-otel-collector:4320
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-gateway.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-gateway.yaml
@@ -49,6 +49,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/otlp-token-passthrough/rendered_manifests/daemonset.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6fb22153ee318c503f270c5649fca022c9c7b0d131b5784b83fe9ddb641a3607
+        checksum/config: 335b5a0e15eb8f008ffb994e33d7e965d36c30e6109992596c3cf0a46d8b5958
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/otlp-token-passthrough/rendered_manifests/gateway-workload.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 6b6052060d1351d95fbd2ac3732865feaf8c576b452660ab286bd271c689ee9a
+        checksum/config: 37ed571cfa2c160f63da47cf6301fa4343d6d59fe7898d474b0fcf01a909baf6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -54,6 +54,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: ffa1b1b3d2f3481976d620e3166fcef49747574514245f6f8449e0d751b53ed5
+        checksum/config: e20d8bed396b13ffc499caa586070ff4e6408ac14ca6bee8b0300da6690d59c6
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secureapp-agent-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/configmap-agent.yaml
@@ -70,6 +70,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/secureapp-agent-mode/rendered_manifests/daemonset.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 550298fb2359c552fd350265f5d03d129aae6eea15d4d4c974ccb129d0d193e7
+        checksum/config: df128edcb7a9db2097d01a2feacf2e25984f8548410bb6062e928fa51c313e81
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secureapp-gateway-mode/rendered_manifests/configmap-gateway.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/configmap-gateway.yaml
@@ -67,6 +67,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/secureapp-gateway-mode/rendered_manifests/gateway-workload.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 575fd562a3da1ce35d9717b7cacbc66c6b86396a0e425aba680ee690c906423c
+        checksum/config: 131e37aea08c290b9f1a57fc6b765d76c115bcc1ad09d70b7a6583455e42419f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 831ff8ad8a48286de2d019a6750277f8d694fb9df6e1d08b54f9eb2070f740ed
+        checksum/config: 484af829fb8cb07cf4fd98e4e614044ca00ee7fe989d371ad9af29c5c6656223
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d9beed3f8bdef6e82f7f7562813665152e87f7009e89e30551c4506deb1c904d
+        checksum/config: 39b8951307555974bab70c682256b72b21f38f914caa6bdc52750d96ab84bd5d
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -50,6 +50,8 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
+          headers:
+            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 13664d1adf17c2f0720f00929beb1a29b31bb3647304ca8eb354262c41c63114
+        checksum/config: 9e11b1f2dd34aa68bbc364181fb01869f4b47b59e88e660e90e24360ab592534
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -681,5 +681,7 @@ http_forwarder/opamp_splunk_o11y:
       {{- else }}
       endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
       {{- end }}
+      headers:
+        X-SF-Token: "${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Adds the Splunk access token header to the default OpAMP HTTP forwarder egress config so the forwarder authenticates upstream out of the box. The header can be removed from the rendered config to defer to a token passed by the caller.