### PR TITLE
feat(chart): add tokenPassthrough option for agent and gateway

### DIFF
--- a/.chloggen/token-passthrough-option.yaml
+++ b/.chloggen/token-passthrough-option.yaml
@@ -5,7 +5,7 @@ component: chart
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add `agent.tokenPassthrough` and `gateway.tokenPassthrough` options to enable passthrough of the client's authentication token to Splunk Observability and OpAMP.
 # One or more tracking issues related to the change
-issues: []
+issues: [2509]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/.chloggen/token-passthrough-option.yaml
+++ b/.chloggen/token-passthrough-option.yaml
@@ -10,6 +10,6 @@ issues: []
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  When enabled, the collector propagates the incoming `X-SF-Token` metadata to Splunk
-  Observability via the `headers_setter` extension and does not override the token on the
-  OpAMP HTTP forwarder egress. Defaults to `false` to preserve the current behavior.
+  When enabled, the collector propagates the caller's `X-SF-Token` to Splunk Observability
+  (via `headers_setter`) and to the OpAMP HTTP forwarder egress. Defaults preserve today's
+  behavior: `agent.tokenPassthrough=false` and `gateway.tokenPassthrough=true`.

--- a/.chloggen/token-passthrough-option.yaml
+++ b/.chloggen/token-passthrough-option.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `agent.tokenPassthrough` and `gateway.tokenPassthrough` options to enable passthrough of the client's authentication token to Splunk Observability and OpAMP.
+# One or more tracking issues related to the change
+issues: []
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When enabled, the collector propagates the incoming `X-SF-Token` metadata to Splunk
+  Observability via the `headers_setter` extension and does not override the token on the
+  OpAMP HTTP forwarder egress. Defaults to `false` to preserve the current behavior.

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -1177,27 +1177,17 @@ where <my-splunk-otel-collector-gateway> is the gateway service name captured in
 
 ### OTLP Token Passthrough
 
-The collector's configurations for the agent and gateway support OTLP token passthrough.
-This allows the collector to forward the authentication token received from the client, OTEL agent or instrumented application,
-to the Splunk Observability backend and to the OpAMP HTTP forwarder egress.
+The `agent.tokenPassthrough` and `gateway.tokenPassthrough` values forward the caller's
+`X-SF-Token` to Splunk Observability (via `headers_setter`) and to the OpAMP HTTP forwarder
+egress. Defaults preserve today's behavior: `agent.tokenPassthrough=false` and
+`gateway.tokenPassthrough=true`. When disabled, `splunkObservability.accessToken` is used
+instead.
 
-Passthrough is controlled by the `agent.tokenPassthrough` and `gateway.tokenPassthrough` values. Both default to
-`false`, which preserves the existing behavior where the collector authenticates upstream using the
-`splunkObservability.accessToken` value configured on this chart.
-
-To enable OTLP token passthrough for the agent and the gateway, use the following configuration in your values.yaml:
+To enable passthrough on the agent:
 ```yaml
 agent:
   tokenPassthrough: true
-
-gateway:
-  enabled: true
-  tokenPassthrough: true
 ```
 
-When enabled, the incoming `X-SF-Token` metadata is propagated to Splunk Observability via the
-`headers_setter` extension, and the OpAMP HTTP forwarder egress no longer overrides the token set
-by the caller.
-
-Note: token passthrough for Splunk Platform is only supported over OTLP; the Splunk Platform HEC exporters
-continue to use the token configured on this chart.
+Token passthrough is not supported for the Splunk Platform HEC exporters; they always use
+`splunkPlatform.token`.

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -1178,32 +1178,26 @@ where <my-splunk-otel-collector-gateway> is the gateway service name captured in
 ### OTLP Token Passthrough
 
 The collector's configurations for the agent and gateway support OTLP token passthrough.
-This functionality is disabled by default for the agent, and enabled by default for the gateway.
 This allows the collector to forward the authentication token received from the client, OTEL agent or instrumented application,
-to the backend services.
+to the Splunk Observability backend and to the OpAMP HTTP forwarder egress.
 
-To enable OTLP token passthrough for the agent, use the following configuration in your values.yaml:
+Passthrough is controlled by the `agent.tokenPassthrough` and `gateway.tokenPassthrough` values. Both default to
+`false`, which preserves the existing behavior where the collector authenticates upstream using the
+`splunkObservability.accessToken` value configured on this chart.
+
+To enable OTLP token passthrough for the agent and the gateway, use the following configuration in your values.yaml:
 ```yaml
 agent:
-  config:
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            include_metadata: true
-          http:
-            include_metadata: true
+  tokenPassthrough: true
+
+gateway:
+  enabled: true
+  tokenPassthrough: true
 ```
 
-To disable OTLP token passthrough in the gateway:
-```yaml
-gateway:
-  config:
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            include_metadata: false
-          http:
-            include_metadata: false
-```
+When enabled, the incoming `X-SF-Token` metadata is propagated to Splunk Observability via the
+`headers_setter` extension, and the OpAMP HTTP forwarder egress no longer overrides the token set
+by the caller.
+
+Note: token passthrough for Splunk Platform is only supported over OTLP; the Splunk Platform HEC exporters
+continue to use the token configured on this chart.

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -1189,5 +1189,11 @@ agent:
   tokenPassthrough: true
 ```
 
+To disable passthrough on the gateway:
+```yaml
+gateway:
+  tokenPassthrough: false
+```
+
 Token passthrough is not supported for the Splunk Platform HEC exporters; they always use
 `splunkPlatform.token`.

--- a/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-agent.yaml
@@ -317,8 +317,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/add-filter-processor/rendered_manifests/daemonset.yaml
+++ b/examples/add-filter-processor/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e5849680c863fc37ac5b82a83a8207b87fa51e5ec6a80261975d7a97e0a032f9
+        checksum/config: a4b035b4599dd83e611534ac6417755e84fa979cd9618605b1b299917f0f50b9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-agent.yaml
@@ -273,8 +273,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d19106f5305a78a7473a58abb8d6159529b284692799a311240ebe03022aa7a1
+        checksum/config: dc235ec279ca1c42efa3dd1bdd34c573d293ab424f82115d7971c6cfabeb5bcd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f7d8b29d1d36a1301fbb59073928e263fd7a83b7aeb8784c765659d04fcc4b31
+        checksum/config: 293874dd91c26df464fd34e86e697df325f1d382e44668aa15d3afc8ce721320
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/add-sampler/rendered_manifests/configmap-agent.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-agent.yaml
@@ -202,8 +202,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/add-sampler/rendered_manifests/daemonset.yaml
+++ b/examples/add-sampler/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f25e342eda50660b5f0d9e71691737e18147c8e2bdc9f9228dee63ef5d4f57ef
+        checksum/config: 9494b387467306e8f1a7b56c3413f0217f50bd7e299c606d17320ed72a0f87dd
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-agent.yaml
@@ -301,8 +301,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: cb7db12b2d92df91bb9714ec16d4fad597853185a0c494fdce256f1fd8dcb8f0
+        checksum/config: 39df056ed0242e6e6c010ee45105a4c1658babb099dc43ed629a442d9d2b49aa
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-agent.yaml
@@ -306,8 +306,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/autodetect-istio/rendered_manifests/daemonset.yaml
+++ b/examples/autodetect-istio/rendered_manifests/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 39dffdfc1983201131208f3e2258597feb7e13013037a3746b3bd05b05cd8922
+        checksum/config: 62d969d9ac74d8081a1230c7124060046551d64a864f6dce26848b5dd8485406
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-agent-only/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/collector-agent-only/rendered_manifests/daemonset.yaml
+++ b/examples/collector-agent-only/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 39b8951307555974bab70c682256b72b21f38f914caa6bdc52750d96ab84bd5d
+        checksum/config: bf83115d3e98f1dc29f5a30f516ced4a3da4c009057693c81bf667cf683eacec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-agent.yaml
@@ -194,8 +194,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-gateway.yaml
@@ -49,8 +49,6 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
-          headers:
-            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/collector-all-modes/rendered_manifests/daemonset.yaml
+++ b/examples/collector-all-modes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0ad611c595c2c073bdafe6feeaf31651a504eaba121764650bd3207d91c37348
+        checksum/config: 66b76b441d232fe51457f0f982982a736de2fb66a23936dd7b4e259781795d95
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/collector-all-modes/rendered_manifests/gateway-workload.yaml
+++ b/examples/collector-all-modes/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 08ebd0910147cc7c7e4d3a2d34d7956efe924715e77f92a043d739b772de79fa
+        checksum/config: 2576766d6ab44940bd7b6c938b532b2f23378920a02a70f348f93f24d1ab0173
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/configmap-gateway.yaml
@@ -49,8 +49,6 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
-          headers:
-            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/collector-gateway-only/rendered_manifests/gateway-workload.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 08ebd0910147cc7c7e4d3a2d34d7956efe924715e77f92a043d739b772de79fa
+        checksum/config: 2576766d6ab44940bd7b6c938b532b2f23378920a02a70f348f93f24d1ab0173
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-gateway-statefulset-only/rendered_manifests/configmap-gateway.yaml
+++ b/examples/collector-gateway-statefulset-only/rendered_manifests/configmap-gateway.yaml
@@ -49,8 +49,6 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
-          headers:
-            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/collector-gateway-statefulset-only/rendered_manifests/gateway-workload.yaml
+++ b/examples/collector-gateway-statefulset-only/rendered_manifests/gateway-workload.yaml
@@ -45,7 +45,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 08ebd0910147cc7c7e4d3a2d34d7956efe924715e77f92a043d739b772de79fa
+        checksum/config: 2576766d6ab44940bd7b6c938b532b2f23378920a02a70f348f93f24d1ab0173
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 09776c02ef8b3d558b891189235bbb8cfaecc563a362200066ee473b96d43b52
+        checksum/config: 52ce381b05bd1fd67d3d14d7e8b77d3a0a0d0820384dcb010aa4d040db59a825
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/default/rendered_manifests/configmap-agent.yaml
+++ b/examples/default/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/default/rendered_manifests/daemonset.yaml
+++ b/examples/default/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 39b8951307555974bab70c682256b72b21f38f914caa6bdc52750d96ab84bd5d
+        checksum/config: bf83115d3e98f1dc29f5a30f516ced4a3da4c009057693c81bf667cf683eacec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-agent.yaml
@@ -307,8 +307,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 1aea510ba92d08baf603cafcb523e5536360d32345f33773ee9405e920ae84d7
+        checksum/config: 9899b7b5d911aaa43e5fb52d432c61327e665fbb47fb633a565ddfe333dab621
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/discovery-mode/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/discovery-mode/rendered_manifests/daemonset.yaml
+++ b/examples/discovery-mode/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 6c60b6f5ff013db6950e5d1974c44ac762e78abf7f1faa41681e422fabee75ae
+        checksum/config: 126ef77f59b9d334e8787f59665764b23f0559d404d05af00e6d05f209a37a55
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-agent.yaml
@@ -201,8 +201,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/distribution-aks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-aks/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 194b7640ee378ea97414989e571d47eec15d734767b24af2fd338797d4c62a48
+        checksum/config: 4877c949a7988280c4cdb6bd5c88cb0bbf0bcbc34aa69f25e7d1f238f386e7f7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-agent.yaml
@@ -225,8 +225,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-gateway.yaml
@@ -49,8 +49,6 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
-          headers:
-            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 2bcb3c02d6bebaf9602e2a2cf82f8056816d10fe2b0215864047ac7ad702f7f8
+        checksum/config: 4b706b8f31a522903424d4671afcc53d7e4d702e7e6cf3d6e054eeb296afe4c9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-eks-auto-mode/rendered_manifests/gateway-workload.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 1173513c0ba37fe2b0c0d913aff5c0421c44623e05ef5456953567915ca8eb2e
+        checksum/config: 2bf2c464b4534e0bc146200942b487f4c794a27beda69c7d4cd2c250371308ab
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-gateway.yaml
@@ -49,8 +49,6 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
-          headers:
-            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/distribution-eks-fargate/rendered_manifests/gateway-workload.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 08ebd0910147cc7c7e4d3a2d34d7956efe924715e77f92a043d739b772de79fa
+        checksum/config: 2576766d6ab44940bd7b6c938b532b2f23378920a02a70f348f93f24d1ab0173
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-agent.yaml
@@ -217,8 +217,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/distribution-eks/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-eks/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 65752122f9fef491859ed16ebff26ee5c1305c3fae5820311125e4b18191893f
+        checksum/config: 8afc095890b0cc0d9689dd65e28ea75ef0f8b775ec2e926ec6084db5f051101c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-agent.yaml
@@ -240,8 +240,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: f2c0fa3b9161b48fb055673970b1bc65381899f2ba6a3d812cd984d6e7735437
+        checksum/config: 4dc84ec72c603de5ea267cf8e7ebaf63b1f622eb8d090b48a19f4ef27a79eb5f
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-agent.yaml
@@ -240,8 +240,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/distribution-gke/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-gke/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0111c75eeeafaf79ab28bcb45e403c8cfc0ebfb6b6d14893201cc1c09c45706c
+        checksum/config: c1b6b45ca9d53179f716bdfa3a7fb3b301e9b5152c80dac2cd19cc6f83e8e137
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-agent.yaml
@@ -200,8 +200,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/distribution-openshift/rendered_manifests/daemonset.yaml
+++ b/examples/distribution-openshift/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: bcd402c3b54d634e06f9b1128848434def343adbeea60bb7b5e39b8c7af4af50
+        checksum/config: 4ab543967a9e45f5aa86ea7667288334a796f6f580c6c350ac36490a2c294ef4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/ebpf-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/ebpf-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 39b8951307555974bab70c682256b72b21f38f914caa6bdc52750d96ab84bd5d
+        checksum/config: bf83115d3e98f1dc29f5a30f516ced4a3da4c009057693c81bf667cf683eacec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-agent.yaml
@@ -271,8 +271,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 8f31b2c0adacfa589d17c2dc04a4a471062e27943ece7b5f6065639824445f89
+        checksum/config: e720f5438800b4d2cb8b336b93f77103c00672308129c1f11466c64286fd1a79
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-agent.yaml
@@ -307,8 +307,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 269c374be2c5094578e268eecdc8c916814b7d36127fc861f5f0b57a9c3b8958
+        checksum/config: 45a92f56dddb4f886c72b0bf3fa825d00a4b4910382cf68a296a5c8ee1cc0ccf
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-agent.yaml
@@ -169,8 +169,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a1bbbfacb7ac62d642f84ee3027d21798832641c6f37e27c85f9d97f4b232ec9
+        checksum/config: 8cca40953fb2502a9586ccf95374847dfc468c5744683e94deea4ee8b7d7af2c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-agent.yaml
@@ -200,8 +200,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9d8f4b61b995b6ecd7c44fb046e9d1c1e7c7ee7ce37e48925955993859138caf
+        checksum/config: 8cfe597def85b37c93b602c0c2e9d69c3484a96a0feffc99b4b470d37f8d9592
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/histograms-disabled/rendered_manifests/configmap-agent.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-agent.yaml
@@ -322,8 +322,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/histograms-disabled/rendered_manifests/daemonset.yaml
+++ b/examples/histograms-disabled/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 0983fb8139a1893e5bfdaf1457f75edfcea7f0cf2f4678fe95ffb4eda3fbf6cd
+        checksum/config: b88f8a6eeb6ea0aa55d2bf9c62bbc8d697e54793a589824f4f2c722c426d78f9
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-agent.yaml
@@ -325,8 +325,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/daemonset.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: a1e5029c279a217ebfc42317d2022285be6af9704af5522d4e7bc11e07202b3c
+        checksum/config: 0338b50294e5f01f929322312f2a707aef4d2e47da00ceb1ce7ebcd93f6ed656
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-agent.yaml
@@ -220,8 +220,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/host-journalctl-logs/rendered_manifests/daemonset.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 7818a997cc2822f189aff5a32ff029c92da3e059d50d2b345531b47bf5e4508e
+        checksum/config: 605d863eeaadf2ffb7ef56e0ade21f7905c7ac3a0202bacc3e1de27e62c9b560
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-agent.yaml
@@ -269,8 +269,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: fb0ca18115ec79302c87faed6bf89b63213cfebdf5ee66c2001ed85dc2b16730
+        checksum/config: c83dab740c758c1e3ce11e9f51d4736af0fc5408f8793da12d9fab356c5aaf3c
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-agent.yaml
@@ -273,8 +273,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/multi-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/multi-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c36a99105c7215b1c983b58bd277008f62744d0994e6a47d73bf97f621d90b83
+        checksum/config: 317aa57b074119482b26c0f28ea2534aef4bc9e2bf826d5a21e648334da61b34
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/multiline-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-agent.yaml
@@ -223,8 +223,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/multiline-logs/rendered_manifests/daemonset.yaml
+++ b/examples/multiline-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 845b1c73c1bb200aebf6a745803d46b654b99e2df503834073b0a5d2d5711aec
+        checksum/config: 0bc628ac380da15dba3a41ffbd3cf648c6c5bb69f51af5262c97e6ce2918ae2a
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-agent.yaml
@@ -213,8 +213,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: d05cb39fd903d9567f28ed9eb98b3525a82ce393b48c5290929c8d3f1cc929ed
+        checksum/config: 951826126d869f18021aa07a12d576579b0b842028399c71feb8f8bbb42e7efe
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-agent.yaml
@@ -205,8 +205,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 25906b250b7052674a09e06dd79ddb23ff2f7e33f5cf799374d5e52a6609cd44
+        checksum/config: 4747c21a8406a6b2fd3b07336138ab03e5b7fa5d65f0e0602aaffae380ad1cb7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-metrics/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-agent.yaml
@@ -188,8 +188,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/only-metrics/rendered_manifests/daemonset.yaml
+++ b/examples/only-metrics/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9662987f956e540d9aa2a0c37a77364b59a2297d0ac8b8a544ab45233bed7804
+        checksum/config: 3db8ba6ddd1126521db7e29940dcffd25ee770591e2d70684da914bb4f16488e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/only-traces/rendered_manifests/configmap-agent.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-agent.yaml
@@ -166,8 +166,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/only-traces/rendered_manifests/daemonset.yaml
+++ b/examples/only-traces/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: c6d72a40e425661ebd393729983a01695db04b2db802d5c48b641fcd3624ab4e
+        checksum/config: 38874f73e6085ed04cd454a8dce386ae84ee76c11fd51b03fa4c022bc619a6e4
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/otlp-token-passthrough/otlp-token-passthrough-values.yaml
+++ b/examples/otlp-token-passthrough/otlp-token-passthrough-values.yaml
@@ -10,7 +10,6 @@ gateway:
     limits:
       cpu: 2
       memory: 4Gi
-  tokenPassthrough: true
 
 agent:
   tokenPassthrough: true

--- a/examples/otlp-token-passthrough/otlp-token-passthrough-values.yaml
+++ b/examples/otlp-token-passthrough/otlp-token-passthrough-values.yaml
@@ -10,13 +10,7 @@ gateway:
     limits:
       cpu: 2
       memory: 4Gi
+  tokenPassthrough: true
 
 agent:
-  config:
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            include_metadata: true
-          http:
-            include_metadata: true
+  tokenPassthrough: true

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-agent.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-agent.yaml
@@ -60,8 +60,6 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: http://default-splunk-otel-collector:4320
-          headers:
-            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       k8s_observer:

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-gateway.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-gateway.yaml
@@ -49,8 +49,6 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
-          headers:
-            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/otlp-token-passthrough/rendered_manifests/daemonset.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 335b5a0e15eb8f008ffb994e33d7e965d36c30e6109992596c3cf0a46d8b5958
+        checksum/config: 6fb22153ee318c503f270c5649fca022c9c7b0d131b5784b83fe9ddb641a3607
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/otlp-token-passthrough/rendered_manifests/gateway-workload.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 08ebd0910147cc7c7e4d3a2d34d7956efe924715e77f92a043d739b772de79fa
+        checksum/config: 2576766d6ab44940bd7b6c938b532b2f23378920a02a70f348f93f24d1ab0173
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-agent.yaml
@@ -203,8 +203,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: e20d8bed396b13ffc499caa586070ff4e6408ac14ca6bee8b0300da6690d59c6
+        checksum/config: b818de2354b5fab61b619028da45bd53ec6edab8c8530b49c6398770d4a590a7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secret-validation/rendered_manifests/configmap-agent.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-agent.yaml
@@ -185,8 +185,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/secret-validation/rendered_manifests/daemonset.yaml
+++ b/examples/secret-validation/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 43ab4893c33ca9d1c6defda67e9dfd13dea11e2e11b63f150d8075e9747f05ad
+        checksum/config: 31622ff81e2347499efb3225ff0d8e3cc115d961dc68c218606b74e0961caff8
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secureapp-agent-mode/rendered_manifests/configmap-agent.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/configmap-agent.yaml
@@ -219,8 +219,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/secureapp-agent-mode/rendered_manifests/daemonset.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: df128edcb7a9db2097d01a2feacf2e25984f8548410bb6062e928fa51c313e81
+        checksum/config: 2dc96dcdb7b6432f79fb135460694dadf7acf6e1be086e21ec94935dbbbc790b
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/secureapp-gateway-mode/rendered_manifests/configmap-gateway.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/configmap-gateway.yaml
@@ -67,8 +67,6 @@ data:
       http_forwarder/opamp_splunk_o11y:
         egress:
           endpoint: https://ingest.CHANGEME.observability.splunkcloud.com
-          headers:
-            X-SF-Token: ${SPLUNK_OBSERVABILITY_ACCESS_TOKEN}
         ingress:
           endpoint: 0.0.0.0:4320
       opamp/splunk_o11y:

--- a/examples/secureapp-gateway-mode/rendered_manifests/gateway-workload.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/gateway-workload.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-collector
         release: default
       annotations:
-        checksum/config: 89c86abfad3f11e625cf131ce1f4575779fd57da0ceedd24f9de5a8691e6cb7b
+        checksum/config: dd2771c25853863be552efea7b7ec8f35836aab8990bbcf16258075a8f0c9b87
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-connect-for-otlp/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/configmap-agent.yaml
@@ -181,8 +181,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/splunk-connect-for-otlp/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 920ccf5d8716d7beb42e9e9ec638f73c7c66fc8ef828ff01dfe1d21ca66543b0
+        checksum/config: 6aaa9cca7ca73ae6d759731314197bce03032bac8d4659373dfb4363fdbf555e
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-agent.yaml
@@ -188,8 +188,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 45f0155ca0ad13ebb81e8828e6cc6ecbdb05b1e16578dc0e41950a85b7363da7
+        checksum/config: 29ed45fb11f8be53d2fd1f5f4cb8fb483b6b5efa23586091c77ab3ba51ce26b5
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-agent.yaml
@@ -280,8 +280,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: da0e9b87174331ba0e41242b7b97c42ef7600dd61bb7a8851441dbd54aa78c80
+        checksum/config: 80ec17a1e046d3f777f16d2419f4ab9a4261080f19679582dcaccb7a6dce8fb3
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/target-allocator/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 484af829fb8cb07cf4fd98e4e614044ca00ee7fe989d371ad9af29c5c6656223
+        checksum/config: 3b0b9fcf58c79477baced80bc3f8716f52f985b77995ed7b5895db85a64f4a88
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/use-proxy/rendered_manifests/configmap-agent.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/use-proxy/rendered_manifests/daemonset.yaml
+++ b/examples/use-proxy/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 39b8951307555974bab70c682256b72b21f38f914caa6bdc52750d96ab84bd5d
+        checksum/config: bf83115d3e98f1dc29f5a30f516ced4a3da4c009057693c81bf667cf683eacec
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-agent.yaml
@@ -199,8 +199,10 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            include_metadata: false
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: false
       prometheus/agent:
         config:
           scrape_configs:

--- a/examples/with-target-allocator/rendered_manifests/daemonset.yaml
+++ b/examples/with-target-allocator/rendered_manifests/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         component: otel-collector-agent
         release: default
       annotations:
-        checksum/config: 9e11b1f2dd34aa68bbc364181fb01869f4b47b59e88e660e90e24360ab592534
+        checksum/config: ceb49f56a1b19bf0ae2bf157e17fcfba0c55c99d2f8b6c6a652ce4fef1fcbda7
         kubectl.kubernetes.io/default-container: otel-collector
     spec:
       hostNetwork: true

--- a/functional_tests/token_passthrough/testdata/agent_only_values.tmpl
+++ b/functional_tests/token_passthrough/testdata/agent_only_values.tmpl
@@ -7,14 +7,8 @@ splunkObservability:
 clusterName: test-cluster
 
 agent:
+  tokenPassthrough: true
   config:
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            include_metadata: true
-          http:
-            include_metadata: true
     exporters:
       otlp_http:
         traces_endpoint: {{ .OTLPSink }}/v2/trace/otlp

--- a/functional_tests/token_passthrough/testdata/agent_with_gateway_values.tmpl
+++ b/functional_tests/token_passthrough/testdata/agent_with_gateway_values.tmpl
@@ -7,14 +7,7 @@ splunkObservability:
 clusterName: test-cluster
 
 agent:
-  config:
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            include_metadata: true
-          http:
-            include_metadata: true
+  tokenPassthrough: true
 
 gateway:
   enabled: true
@@ -24,13 +17,6 @@ gateway:
       cpu: 200m
       memory: 256Mi
   config:
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            include_metadata: true
-          http:
-            include_metadata: true
     exporters:
       otlp_http:
         traces_endpoint: {{ .OTLPSink }}/v2/trace/otlp

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -672,7 +672,6 @@ Common config for Splunk O11Y Ingest HTTP Forwarder extension
 {{- define "splunk-otel-collector.o11yIngestHttpForwarderExtension" -}}
 {{- if eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true" }}
 {{- $forceDirectEndpoint := .forceDirectEndpoint | default false }}
-{{- $tokenPassthrough := .tokenPassthrough | default false }}
 http_forwarder/opamp_splunk_o11y:
   ingress:
       endpoint: "0.0.0.0:4320"
@@ -682,7 +681,7 @@ http_forwarder/opamp_splunk_o11y:
       {{- else }}
       endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
       {{- end }}
-      {{- if not $tokenPassthrough }}
+      {{- if not .tokenPassthrough }}
       headers:
         X-SF-Token: "{{ include "splunk-otel-collector.splunkObservabilityAccessToken" . }}"
       {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_common.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_common.tpl
@@ -672,6 +672,7 @@ Common config for Splunk O11Y Ingest HTTP Forwarder extension
 {{- define "splunk-otel-collector.o11yIngestHttpForwarderExtension" -}}
 {{- if eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true" }}
 {{- $forceDirectEndpoint := .forceDirectEndpoint | default false }}
+{{- $tokenPassthrough := .tokenPassthrough | default false }}
 http_forwarder/opamp_splunk_o11y:
   ingress:
       endpoint: "0.0.0.0:4320"
@@ -681,7 +682,9 @@ http_forwarder/opamp_splunk_o11y:
       {{- else }}
       endpoint: {{ include "splunk-otel-collector.o11yIngestUrl" . }}
       {{- end }}
+      {{- if not $tokenPassthrough }}
       headers:
         X-SF-Token: "{{ include "splunk-otel-collector.splunkObservabilityAccessToken" . }}"
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -5,7 +5,7 @@ The values can be overridden in .Values.agent.config
 {{- define "splunk-otel-collector.agentConfig" -}}
 extensions:
   {{- include "splunk-otel-collector.opampExtension" . | nindent 2 }}
-  {{- include "splunk-otel-collector.o11yIngestHttpForwarderExtension" . | nindent 2 }}
+  {{- include "splunk-otel-collector.o11yIngestHttpForwarderExtension" (merge (dict "tokenPassthrough" .Values.agent.tokenPassthrough) .) | nindent 2 }}
   {{- if eq (include "splunk-otel-collector.logsEnabled" .) "true" }}
   file_storage:
     directory: {{ .Values.logsCollection.checkpointPath }}
@@ -49,9 +49,15 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+        {{- if .Values.agent.tokenPassthrough }}
+        include_metadata: true
+        {{- end }}
       http:
         # https://github.com/open-telemetry/opentelemetry-collector/blob/9d3a8a4608a7dbd9f787867226a78356ace9b5e4/receiver/otlpreceiver/otlp.go#L140-L152
         endpoint: 0.0.0.0:4318
+        {{- if .Values.agent.tokenPassthrough }}
+        include_metadata: true
+        {{- end }}
 
   {{- if eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true" }}
   # Placeholder receiver needed for discovery mode

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -49,15 +49,11 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
-        {{- if .Values.agent.tokenPassthrough }}
-        include_metadata: true
-        {{- end }}
+        include_metadata: {{ .Values.agent.tokenPassthrough }}
       http:
         # https://github.com/open-telemetry/opentelemetry-collector/blob/9d3a8a4608a7dbd9f787867226a78356ace9b5e4/receiver/otlpreceiver/otlp.go#L140-L152
         endpoint: 0.0.0.0:4318
-        {{- if .Values.agent.tokenPassthrough }}
-        include_metadata: true
-        {{- end }}
+        include_metadata: {{ .Values.agent.tokenPassthrough }}
 
   {{- if eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true" }}
   # Placeholder receiver needed for discovery mode

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -5,7 +5,7 @@ The values can be overridden in .Values.gateway.config
 {{- define "splunk-otel-collector.gatewayConfig" -}}
 extensions:
   {{- include "splunk-otel-collector.opampExtension" (merge (dict "forceDirectEndpoint" true) .) | nindent 2 }}
-  {{- include "splunk-otel-collector.o11yIngestHttpForwarderExtension" (merge (dict "forceDirectEndpoint" true) .) | nindent 2 }}
+  {{- include "splunk-otel-collector.o11yIngestHttpForwarderExtension" (merge (dict "forceDirectEndpoint" true "tokenPassthrough" .Values.gateway.tokenPassthrough) .) | nindent 2 }}
   health_check:
     endpoint: 0.0.0.0:13133
   {{- if (eq (include "splunk-otel-collector.splunkO11yEnabled" .) "true") }}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -33,11 +33,15 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+        {{- if .Values.gateway.tokenPassthrough }}
         include_metadata: true
+        {{- end }}
       http:
         # https://github.com/open-telemetry/opentelemetry-collector/blob/9d3a8a4608a7dbd9f787867226a78356ace9b5e4/receiver/otlpreceiver/otlp.go#L140-L152
         endpoint: 0.0.0.0:4318
+        {{- if .Values.gateway.tokenPassthrough }}
         include_metadata: true
+        {{- end }}
 
   # Prometheus receiver scraping metrics from the pod itself
   {{- include "splunk-otel-collector.prometheusInternalMetrics" (dict "receiver" "collector") | nindent 2}}

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-collector.tpl
@@ -33,15 +33,11 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
-        {{- if .Values.gateway.tokenPassthrough }}
-        include_metadata: true
-        {{- end }}
+        include_metadata: {{ .Values.gateway.tokenPassthrough }}
       http:
         # https://github.com/open-telemetry/opentelemetry-collector/blob/9d3a8a4608a7dbd9f787867226a78356ace9b5e4/receiver/otlpreceiver/otlp.go#L140-L152
         endpoint: 0.0.0.0:4318
-        {{- if .Values.gateway.tokenPassthrough }}
-        include_metadata: true
-        {{- end }}
+        include_metadata: {{ .Values.gateway.tokenPassthrough }}
 
   # Prometheus receiver scraping metrics from the pod itself
   {{- include "splunk-otel-collector.prometheusInternalMetrics" (dict "receiver" "collector") | nindent 2}}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -387,6 +387,10 @@
         "enabled": {
           "type": "boolean"
         },
+        "tokenPassthrough": {
+          "description": "Enable passthrough of the client's authentication token for Splunk Observability and Splunk Platform backends and OpAMP.",
+          "type": "boolean"
+        },
         "controlPlaneEnabled": {
           "type": "boolean",
           "deprecated": true
@@ -1235,6 +1239,10 @@
       "additionalProperties": false,
       "properties": {
         "enabled": {
+          "type": "boolean"
+        },
+        "tokenPassthrough": {
+          "description": "Enable passthrough of the client's authentication token for Splunk Observability and Splunk Platform backends and OpAMP.",
           "type": "boolean"
         },
         "mode": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -342,6 +342,16 @@ extraAttributes:
 agent:
   enabled: true
 
+  # Enables passthrough of the client's authentication token received by the agent's OTLP
+  # receivers and the OpAMP HTTP forwarder ingress. When true, the incoming `X-SF-Token`
+  # metadata is propagated to Splunk Observability and to the gateway (if enabled) via the
+  # `headers_setter` extension, and the OpAMP forwarder egress does not override the token
+  # set by the caller. When false (default), the agent authenticates upstream using the
+  # `splunkObservability.accessToken` and `splunkPlatform.token` values configured on this
+  # chart. Note: passthrough for Splunk Platform is only supported over OTLP; the HEC
+  # exporters continue to use the configured token.
+  tokenPassthrough: false
+
   # Metric collection from k8s control plane components.
   # For control plane configuration details see: docs/advanced-configuration.md#control-plane-metrics
   controlPlaneMetrics:
@@ -929,6 +939,15 @@ gateway:
   # Defines if the gateway collector workload is enabled
   # Recommended for large k8s clusters, disabled by default.
   enabled: false
+
+  # Enables passthrough of the client's authentication token received by the gateway's OTLP
+  # receivers and the OpAMP HTTP forwarder ingress. When true, the incoming `X-SF-Token`
+  # metadata is propagated to Splunk Observability via the `headers_setter` extension, and the
+  # OpAMP forwarder egress does not override the token set by the caller. When false (default),
+  # the gateway authenticates upstream using the `splunkObservability.accessToken` and
+  # `splunkPlatform.token` values configured on this chart. Note: passthrough for Splunk Platform
+  # is only supported over OTLP; the HEC exporters continue to use the configured token.
+  tokenPassthrough: false
 
   # Gateway workload mode. Supported values: deployment, statefulset.
   mode: deployment

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -342,14 +342,8 @@ extraAttributes:
 agent:
   enabled: true
 
-  # Enables passthrough of the client's authentication token received by the agent's OTLP
-  # receivers and the OpAMP HTTP forwarder ingress. When true, the incoming `X-SF-Token`
-  # metadata is propagated to Splunk Observability and to the gateway (if enabled) via the
-  # `headers_setter` extension, and the OpAMP forwarder egress does not override the token
-  # set by the caller. When false (default), the agent authenticates upstream using the
-  # `splunkObservability.accessToken` and `splunkPlatform.token` values configured on this
-  # chart. Note: passthrough for Splunk Platform is only supported over OTLP; the HEC
-  # exporters continue to use the configured token.
+  # Forward the caller's `X-SF-Token` to Splunk Observability (via OTLP) and to the OpAMP
+  # HTTP forwarder egress. When false, `splunkObservability.accessToken` is used instead.
   tokenPassthrough: false
 
   # Metric collection from k8s control plane components.
@@ -940,14 +934,9 @@ gateway:
   # Recommended for large k8s clusters, disabled by default.
   enabled: false
 
-  # Enables passthrough of the client's authentication token received by the gateway's OTLP
-  # receivers and the OpAMP HTTP forwarder ingress. When true, the incoming `X-SF-Token`
-  # metadata is propagated to Splunk Observability via the `headers_setter` extension, and the
-  # OpAMP forwarder egress does not override the token set by the caller. When false (default),
-  # the gateway authenticates upstream using the `splunkObservability.accessToken` and
-  # `splunkPlatform.token` values configured on this chart. Note: passthrough for Splunk Platform
-  # is only supported over OTLP; the HEC exporters continue to use the configured token.
-  tokenPassthrough: false
+  # Forward the caller's `X-SF-Token` to Splunk Observability (via OTLP) and to the OpAMP
+  # HTTP forwarder egress. When false, `splunkObservability.accessToken` is used instead.
+  tokenPassthrough: true
 
   # Gateway workload mode. Supported values: deployment, statefulset.
   mode: deployment


### PR DESCRIPTION
Add `agent.tokenPassthrough` and `gateway.tokenPassthrough` boolean values (default `false`) that enable passthrough of the client's authentication token to Splunk Observability and the OpAMP HTTP forwarder egress. Current behavior is preserved by default — when both flags are `false`, rendered configs are unchanged.

When enabled:
- The agent's OTLP receiver adds `include_metadata: true` on both grpc and http protocols so the incoming `X-SF-Token` flows through the `headers_setter` extension. (The gateway's OTLP receiver already has `include_metadata: true` unconditionally.)
- The OpAMP HTTP forwarder egress omits the static `X-SF-Token` header, letting the caller-supplied token flow upstream (gateway or Splunk Observability ingest).

Passthrough for Splunk Platform is supported over OTLP only; the Splunk Platform HEC exporters continue to use the token configured on the chart. This is called out in the values.yaml comments and in the docs update.

The existing `examples/otlp-token-passthrough` example was updated to use the new flags in place of the manual `include_metadata: true` overrides, and the rendered manifests were regenerated.