### PR TITLE
Remove section on issues reporting from `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,14 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project! Whether it's a bug
-report, new feature, question, or additional documentation, we greatly value
+Thank you for your interest in contributing to our project! Whether it's a new feature, question, or additional documentation, we greatly value
 feedback and contributions from our community. Read through this document
-before submitting any issues or pull requests to ensure we have all the
-necessary information to effectively respond to your bug report or
+before submitting any pull requests to ensure we have all the
+necessary information to effectively respond to your feedback or
 contribution.
 
 In addition to this document, please review our [Code of
 Conduct](CODE_OF_CONDUCT.md). For any code of conduct questions or comments
 please email oss@splunk.com.
-
-## Reporting Bugs/Feature Requests
-
-We welcome you to use the GitHub issue tracker to report bugs or suggest
-features. When filing an issue, please check existing open, or recently closed,
-issues to make sure somebody else hasn't already reported the issue. Please try
-to include as much information as you can. Details like these are incredibly
-useful:
-
-- A reproducible test case or series of steps
-- The version of our code being used
-- Any modifications you've made relevant to the bug
-- Anything unusual about your environment or deployment
-- Any known workarounds
-
-When filing an issue, please do *NOT* include:
-
-- Internal identifiers such as JIRA tickets
-- Any sensitive information related to your environment, users, etc.
 
 ## Documentation
 
@@ -137,13 +117,6 @@ Include a changelog entry for pull requests affecting:
 **Manual Option:**
 
 - Copy `./.chloggen/TEMPLATE.yaml` or create a unique `.yaml` file.
-
-## Finding contributions to work on
-
-Looking at the existing issues is a great way to find something to contribute
-on. As our projects, by default, use the default GitHub issue labels
-(enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at
-any 'help wanted' issues is a great place to start.
 
 ## Building
 


### PR DESCRIPTION
**Description:** Remove the section on issues reporting as well as other references pertaining to the use of GitHub Issues, as the "Issues" tab is disabled in this repository, so the information doesn't apply.

**Link to Splunk idea:** N/A

**Testing:** I have tested that, indeed, the "Issues" tab is not there.

**Documentation:** The PR *is* the documentation.
