### PR TITLE
Added deployment.environment.name attribute to opamp

### DIFF
--- a/.chloggen/opamp-bridge-environment-attribute.yaml
+++ b/.chloggen/opamp-bridge-environment-attribute.yaml
@@ -5,7 +5,7 @@ component: chart
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add `deployment.environment.name` to OpAMP Bridge descriptions when `environment` is set.
 # One or more tracking issues related to the change
-issues: [2548]
+issues: [2569]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.

--- a/.chloggen/opamp-bridge-environment-attribute.yaml
+++ b/.chloggen/opamp-bridge-environment-attribute.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `deployment.environment.name` to OpAMP Bridge descriptions when `environment` is set.
+# One or more tracking issues related to the change
+issues: [2548]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/helm-charts/splunk-otel-collector/templates/_opamp-bridge.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_opamp-bridge.tpl
@@ -99,6 +99,9 @@ Render standalone OpAMP Bridge non-identifying attributes.
 {{- with .Values.clusterName -}}
 {{- $_ := set $attrs "k8s.cluster.name" . -}}
 {{- end -}}
+{{- with .Values.environment -}}
+{{- $_ := set $attrs "deployment.environment.name" . -}}
+{{- end -}}
 {{- if $attrs -}}
 {{- toYaml $attrs -}}
 {{- end -}}
@@ -112,6 +115,9 @@ Render standalone OpAMP Bridge non-identifying attributes for a chart-managed wo
 {{- $_ := set $attrs "otelcol.service.mode" .workload.serviceMode -}}
 {{- with .root.Values.clusterName -}}
 {{- $_ := set $attrs "k8s.cluster.name" . -}}
+{{- end -}}
+{{- with .root.Values.environment -}}
+{{- $_ := set $attrs "deployment.environment.name" . -}}
 {{- end -}}
 {{- toYaml $attrs -}}
 {{- end -}}

--- a/helm-charts/splunk-otel-collector/templates/opamp-bridge-deployment.yaml
+++ b/helm-charts/splunk-otel-collector/templates/opamp-bridge-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml $bridge.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ printf "%s\n%s\n%s" (toYaml $bridge) (include "splunk-otel-collector.opampBridgeEndpoint" .) .Values.clusterName | sha256sum }}
+        checksum/config: {{ printf "%s\n%s\n%s\n%s" (toYaml $bridge) (include "splunk-otel-collector.opampBridgeEndpoint" .) .Values.clusterName .Values.environment | sha256sum }}
         {{- if $bridge.podAnnotations }}
         {{- toYaml $bridge.podAnnotations | nindent 8 }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -321,7 +321,7 @@
       ]
     },
     "environment": {
-      "description": "Optional \"environment\" parameter that will be added to all the telemetry data (traces/logs/metrics), including Collector internal telemetry, as the \"deployment.environment.name\" resource attribute. It will allow Splunk Observability users to investigate data from different sources separately.",
+      "description": "Optional \"environment\" parameter that will be added to all the telemetry data (traces/logs/metrics), including Collector internal telemetry, as the \"deployment.environment.name\" resource attribute, and to OpAMP Bridge descriptions as a non-identifying attribute. It will allow Splunk Observability users to investigate data from different sources separately.",
       "type": "string"
     },
     "autodetect": {

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -261,7 +261,8 @@ distribution: ""
 ################################################################################
 # Optional "environment" parameter that will be added to all the telemetry
 # data (traces/logs/metrics), including Collector internal telemetry, as the
-# "deployment.environment.name" resource attribute. It will allow Splunk Observability
+# "deployment.environment.name" resource attribute, and to OpAMP Bridge
+# descriptions as a non-identifying attribute. It will allow Splunk Observability
 # users to investigate data from different sources separately.
 # See: https://help.splunk.com/en/splunk-observability-cloud/monitor-application-performance/set-up-splunk-apm/set-up-deployment-environments-in-splunk-apm
 ################################################################################

--- a/unittests/environment_test.yaml
+++ b/unittests/environment_test.yaml
@@ -5,6 +5,7 @@ templates:
   - configmap-agent.yaml
   - configmap-cluster-receiver.yaml
   - configmap-gateway.yaml
+  - opamp-bridge-configmap.yaml
 
 tests:
   - it: agent omits the deployment environment when environment is unset
@@ -28,6 +29,16 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["relay"]
+          pattern: "deployment\\.environment"
+
+  - it: opamp bridge omits the deployment environment when environment is unset
+    set:
+      remoteManagement:
+        enabled: true
+    template: opamp-bridge-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
           pattern: "deployment\\.environment"
 
   - it: agent uses deployment.environment.name for collected and internal telemetry
@@ -78,6 +89,31 @@ tests:
           pattern: "name: deployment\\.environment\\.name\\n\\s+value: production"
       - notMatchRegex:
           path: data["relay"]
+          pattern: "(?m)^\\s+(key|name): deployment\\.environment$"
+
+  - it: opamp bridge uses deployment.environment.name for bridge and managed workload descriptions
+    set:
+      environment: production
+      remoteManagement:
+        enabled: true
+      gateway:
+        enabled: true
+    template: opamp-bridge-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?s)name: \".*-opamp-bridge\".*description:\\n\\s+non_identifying_attributes:\\n\\s+deployment\\.environment\\.name: production"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?s)type: otel-agent\\n\\s+description:\\n\\s+non_identifying_attributes:\\n\\s+deployment\\.environment\\.name: production"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?s)type: otel-collector\\n\\s+description:\\n\\s+non_identifying_attributes:\\n\\s+deployment\\.environment\\.name: production\\n\\s+k8s\\.cluster\\.name: test\\n\\s+otelcol\\.service\\.mode: gateway"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?s)type: otel-collector\\n\\s+description:\\n\\s+non_identifying_attributes:\\n\\s+deployment\\.environment\\.name: production\\n\\s+k8s\\.cluster\\.name: test\\n\\s+otelcol\\.service\\.mode: clusterReceiver"
+      - notMatchRegex:
+          path: data["config.yaml"]
           pattern: "(?m)^\\s+(key|name): deployment\\.environment$"
 
   - it: cluster receiver internal telemetry has the environment without object or event pipelines


### PR DESCRIPTION
**Description:**
OpAMP bridge will not add the deployment.environemnt.name attribute as a non-identifying attribute to each OpAMP agent it reports to the server.



**Testing:**  tested manually and added a test

**Documentation:** updated doc to mention that the attribute is now also used by the bridge
