### PR TITLE
[chore] Fix flaky k8s-clusters tests

### DIFF
--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -116,7 +116,7 @@ func setupSinks(t *testing.T) {
 	}
 }
 
-func deployChartsAndApps(t *testing.T, testKubeConfig string) {
+func deployCharts(t *testing.T, testKubeConfig string) {
 	kubeTestEnv, setKubeTestEnv := os.LookupEnv("KUBE_TEST_ENV")
 	require.True(t, setKubeTestEnv, "the environment variable KUBE_TEST_ENV must be set")
 	kubeConfig, err := clientcmd.BuildConfigFromFlags("", testKubeConfig)
@@ -125,9 +125,6 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 	require.NoError(t, err)
 	extensionsClient, err := clientset.NewForConfig(kubeConfig)
 	require.NoError(t, err)
-	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-	decode := scheme.Codecs.UniversalDeserializer().Decode
 
 	if requiresPrometheusResources(kubeTestEnv) {
 		deployPrometheusCRDs(t, extensionsClient)
@@ -203,6 +200,30 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 	for valuesFile, chartOption := range chartInfo {
 		internal.ChartInstallOrUpgrade(t, testKubeConfig, valuesFile, replacements, 1*time.Minute, chartOption)
 	}
+
+	t.Cleanup(func() {
+		if os.Getenv("SKIP_TEARDOWN") == "true" {
+			t.Log("Skipping teardown as SKIP_TEARDOWN is set to true")
+			return
+		}
+		t.Log("Cleaning up cluster")
+		// t.Cleanup is called after t.Context has been cancelled. teardown uses the passed in
+		// context to cleanup resources created for the test. A valid context needs to be used
+		// to properly delete k8s resources, otherwise all actions fail with a context
+		// cancelled error.
+		teardown(context.Background(), t, testKubeConfig) //nolint:usetesting
+	})
+}
+
+func deployTestResources(t *testing.T, testKubeConfig string) {
+	kubeTestEnv := requireEnv(t, "KUBE_TEST_ENV")
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", testKubeConfig)
+	require.NoError(t, err)
+	client, err := kubernetes.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
+	require.NoError(t, err)
+	decode := scheme.Codecs.UniversalDeserializer().Decode
 
 	deployments := client.AppsV1().Deployments(internal.DefaultNamespace)
 
@@ -283,19 +304,6 @@ func deployChartsAndApps(t *testing.T, testKubeConfig string) {
 			t.Logf("Deployed job %s", job.Name)
 		}
 	}
-
-	t.Cleanup(func() {
-		if os.Getenv("SKIP_TEARDOWN") == "true" {
-			t.Log("Skipping teardown as SKIP_TEARDOWN is set to true")
-			return
-		}
-		t.Log("Cleaning up cluster")
-		// t.Cleanup is called after t.Context has been cancelled. teardown uses the passed in
-		// context to cleanup resources created for the test. A valid context needs to be used
-		// to properly delete k8s resources, otherwise all actions fail with a context
-		// cancelled error.
-		teardown(context.Background(), t, testKubeConfig) //nolint:usetesting
-	})
 }
 
 // createAKSWindowsValidationSecret ensures the mixed-node AKS test exercises the
@@ -422,31 +430,39 @@ func Test_Functions(t *testing.T) {
 	setupSinks(t)
 
 	testKubeConfig := requireEnv(t, "KUBECONFIG")
+	kubeTestEnv := requireEnv(t, "KUBE_TEST_ENV")
+	skipSetup := os.Getenv("SKIP_SETUP") == "true"
+	skipTests := os.Getenv("SKIP_TESTS") == "true"
+	if kubeTestEnv == kindTestKubeEnv {
+		expectedValuesDir = kindValuesDir
+	}
+
 	internal.AcquireLeaseForTest(t, testKubeConfig)
 
 	if os.Getenv("TEARDOWN_BEFORE_SETUP") == "true" {
 		teardown(t.Context(), t, testKubeConfig)
 	}
 
-	if os.Getenv("SKIP_SETUP") != "true" {
-		deployChartsAndApps(t, testKubeConfig)
+	if !skipSetup {
+		deployCharts(t, testKubeConfig)
+		if !skipTests && kubeTestEnv == kindTestKubeEnv && os.Getenv("UPGRADE_FROM_VALUES") == "" {
+			t.Run("kubernetes cluster metrics", testK8sClusterReceiverMetrics)
+		}
+		deployTestResources(t, testKubeConfig)
 	} else {
 		t.Log("Skipping setup as SKIP_SETUP is set to true")
 	}
 
-	if os.Getenv("SKIP_TESTS") == "true" {
+	if skipTests {
 		t.Log("Skipping tests as SKIP_TESTS is set to true")
 		return
 	}
 
-	kubeTestEnv := requireEnv(t, "KUBE_TEST_ENV")
-
 	if kubeTestEnv == kindTestKubeEnv {
-		expectedValuesDir = kindValuesDir
 		if os.Getenv("UPGRADE_FROM_VALUES") != "" {
 			runLocalClusterUpgradeTests(t)
 		} else {
-			runLocalClusterTests(t)
+			runLocalClusterTests(t, skipSetup)
 		}
 	} else {
 		runHostedClusterTests(t, kubeTestEnv)
@@ -590,7 +606,7 @@ func testLocalClusterComponentHealth(t *testing.T) {
 // runLocalClusterTests runs tests that are expected to pass on local clusters like kind, minikube, etc.
 // These tests are not ready to run in hosted clusters as we don't have the setup to send data to sinks.
 // Eventually, we can update the tests to export to a file and run them in hosted clusters, example: testResourceAttributes
-func runLocalClusterTests(t *testing.T) {
+func runLocalClusterTests(t *testing.T, includeK8sClusterReceiverTest bool) {
 	t.Run("node.js traces captured", testNodeJSTraces)
 	t.Run("java traces captured", testJavaTraces)
 	t.Run(".NET traces captured", testDotNetTraces)
@@ -603,7 +619,9 @@ func runLocalClusterTests(t *testing.T) {
 	t.Run("node.js profiling captured", testNodeJSProfiling)
 	t.Run(".NET profiling captured", testDotNetProfiling)
 	t.Run("Python profiling captured", testPythonProfiling)
-	t.Run("kubernetes cluster metrics", testK8sClusterReceiverMetrics)
+	if includeK8sClusterReceiverTest {
+		t.Run("kubernetes cluster metrics", testK8sClusterReceiverMetrics)
+	}
 	t.Run("agent logs", testAgentLogs)
 	t.Run("container log attributes validation", func(t *testing.T) {
 		validateLogAttributes(t, globalSinks.logsConsumer)
@@ -855,6 +873,7 @@ func testK8sClusterReceiverMetrics(t *testing.T) {
 	)
 	internal.AssertMetricsSnapshot(t, globalSinks.k8sclusterReceiverMetricsConsumer,
 		"k8s.pod.phase", assertionFile, 3*time.Minute, 10*time.Second,
+		internal.WithWaitForSnapshotMatch(),
 		internal.WithVolatileAttributes(existsAttrs...),
 		internal.WithRegexAttributes(internal.CommonK8sMetricAssertionRegexAttrs),
 		internal.WithFirstDatapointOnly(

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -116,15 +116,14 @@ func setupSinks(t *testing.T) {
 	}
 }
 
-func deployCharts(t *testing.T, testKubeConfig string) {
+func deployCharts(
+	t *testing.T,
+	testKubeConfig string,
+	client *kubernetes.Clientset,
+	extensionsClient *clientset.Clientset,
+) {
 	kubeTestEnv, setKubeTestEnv := os.LookupEnv("KUBE_TEST_ENV")
 	require.True(t, setKubeTestEnv, "the environment variable KUBE_TEST_ENV must be set")
-	kubeConfig, err := clientcmd.BuildConfigFromFlags("", testKubeConfig)
-	require.NoError(t, err)
-	client, err := kubernetes.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-	extensionsClient, err := clientset.NewForConfig(kubeConfig)
-	require.NoError(t, err)
 
 	if requiresPrometheusResources(kubeTestEnv) {
 		deployPrometheusCRDs(t, extensionsClient)
@@ -178,7 +177,6 @@ func deployCharts(t *testing.T, testKubeConfig string) {
 	default:
 		addChartInfo("test_values.yaml.tmpl", internal.GetDefaultChartOptions())
 	}
-	assert.NoError(t, err)
 
 	hostEp := internal.HostEndpoint(t)
 	if len(hostEp) == 0 {
@@ -215,14 +213,8 @@ func deployCharts(t *testing.T, testKubeConfig string) {
 	})
 }
 
-func deployTestResources(t *testing.T, testKubeConfig string) {
+func deployTestResources(t *testing.T, client *kubernetes.Clientset, dynamicClient dynamic.Interface) {
 	kubeTestEnv := requireEnv(t, "KUBE_TEST_ENV")
-	kubeConfig, err := clientcmd.BuildConfigFromFlags("", testKubeConfig)
-	require.NoError(t, err)
-	client, err := kubernetes.NewForConfig(kubeConfig)
-	require.NoError(t, err)
-	dynamicClient, err := dynamic.NewForConfig(kubeConfig)
-	require.NoError(t, err)
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
 	deployments := client.AppsV1().Deployments(internal.DefaultNamespace)
@@ -444,11 +436,20 @@ func Test_Functions(t *testing.T) {
 	}
 
 	if !skipSetup {
-		deployCharts(t, testKubeConfig)
+		kubeConfig, err := clientcmd.BuildConfigFromFlags("", testKubeConfig)
+		require.NoError(t, err)
+		client, err := kubernetes.NewForConfig(kubeConfig)
+		require.NoError(t, err)
+		extensionsClient, err := clientset.NewForConfig(kubeConfig)
+		require.NoError(t, err)
+		dynamicClient, err := dynamic.NewForConfig(kubeConfig)
+		require.NoError(t, err)
+
+		deployCharts(t, testKubeConfig, client, extensionsClient)
 		if !skipTests && kubeTestEnv == kindTestKubeEnv && os.Getenv("UPGRADE_FROM_VALUES") == "" {
 			t.Run("kubernetes cluster metrics", testK8sClusterReceiverMetrics)
 		}
-		deployTestResources(t, testKubeConfig)
+		deployTestResources(t, client, dynamicClient)
 	} else {
 		t.Log("Skipping setup as SKIP_SETUP is set to true")
 	}

--- a/functional_tests/internal/metricassert.go
+++ b/functional_tests/internal/metricassert.go
@@ -31,9 +31,10 @@ type metricsAssertionConfig struct {
 	selectedNumberDatapoint        map[string]string
 	exactDatapointAttrs            map[string]struct{}
 	includeHistogramExplicitBounds bool
+	waitForSnapshotMatch           bool
 }
 
-// MetricsAssertionOption configures preprocessing before pmetricassert comparison.
+// MetricsAssertionOption configures snapshot selection and preprocessing.
 type MetricsAssertionOption func(*metricsAssertionConfig)
 
 const (
@@ -115,6 +116,13 @@ func WithScopeVersionRegex(pattern string) MetricsAssertionOption {
 	}
 }
 
+// WithWaitForSnapshotMatch retries live batches until one satisfies the assertion.
+func WithWaitForSnapshotMatch() MetricsAssertionOption {
+	return func(cfg *metricsAssertionConfig) {
+		cfg.waitForSnapshotMatch = true
+	}
+}
+
 // WithFirstDatapointOnly preserves old pmetrictest.IgnoreSubsequentDataPoints behavior.
 func WithFirstDatapointOnly(metricNames ...string) MetricsAssertionOption {
 	return func(cfg *metricsAssertionConfig) {
@@ -166,6 +174,13 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 	cfg := newMetricsAssertionConfig(opts...)
 	wantResources, wantMetrics, err := assertionExpectedCounts(assertionFile)
 	require.NoError(t, err, "Failed to read expected counts from %s", assertionFile)
+	if cfg.waitForSnapshotMatch && !shouldUpdateExpectedResults() {
+		selected, assertErr := selectMetricSetByAssertionWithTimeout(t, targetMetric, sink, wantResources, wantMetrics, assertionFile, cfg, timeout, interval)
+		require.NotNil(t, selected, "No metrics batch found containing target metric: %s", targetMetric)
+		require.NoError(t, assertErr, "Metric assertion failed for %s. Error: %v", assertionFile, assertErr)
+		t.Logf("Metric assertion passed for %d metrics (%s)", selected.MetricCount(), assertionFile)
+		return
+	}
 
 	selected, exactMatch := selectMetricSetByCountsWithTimeout(t, targetMetric, sink, wantResources, wantMetrics, timeout, interval)
 	require.NotNil(t, selected, "No metrics batch found containing target metric: %s", targetMetric)
@@ -182,6 +197,30 @@ func AssertMetricsSnapshot(t *testing.T, sink *consumertest.MetricsSink, targetM
 	}
 
 	t.Logf("Metric assertion passed for %d metrics (%s)", selected.MetricCount(), assertionFile)
+}
+
+func selectMetricSetByAssertionWithTimeout(t *testing.T, targetMetric string, metricSink *consumertest.MetricsSink, wantResources, wantMetrics int, assertionFile string, cfg metricsAssertionConfig, timeout, interval time.Duration) (*pmetric.Metrics, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if selected := selectMetricSetByCounts(targetMetric, metricSink, wantResources, wantMetrics); selected != nil {
+			actual := prepareMetricsAssertion(*selected, cfg)
+			if err := pmetricassert.AssertMetrics(assertionFile, actual); err == nil {
+				t.Logf("Selected matching payload with target metric '%s': %d metrics, %d resources",
+					targetMetric, selected.MetricCount(), selected.ResourceMetrics().Len())
+				return selected, nil
+			}
+		}
+		time.Sleep(interval)
+	}
+
+	selected := richestMetricSet(targetMetric, metricSink)
+	if selected == nil {
+		return nil, nil
+	}
+	t.Logf("No matching payload (%d resources, %d metrics) for '%s' within %v; using best-effort fallback: %d metrics, %d resources",
+		wantResources, wantMetrics, targetMetric, timeout, selected.MetricCount(), selected.ResourceMetrics().Len())
+	actual := prepareMetricsAssertion(*selected, cfg)
+	return selected, pmetricassert.AssertMetrics(assertionFile, actual)
 }
 
 func selectMetricSetByCountsWithTimeout(t *testing.T, targetMetric string, metricSink *consumertest.MetricsSink, wantResources, wantMetrics int, timeout, interval time.Duration) (*pmetric.Metrics, bool) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Run the k8s cluster metrics assertion after chart installation but before deploying instrumentation test workloads. This prevents Node.js, Java, .NET, or Python resources from adding timing-dependent datapoints to the exact pmetricassert snapshot.
Normal Kind runs execute the assertion once at this isolated point. The existing `SKIP_SETUP=true` behavior is retained for manual runs that reuse an already-deployed cluster, although it is not used by current CI workflows.

Also add an opt-in `WithWaitForSnapshotMatch` option because matching resource and metric counts does not always guarantee that datapoints have converged. It retries the full `pmetricassert` comparison until the snapshot matches.