### PR TITLE
[chore][histogram test] Re-check expected metric contents to address flaky failures

### DIFF
--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -148,6 +148,7 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 	require.NoError(t, err, "Failed to read expected counts from %s", assertionFile)
 
 	require.Eventually(t, func() bool {
+		firstFailure := true
 		sinkMetrics := sink.AllMetrics()
 		for i := len(sinkMetrics) - 1; i >= 0; i-- {
 			m := sinkMetrics[i]
@@ -166,7 +167,10 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 			if assertErr == nil {
 				return true
 			}
-			t.Logf("metrics assertion failed: %v", assertErr)
+			if firstFailure {
+				t.Logf("metrics assertion failed: %v", assertErr)
+				firstFailure = false
+			}
 		}
 		return false
 	}, timeout, interval, "Failed to find expected metrics in allotted time")

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetricassert"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -148,33 +147,30 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 	wantResources, wantMetrics, err := assertionExpectedCounts(assertionFile)
 	require.NoError(t, err, "Failed to read expected counts from %s", assertionFile)
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		selected := selectMetricSetByCounts(targetMetric, sink, wantResources, wantMetrics)
-		assert.NotNil(c, selected, "No metrics batch found containing target metric: %s", targetMetric)
-
-		actual := prepareMetricsAssertion(*selected, cfg)
-		maybeUpdateExpectedMetricsAssertion(t, assertionFile, actual, opts...)
-		assertErr := pmetricassert.AssertMetrics(assertionFile, actual)
-		if assertErr != nil {
-			assert.NoError(c, assertErr, "Metric assertion failed for %s. Error: %v", assertionFile, assertErr)
+	require.Eventually(t, func() bool {
+		sinkMetrics := sink.AllMetrics()
+		for i := len(sinkMetrics) - 1; i >= 0; i-- {
+			m := sinkMetrics[i]
+			if !containsMetric(m, targetMetric) {
+				continue
+			}
+			if m.ResourceMetrics().Len() != wantResources {
+				continue
+			}
+			if m.MetricCount() != wantMetrics {
+				continue
+			}
+			actual := prepareMetricsAssertion(m, cfg)
+			maybeUpdateExpectedMetricsAssertion(t, assertionFile, actual, opts...)
+			assertErr := pmetricassert.AssertMetrics(assertionFile, actual)
+			if assertErr != nil {
+				return true
+			}
 		}
-	}, 5*time.Minute, 1*time.Second, "Failed to find expected metrics in allotted time")
+		return false
+	}, timeout, interval, "Failed to find expected metrics in allotted time")
 
 	t.Logf("Metric assertion passed for %d metrics (%s)", wantMetrics, assertionFile)
-}
-
-func selectMetricSetByCounts(targetMetric string, metricSink *consumertest.MetricsSink, wantResources, wantMetrics int) *pmetric.Metrics {
-	metrics := metricSink.AllMetrics()
-	for h := len(metrics) - 1; h >= 0; h-- {
-		m := metrics[h]
-		if !containsMetric(m, targetMetric) {
-			continue
-		}
-		if m.ResourceMetrics().Len() == wantResources && m.MetricCount() == wantMetrics {
-			return &metrics[h]
-		}
-	}
-	return nil
 }
 
 func assertionExpectedCounts(file string) (int, int, error) {

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -163,7 +163,7 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 			assert.NoError(c, assertErr, "Metric assertion failed for %s. Error: %v", assertionFile, assertErr)
 		}
 		t.Logf("Metric assertion passed for %d metrics (%s)", selected.MetricCount(), assertionFile)
-	}, 5*time.Minute, 1*time.Second, "Failed to find expected metrics in alloted time")
+	}, 5*time.Minute, 1*time.Second, "Failed to find expected metrics in allotted time")
 }
 
 func selectMetricSetByCountsWithTimeout(t *testing.T, targetMetric string, metricSink *consumertest.MetricsSink, wantResources, wantMetrics int, timeout, interval time.Duration) (*pmetric.Metrics, bool) {

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -163,7 +163,7 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 			actual := prepareMetricsAssertion(m, cfg)
 			maybeUpdateExpectedMetricsAssertion(t, assertionFile, actual, opts...)
 			assertErr := pmetricassert.AssertMetrics(assertionFile, actual)
-			if assertErr != nil {
+			if assertErr == nil {
 				return true
 			}
 		}

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -149,39 +149,18 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 	require.NoError(t, err, "Failed to read expected counts from %s", assertionFile)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		selected, exactMatch := selectMetricSetByCountsWithTimeout(t, targetMetric, sink, wantResources, wantMetrics, timeout, interval)
+		selected := selectMetricSetByCounts(targetMetric, sink, wantResources, wantMetrics)
 		assert.NotNil(c, selected, "No metrics batch found containing target metric: %s", targetMetric)
 
 		actual := prepareMetricsAssertion(*selected, cfg)
 		maybeUpdateExpectedMetricsAssertion(t, assertionFile, actual, opts...)
 		assertErr := pmetricassert.AssertMetrics(assertionFile, actual)
 		if assertErr != nil {
-			if !exactMatch {
-				t.Logf("No exact-count match (want %d resources, %d metrics); selected payload has %d metrics",
-					wantResources, wantMetrics, selected.MetricCount())
-			}
 			assert.NoError(c, assertErr, "Metric assertion failed for %s. Error: %v", assertionFile, assertErr)
 		}
-		t.Logf("Metric assertion passed for %d metrics (%s)", selected.MetricCount(), assertionFile)
 	}, 5*time.Minute, 1*time.Second, "Failed to find expected metrics in allotted time")
-}
 
-func selectMetricSetByCountsWithTimeout(t *testing.T, targetMetric string, metricSink *consumertest.MetricsSink, wantResources, wantMetrics int, timeout, interval time.Duration) (*pmetric.Metrics, bool) {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if m := selectMetricSetByCounts(targetMetric, metricSink, wantResources, wantMetrics); m != nil {
-			t.Logf("Selected exact-count payload with target metric '%s': %d metrics, %d resources",
-				targetMetric, m.MetricCount(), m.ResourceMetrics().Len())
-			return m, true
-		}
-		time.Sleep(interval)
-	}
-
-	best := richestMetricSet(targetMetric, metricSink)
-	require.NotNilf(t, best, "No payload containing metric %s found within %v", targetMetric, timeout)
-	t.Logf("No exact-count payload (%d resources, %d metrics) for '%s' within %v; using best-effort fallback: %d metrics, %d resources",
-		wantResources, wantMetrics, targetMetric, timeout, best.MetricCount(), best.ResourceMetrics().Len())
-	return best, false
+	t.Logf("Metric assertion passed for %d metrics (%s)", wantMetrics, assertionFile)
 }
 
 func selectMetricSetByCounts(targetMetric string, metricSink *consumertest.MetricsSink, wantResources, wantMetrics int) *pmetric.Metrics {
@@ -196,26 +175,6 @@ func selectMetricSetByCounts(targetMetric string, metricSink *consumertest.Metri
 		}
 	}
 	return nil
-}
-
-func richestMetricSet(targetMetric string, metricSink *consumertest.MetricsSink) *pmetric.Metrics {
-	metrics := metricSink.AllMetrics()
-	bestIndex := -1
-	bestCount := -1
-	for h := len(metrics) - 1; h >= 0; h-- {
-		m := metrics[h]
-		if !containsMetric(m, targetMetric) {
-			continue
-		}
-		if m.MetricCount() > bestCount {
-			bestIndex = h
-			bestCount = m.MetricCount()
-		}
-	}
-	if bestIndex < 0 {
-		return nil
-	}
-	return &metrics[bestIndex]
 }
 
 func assertionExpectedCounts(file string) (int, int, error) {

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -166,6 +166,7 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 			if assertErr == nil {
 				return true
 			}
+			t.Logf("metrics assertion failed: %s", assertErr.Error())
 		}
 		return false
 	}, timeout, interval, "Failed to find expected metrics in allotted time")

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetricassert"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -147,21 +148,22 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 	wantResources, wantMetrics, err := assertionExpectedCounts(assertionFile)
 	require.NoError(t, err, "Failed to read expected counts from %s", assertionFile)
 
-	selected, exactMatch := selectMetricSetByCountsWithTimeout(t, targetMetric, sink, wantResources, wantMetrics, timeout, interval)
-	require.NotNil(t, selected, "No metrics batch found containing target metric: %s", targetMetric)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		selected, exactMatch := selectMetricSetByCountsWithTimeout(t, targetMetric, sink, wantResources, wantMetrics, timeout, interval)
+		assert.NotNil(c, selected, "No metrics batch found containing target metric: %s", targetMetric)
 
-	actual := prepareMetricsAssertion(*selected, cfg)
-	maybeUpdateExpectedMetricsAssertion(t, assertionFile, actual, opts...)
-	assertErr := pmetricassert.AssertMetrics(assertionFile, actual)
-	if assertErr != nil {
-		if !exactMatch {
-			t.Logf("No exact-count match (want %d resources, %d metrics); selected payload has %d metrics",
-				wantResources, wantMetrics, selected.MetricCount())
+		actual := prepareMetricsAssertion(*selected, cfg)
+		maybeUpdateExpectedMetricsAssertion(t, assertionFile, actual, opts...)
+		assertErr := pmetricassert.AssertMetrics(assertionFile, actual)
+		if assertErr != nil {
+			if !exactMatch {
+				t.Logf("No exact-count match (want %d resources, %d metrics); selected payload has %d metrics",
+					wantResources, wantMetrics, selected.MetricCount())
+			}
+			assert.NoError(c, assertErr, "Metric assertion failed for %s. Error: %v", assertionFile, assertErr)
 		}
-		require.NoError(t, assertErr, "Metric assertion failed for %s. Error: %v", assertionFile, assertErr)
-	}
-
-	t.Logf("Metric assertion passed for %d metrics (%s)", selected.MetricCount(), assertionFile)
+		t.Logf("Metric assertion passed for %d metrics (%s)", selected.MetricCount(), assertionFile)
+	}, 5*time.Minute, 1*time.Second, "Failed to find expected metrics in alloted time")
 }
 
 func selectMetricSetByCountsWithTimeout(t *testing.T, targetMetric string, metricSink *consumertest.MetricsSink, wantResources, wantMetrics int, timeout, interval time.Duration) (*pmetric.Metrics, bool) {

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -166,7 +166,7 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 			if assertErr == nil {
 				return true
 			}
-			t.Logf("metrics assertion failed: %s", assertErr.Error())
+			t.Logf("metrics assertion failed: %v", assertErr)
 		}
 		return false
 	}, timeout, interval, "Failed to find expected metrics in allotted time")


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Use `require.EventuallyWithT` to retry flaky metric check. The test has passed 3/3 times on this PR.