### PR TITLE
chore: fixed aks windows functional tests

### DIFF
--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -65,9 +65,9 @@ const (
 	splunkOtelCollectorTAResourceName      = "splunk-otel-collector-ta"
 	taResourceName                         = "targetallocator-ta"
 	linuxPodMetricsPath                    = "/splunk-metrics/metrics.json"
-	winPodMetricsPath                      = "C:\\metrics.json"
+	winPodMetricsPath                      = "C:\\Users\\ContainerUser\\AppData\\Local\\Temp\\metrics.json"
 	linuxPodK8sClusterMetricsPath          = "/splunk-metrics/k8s_cluster_metrics.json"
-	winPodK8sClusterMetricsPath            = "C:\\k8s_cluster_metrics.json"
+	winPodK8sClusterMetricsPath            = "C:\\Users\\ContainerUser\\AppData\\Local\\Temp\\k8s_cluster_metrics.json"
 	aksWindowsValidationResourceName       = "aks-win-validation-secret"
 )
 

--- a/functional_tests/functional/testdata/values/aks_test_win_values.yaml.tmpl
+++ b/functional_tests/functional/testdata/values/aks_test_win_values.yaml.tmpl
@@ -30,7 +30,7 @@ agent:
         tls:
           insecure: true
       file:
-        path: C:\metrics.json
+        path: 'C:\Users\ContainerUser\AppData\Local\Temp\metrics.json'
     service:
       pipelines:
         traces:
@@ -50,9 +50,9 @@ clusterReceiver:
         tls:
           insecure: true
       file:
-        path: C:\metrics.json
+        path: 'C:\Users\ContainerUser\AppData\Local\Temp\metrics.json'
       file/k8s_cluster:
-        path: C:\k8s_cluster_metrics.json
+        path: 'C:\Users\ContainerUser\AppData\Local\Temp\k8s_cluster_metrics.json'
     service:
       pipelines:
         metrics/collector:


### PR DESCRIPTION
something did change in 0.157.0: the Splunk Collector Windows container now runs as `ContainerUser` by default, per the [v0.157.0 release notes](https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.157.0). The AKS Windows functional values were writing file exporter output to `C:\metrics.json` and `C:\k8s_cluster_metrics.json`, which works as admin but can fail as `ContainerUser`.