### PR TITLE
[chore][histogram test] Pin API server request datapoints

### DIFF
--- a/functional_tests/histogram/histogram_test.go
+++ b/functional_tests/histogram/histogram_test.go
@@ -151,6 +151,12 @@ func runMetricsTest(t *testing.T, isHistogram bool, metricsSink *consumertest.Me
 	if isHistogram {
 		opts = append(opts, internal.WithHistogramExplicitBounds())
 	}
+	if input.ServiceName == "kubernetes-apiserver" && !isHistogram {
+		opts = append(opts, internal.WithSelectedNumberDatapoint(input.NonHistogramMetricName, map[string]string{
+			"code": "200", "component": "apiserver", "resource": "services",
+			"scope": "resource", "verb": "GET", "version": "v1",
+		}))
+	}
 
 	internal.AssertMetricsSnapshot(t, metricsSink, metricName, expectedFilePath,
 		3*time.Minute, 5*time.Second, opts...)

--- a/functional_tests/histogram/histogram_test.go
+++ b/functional_tests/histogram/histogram_test.go
@@ -152,6 +152,8 @@ func runMetricsTest(t *testing.T, isHistogram bool, metricsSink *consumertest.Me
 		opts = append(opts, internal.WithHistogramExplicitBounds())
 	}
 	if input.ServiceName == "kubernetes-apiserver" && !isHistogram {
+		// TODO: Replace this selector with a datapoints/include assertion in the YAML once
+		// https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48545 lands.
 		opts = append(opts, internal.WithSelectedNumberDatapoint(input.NonHistogramMetricName, map[string]string{
 			"code": "200", "component": "apiserver", "resource": "services",
 			"scope": "resource", "verb": "GET", "version": "v1",

--- a/functional_tests/histogram/testdata/expected/kubernetes-apiserver_metrics_assertion.yaml
+++ b/functional_tests/histogram/testdata/expected/kubernetes-apiserver_metrics_assertion.yaml
@@ -39,7 +39,6 @@ resources:
                     server.port/exists: true
                     service.instance.id/exists: true
                     service.name: kubernetes-apiserver
-                    subresource/exists: true
                     url.scheme: https
                     verb/regex: ^(APPLY|CONNECT|CREATE|DELETE|DELETECOLLECTION|GET|LIST|PATCH|POST|PROXY|PUT|UPDATE|WATCH|WATCHLIST|other)$
                     version/exists: true

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -26,6 +26,8 @@ type metricsAssertionConfig struct {
 	regexAttrs                     map[string]string
 	firstDatapointOnly             []string
 	maxDatapointsPerMetric         int
+	selectedNumberMetric           string
+	selectedNumberDatapoint        map[string]string
 	exactDatapointAttrs            map[string]struct{}
 	includeHistogramExplicitBounds bool
 }
@@ -115,6 +117,15 @@ func WithFirstDatapointOnly(metricNames ...string) MetricsAssertionOption {
 func WithMaxDatapointsPerMetric(maxDatapoints int) MetricsAssertionOption {
 	return func(cfg *metricsAssertionConfig) {
 		cfg.maxDatapointsPerMetric = maxDatapoints
+	}
+}
+
+// WithSelectedNumberDatapoint retains datapoints for a number metric that
+// contain the provided attributes.
+func WithSelectedNumberDatapoint(metricName string, attributes map[string]string) MetricsAssertionOption {
+	return func(cfg *metricsAssertionConfig) {
+		cfg.selectedNumberMetric = metricName
+		cfg.selectedNumberDatapoint = attributes
 	}
 }
 
@@ -446,11 +457,34 @@ func newMetricsAssertionConfig(opts ...MetricsAssertionOption) metricsAssertionC
 func prepareMetricsAssertion(actual pmetric.Metrics, cfg metricsAssertionConfig) pmetric.Metrics {
 	prepared := pmetric.NewMetrics()
 	actual.CopyTo(prepared)
+	retainSelectedNumberDatapoint(prepared, cfg.selectedNumberMetric, cfg.selectedNumberDatapoint)
 	if cfg.maxDatapointsPerMetric > 0 {
 		ReduceDatapoints(&prepared, cfg.maxDatapointsPerMetric)
 	}
 	keepFirstDatapointOnly(prepared, cfg.firstDatapointOnly, cfg.flexibleAttrs())
 	return prepared
+}
+
+func retainSelectedNumberDatapoint(metrics pmetric.Metrics, metricName string, attributes map[string]string) {
+	metric, found := GetMetric(&metrics, metricName)
+	if !found {
+		return
+	}
+	remove := func(dp pmetric.NumberDataPoint) bool {
+		for key, expected := range attributes {
+			actual, ok := dp.Attributes().Get(key)
+			if !ok || actual.Type() != pcommon.ValueTypeStr || actual.Str() != expected {
+				return true
+			}
+		}
+		return false
+	}
+	switch metric.Type() {
+	case pmetric.MetricTypeGauge:
+		metric.Gauge().DataPoints().RemoveIf(remove)
+	case pmetric.MetricTypeSum:
+		metric.Sum().DataPoints().RemoveIf(remove)
+	}
 }
 
 func (cfg metricsAssertionConfig) flexibleAttrs() []string {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Reduce flakiness in API-server non-histogram test assertion by selecting the deterministic `apiserver_request_total` datapoint generated by the test’s k8s service request. This prevents the test from arbitrarily selecting `/healthz`, whose empty Prometheus labels are omitted during OTLP conversion and lack component, resource, scope, and version.

Once pmetricassert supports datapoints/include, this selector can be replaced with a YAML-only assertion.
