### PR TITLE
[chore][discovery test] Recheck redis metrics until timeout

### DIFF
--- a/functional_tests/discovery/discovery_test.go
+++ b/functional_tests/discovery/discovery_test.go
@@ -146,9 +146,12 @@ func assertRedisMetrics(t *testing.T, sink *consumertest.MetricsSink) {
 		foundMetrics := make(map[string]bool)
 		for _, m := range sink.AllMetrics() {
 			for i := 0; i < m.ResourceMetrics().Len(); i++ {
-				sm := m.ResourceMetrics().At(i).ScopeMetrics().At(0)
-				for j := 0; j < sm.Metrics().Len(); j++ {
-					foundMetrics[sm.Metrics().At(j).Name()] = true
+				rm := m.ResourceMetrics().At(i)
+				for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+					sm := m.ResourceMetrics().At(i).ScopeMetrics().At(j)
+					for k := 0; k < sm.Metrics().Len(); k++ {
+						foundMetrics[sm.Metrics().At(k).Name()] = true
+					}
 				}
 			}
 		}

--- a/functional_tests/discovery/discovery_test.go
+++ b/functional_tests/discovery/discovery_test.go
@@ -114,8 +114,6 @@ func assertAttr(t *testing.T, attrs pcommon.Map, name string, val any) {
 }
 
 func assertRedisMetrics(t *testing.T, sink *consumertest.MetricsSink) {
-	internal.WaitForMetrics(t, 5, sink)
-
 	expectedRedisMetrics := []string{
 		"redis.clients.blocked",
 		"redis.clients.connected",
@@ -159,7 +157,6 @@ func assertRedisMetrics(t *testing.T, sink *consumertest.MetricsSink) {
 			assert.Contains(tt, foundMetrics, rm)
 		}
 	}, 5*time.Minute, 3*time.Second, "Missing expected redis metrics")
-
 }
 
 func installCollectorChart(t *testing.T, kubeConfig, valuesTmpl string) {

--- a/functional_tests/discovery/discovery_test.go
+++ b/functional_tests/discovery/discovery_test.go
@@ -148,7 +148,7 @@ func assertRedisMetrics(t *testing.T, sink *consumertest.MetricsSink) {
 			for i := 0; i < m.ResourceMetrics().Len(); i++ {
 				rm := m.ResourceMetrics().At(i)
 				for j := 0; j < rm.ScopeMetrics().Len(); j++ {
-					sm := m.ResourceMetrics().At(i).ScopeMetrics().At(j)
+					sm := rm.ScopeMetrics().At(j)
 					for k := 0; k < sm.Metrics().Len(); k++ {
 						foundMetrics[sm.Metrics().At(k).Name()] = true
 					}

--- a/functional_tests/discovery/discovery_test.go
+++ b/functional_tests/discovery/discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -114,15 +115,7 @@ func assertAttr(t *testing.T, attrs pcommon.Map, name string, val any) {
 
 func assertRedisMetrics(t *testing.T, sink *consumertest.MetricsSink) {
 	internal.WaitForMetrics(t, 5, sink)
-	foundMetrics := make(map[string]bool)
-	for _, m := range sink.AllMetrics() {
-		for i := 0; i < m.ResourceMetrics().Len(); i++ {
-			sm := m.ResourceMetrics().At(i).ScopeMetrics().At(0)
-			for j := 0; j < sm.Metrics().Len(); j++ {
-				foundMetrics[sm.Metrics().At(j).Name()] = true
-			}
-		}
-	}
+
 	expectedRedisMetrics := []string{
 		"redis.clients.blocked",
 		"redis.clients.connected",
@@ -151,9 +144,22 @@ func assertRedisMetrics(t *testing.T, sink *consumertest.MetricsSink) {
 		"redis.slaves.connected",
 		"redis.uptime",
 	}
-	for _, rm := range expectedRedisMetrics {
-		assert.Contains(t, foundMetrics, rm)
-	}
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		foundMetrics := make(map[string]bool)
+		for _, m := range sink.AllMetrics() {
+			for i := 0; i < m.ResourceMetrics().Len(); i++ {
+				sm := m.ResourceMetrics().At(i).ScopeMetrics().At(0)
+				for j := 0; j < sm.Metrics().Len(); j++ {
+					foundMetrics[sm.Metrics().At(j).Name()] = true
+				}
+			}
+		}
+
+		for _, rm := range expectedRedisMetrics {
+			assert.Contains(tt, foundMetrics, rm)
+		}
+	}, 5*time.Minute, 3*time.Second, "Missing expected redis metrics")
+
 }
 
 func installCollectorChart(t *testing.T, kubeConfig, valuesTmpl string) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Test has been flaky ([recent example](https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/30961181905/job/92165261599?pr=2513)), attempt to stabilize by putting metric check in a `require.EventuallyWithT` block, instead of simply checking once after any 5 metrics have been received.