### PR TITLE
[chore] fix transform

### DIFF
--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,11 +131,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 26711a96e3c7e46fa20e2a0db43f6212b234479763649a7878b24f86c0c56996
+        checksum/config: fdd04cc72fd04f1cbff38d0e1fbbb1a88e3120fe34cc83cb88844999aaed3a8d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,11 +131,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 26711a96e3c7e46fa20e2a0db43f6212b234479763649a7878b24f86c0c56996
+        checksum/config: fdd04cc72fd04f1cbff38d0e1fbbb1a88e3120fe34cc83cb88844999aaed3a8d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,11 +131,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 26711a96e3c7e46fa20e2a0db43f6212b234479763649a7878b24f86c0c56996
+        checksum/config: fdd04cc72fd04f1cbff38d0e1fbbb1a88e3120fe34cc83cb88844999aaed3a8d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,11 +131,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 26711a96e3c7e46fa20e2a0db43f6212b234479763649a7878b24f86c0c56996
+        checksum/config: fdd04cc72fd04f1cbff38d0e1fbbb1a88e3120fe34cc83cb88844999aaed3a8d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 299ac7ee367cf065268d8ad05c00d8a87213b7d003e992d0c97c7946220adda6
+        checksum/config: 478aa41e7e8da800dc967218e4e35e742a21613840c8e035f3acf58cc8a2e978
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,11 +116,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d6d1ca40e957daefa7699129361d019d18cbca3a32ed00f01569411a4097b627
+        checksum/config: 2315c94b4e5f07129a8a7ea9a3942bf26f704e1c501e68d7038a8bed8b25b50e
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -177,11 +177,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3773cec1f1e5b439c229d67d0989817ed2bae4f41a9c19166d66d3cf7f3e7bef
+        checksum/config: 41cd7353ab14c3f23dc47f2c1f5a0cdabf0329a43130cf7f7582c78541c20150
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -72,11 +72,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e412bd5ce564c4066e22c01608a08eadb1de2ccab7678c0e11fa7c35ea6c4826
+        checksum/config: 487bf62fec0ea0ed4d56150110eb17b8c07769cb6e0a09fee895c92201065f4b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
@@ -108,11 +108,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 6a84867275712803f6c7d4cd97b636b5a4ef61292e235a36070dcd3a4453dfc7
+        checksum/config: b44dee49bd8e061c639240977f45f9ab20e9575ec8745629ddbd5c3c1702d903
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -79,11 +79,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 264d2653ff9c5a39cd6459fdf9a57d51a503bd1918cfe97ddc26a589c8d853be
+        checksum/config: 5484866fdb869c4c818bc489e3ec0d9cf5a8f2784c6bd85609aa846ea3e02931
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -95,11 +95,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: aed2a7643715322fba3a104e8c794c861bb2d1a916c7ae54be395d6f1034281c
+        checksum/config: 4ae431e2c9c72a77ab90b559325d30b880a2cd2803adb7a8efa4fc79d4b7d411
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -111,11 +111,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9e88f0414c8c8488bc58e6439e74345fc968a46979159a659d907f626a423509
+        checksum/config: 9cb19c60c3bcb8fc0bb8821c4f37ba364e44aeb65e925e3742140199d58f9824
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -111,11 +111,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 9e88f0414c8c8488bc58e6439e74345fc968a46979159a659d907f626a423509
+        checksum/config: 9cb19c60c3bcb8fc0bb8821c4f37ba364e44aeb65e925e3742140199d58f9824
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -71,11 +71,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 988615fdee8e7f6b0e26ede824839bafcb632c36bf5705d397078615faea972a
+        checksum/config: 5215dfb3f57b5396e6ddda8d9316a0b9fa1c561dea97b5858dd8b9a770a43518
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/ebpf-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -136,11 +136,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f2908a2e4fad2b141823c1831be79081538f2266d6c989349a162b5283d51791
+        checksum/config: fe489e9191803494954379631743c822bbd519eafbf7a21a9feba1817304cf21
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/configmap-cluster-receiver.yaml
@@ -177,11 +177,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3773cec1f1e5b439c229d67d0989817ed2bae4f41a9c19166d66d3cf7f3e7bef
+        checksum/config: 41cd7353ab14c3f23dc47f2c1f5a0cdabf0329a43130cf7f7582c78541c20150
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-trace-sampling/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/configmap-cluster-receiver.yaml
@@ -64,11 +64,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/enable-trace-sampling/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 841963ae2297659841f4d40a4580c7e075ddedfde074c21e20834522c4966756
+        checksum/config: 575c0b4ca678f438f429fac4f76b5636a702e00acd90e926bbd4bab5cc6abfe3
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -192,11 +192,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 2c8fdf4c5c790e2a9caacee2192be97b20016411a4332b85ed4e6cb7b5b67088
+        checksum/config: 1912b95e2d1d064e3bf3a010106e1a22b01e96fee30f779813f39698c981600c
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -186,11 +186,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: f2818fd84139abb961da8350ec9965628f7781bf5c2b054bc9f28b4993d3ccfd
+        checksum/config: 836449a1bc6df049f5fb177ab349b5de302fd10c01f94d2d10b7fa575a7b805a
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,11 +116,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d9685a827f4b29f5e2800105ebc8755d089c69f55d12faa3509b7ca0751a8c14
+        checksum/config: c7b8374187d89c0c068582e3628608faa62dbca18170a92d3095ee8e81fd4881
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
@@ -111,11 +111,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 3fc72a1fa822773b1ade7bf92665c4180e79cbab5bbbf8df19a803f5a9ded6f9
+        checksum/config: a6c62b833d49fb7d33483dd00a382821b4c46b4cd174726ddfd5748c161a66df
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -131,11 +131,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 26711a96e3c7e46fa20e2a0db43f6212b234479763649a7878b24f86c0c56996
+        checksum/config: fdd04cc72fd04f1cbff38d0e1fbbb1a88e3120fe34cc83cb88844999aaed3a8d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -177,11 +177,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multi-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a0bbe5ac2d49d260021171a1ab32947c3f48f8a0af564a0c4ef726d1147c61e6
+        checksum/config: 9debf6de7a5f85c2008128957904a36a9e5f95764b4fd31a68c8eb702053d66f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,11 +116,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/multiline-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d9685a827f4b29f5e2800105ebc8755d089c69f55d12faa3509b7ca0751a8c14
+        checksum/config: c7b8374187d89c0c068582e3628608faa62dbca18170a92d3095ee8e81fd4881
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,11 +116,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d9685a827f4b29f5e2800105ebc8755d089c69f55d12faa3509b7ca0751a8c14
+        checksum/config: c7b8374187d89c0c068582e3628608faa62dbca18170a92d3095ee8e81fd4881
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,11 +116,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 71d222a2d18d9dc91b00fa9b74122a7d761490c8e7c3e0e5872abaf35660af9c
+        checksum/config: c4f116717b294865a2a8123561b341320209c9c924dee5a68baf703a0b4a0a05
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-traces/rendered_manifests/configmap-cluster-receiver.yaml
@@ -64,11 +64,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/only-traces/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-traces/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 841963ae2297659841f4d40a4580c7e075ddedfde074c21e20834522c4966756
+        checksum/config: 575c0b4ca678f438f429fac4f76b5636a702e00acd90e926bbd4bab5cc6abfe3
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 299ac7ee367cf065268d8ad05c00d8a87213b7d003e992d0c97c7946220adda6
+        checksum/config: 478aa41e7e8da800dc967218e4e35e742a21613840c8e035f3acf58cc8a2e978
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c2f98ce989f72d5cbe0b9adff32d94dd2f8c28a79395460dccbca7ada6b76750
+        checksum/config: 43616f34c5eed5cad74d320e9c86b258ed2ae403bcb59b1888d2e898d2f27a0f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,11 +116,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/secret-validation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: d9685a827f4b29f5e2800105ebc8755d089c69f55d12faa3509b7ca0751a8c14
+        checksum/config: c7b8374187d89c0c068582e3628608faa62dbca18170a92d3095ee8e81fd4881
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-connect-for-otlp/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,11 +116,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/splunk-connect-for-otlp/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: dc04b25df7653ee4dd94b677d42f96db45960dd5238aa8ccdbd90751287ddbd6
+        checksum/config: 9b44cc6266e6ee7ce7c8da90bbb3f2e643cf5b443d8b9789a3082c4273f58a88
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/configmap-cluster-receiver.yaml
@@ -116,11 +116,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: efb9a05fa60d5033b2ccc8a26256a248eb073ef1e3cbbf79e23be42b0cda1417
+        checksum/config: 058caaa056bd0925907af2ae18acacecfc2846bc032d73eb4a87388543206b46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -182,11 +182,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1a56cbf0d4f986d019c1e4dd64abec81b1b4adfff158d3c4a5edd85c78699598
+        checksum/config: e351ee39dfcf0e360b7be4011705a6c3fee90698f8f1e791061c6dad8570651d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -70,11 +70,11 @@ data:
         metric_statements:
         - context: resource
           statements:
-          - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-          - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-          - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+          - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
             where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
     receivers:
       k8s_cluster:

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 56607217bad994812bd7c2ca38ed31c086445d71a9fb582f53810938ba707ce8
+        checksum/config: b6115a46747a3c9e082c8ea67895397a6a087929a4748e64b2d8dbbb18964f46
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -145,11 +145,11 @@ processors:
     metric_statements:
     - context: resource
       statements:
-      - set(attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+      - set(resource.attributes["k8s.replicaset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
         where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "ReplicaSet")
-      - set(attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+      - set(resource.attributes["k8s.statefulset.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
         where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "StatefulSet")
-      - set(attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
+      - set(resource.attributes["k8s.deployment.name"], resource.attributes["k8s.hpa.scaletargetref.name"])
         where IsMatch(resource.attributes["k8s.hpa.scaletargetref.kind"], "Deployment")
 
   {{- if eq (include "splunk-otel-collector.o11yInfraMonEventsEnabled" .) "true" }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Explicitly qualify HPA scale-target transform destinations with resource.attributes. This preserves the existing output while preventing OTTL parser logs about automatically corrected context prefixes.

```
one or more paths were modified to include their context prefix, please rewrite them accordingly
```