### PR TITLE
[chore] Upgrade Prometheus receiver versions as part of chart upgrade

### DIFF
--- a/ci_scripts/prepare-release.sh
+++ b/ci_scripts/prepare-release.sh
@@ -14,6 +14,9 @@ source "$SCRIPT_DIR/base_util.sh"
 update_versions() {
     yq e ".version = \"$LATEST_CHART_VERSION\"" -i "${CHART_FILE_PATH}"
     yq e ".appVersion = \"$LATEST_APP_VERSION\"" -i "${CHART_FILE_PATH}"
+    # Histogram tests check version as part of expected metric tests, upgrade expected version
+    # as a part of the upgrade.
+    find functional_tests/histogram/testdata/expected -type f -exec sed -i.bak "s/version: ${PREVIOUS_CONTRIB_RELEASE}/version: ${LATEST_CONTRIB_RELEASE}/g" {} + && find functional_tests/histogram/testdata/expected -type f -name '*.bak' -delete
 }
 
 notify_workflows_for_need_update() {
@@ -62,6 +65,14 @@ CURRENT_CHART_VERSION_MINOR=$(get_minor_version "v$CURRENT_CHART_VERSION")
 LATEST_APP_VERSION=$(curl -L -qs -H 'Accept: application/vnd.github+json' \
   "https://api.github.com/repos/$OWNER/splunk-otel-collector/releases?per_page=50" | \
   jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | first' | \
+  sed 's/^v//')
+LATEST_CONTRIB_VERSION=$(curl -L -qs -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/open-telemetry/opentelemetry-collector-contrib/releases?per_page=50" | \
+  jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | first' | \
+  sed 's/^v//')
+PREVIOUS_CONTRIB_VERSION=$(curl -L -qs -H 'Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/open-telemetry/opentelemetry-collector-contrib/releases?per_page=50" | \
+  jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | nth(1)' | \
   sed 's/^v//')
 if [[ "$APP_VERSION_OVERRIDDEN" = true ]]; then
     LATEST_APP_VERSION=$APP_VERSION

--- a/ci_scripts/prepare-release.sh
+++ b/ci_scripts/prepare-release.sh
@@ -68,12 +68,10 @@ LATEST_APP_VERSION=$(curl -L -qs -H 'Accept: application/vnd.github+json' \
   sed 's/^v//')
 LATEST_CONTRIB_VERSION=$(curl -L -qs -H 'Accept: application/vnd.github+json' \
   "https://api.github.com/repos/open-telemetry/opentelemetry-collector-contrib/releases?per_page=50" | \
-  jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | first' | \
-  sed 's/^v//')
+  jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | first')
 PREVIOUS_CONTRIB_VERSION=$(curl -L -qs -H 'Accept: application/vnd.github+json' \
   "https://api.github.com/repos/open-telemetry/opentelemetry-collector-contrib/releases?per_page=50" | \
-  jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | nth(1)' | \
-  sed 's/^v//')
+  jq -r '[.[] | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) | .tag_name] | nth(1)')
 if [[ "$APP_VERSION_OVERRIDDEN" = true ]]; then
     LATEST_APP_VERSION=$APP_VERSION
     debug "Using override collector app version value $LATEST_APP_VERSION"

--- a/ci_scripts/prepare-release.sh
+++ b/ci_scripts/prepare-release.sh
@@ -16,7 +16,7 @@ update_versions() {
     yq e ".appVersion = \"$LATEST_APP_VERSION\"" -i "${CHART_FILE_PATH}"
     # Histogram tests check version as part of expected metric tests, upgrade expected version
     # as a part of the upgrade.
-    find functional_tests/histogram/testdata/expected -type f -exec sed -i.bak "s/version: ${PREVIOUS_CONTRIB_RELEASE}/version: ${LATEST_CONTRIB_RELEASE}/g" {} + && find functional_tests/histogram/testdata/expected -type f -name '*.bak' -delete
+    find functional_tests/histogram/testdata/expected -type f -exec sed -i.bak "s/version: ${PREVIOUS_CONTRIB_VERSION}/version: ${LATEST_CONTRIB_VERSION}/g" {} + && find functional_tests/histogram/testdata/expected -type f -name '*.bak' -delete
 }
 
 notify_workflows_for_need_update() {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This is intended to resolve [failures that will happen every upgrade](https://github.com/signalfx/splunk-otel-collector-chart/actions/runs/31213550790/job/92981907376?pr=2543).

The alternative to this is to simply update the tests to match a regex version. This may allow prometheus receiver versions to be different than what's expected, but it may be simpler logic than what I've added here.

**Testing:**
Tested locally and worked as expected