### PR TITLE
[chore] Bump Go to 1.26.6

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
 jobs:
   setup-environment:
     timeout-minutes: 30

--- a/.github/workflows/functional_test.yaml
+++ b/.github/workflows/functional_test.yaml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/functional_test_v2.yaml
+++ b/.github/workflows/functional_test_v2.yaml
@@ -32,7 +32,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2

--- a/.github/workflows/validate-changelog.yaml
+++ b/.github/workflows/validate-changelog.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.26.5
+  GO_VERSION: 1.26.6
 
 jobs:
   validate-changelog:

--- a/functional_tests/go.mod
+++ b/functional_tests/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/signalfx/splunk-otel-collector-chart/functional_tests
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/moby/moby/client v0.5.1

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 # Splunk Platform Functional Test Environment Setup
 
 ## Prerequisites
-* Golang version >= 1.26.5
+* Golang version >= 1.26.6
 * Kubectl = v1.15.2
 * Minikube = v1.20.0
 * Helm = 3.3.x

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module splunk-integration-tests
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/tools/k8s_versions/go.mod
+++ b/tools/k8s_versions/go.mod
@@ -1,6 +1,6 @@
 module k8sVersions
 
-go 1.26.5
+go 1.26.6
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
Bump the Go toolchain from 1.26.5 to 1.26.6 across CI workflows