### PR TITLE
Preserve remote-managed ConfigMaps during upgrades

### DIFF
--- a/.chloggen/remote-management-preserve-configmap.yaml
+++ b/.chloggen/remote-management-preserve-configmap.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve OpAMP-managed collector ConfigMaps on Helm upgrades when Remote Management is enabled.
+# One or more tracking issues related to the change
+issues: [2575]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/ci-matrix.json
+++ b/ci-matrix.json
@@ -28,6 +28,7 @@
       "k8sevents",
       "k8sentities",
       "istio",
+      "remote_management",
       "discovery",
       "gateway",
       "logs",

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -65,6 +65,20 @@ can apply remote configuration and roll out workload changes. When Remote
 Management is enabled, chart-created collectors do not open their own direct
 OpAMP sessions to Splunk Observability Cloud; the bridge owns that connection.
 
+When Remote Management manages a chart-created collector, Helm marks the
+collector ConfigMap and preserves its live `data.relay` value on later upgrades
+so remote configuration applied by the bridge is not overwritten. Set
+`remoteManagement.collectorConfig.upgradeStrategy: resetFromHelm` to force Helm
+to render collector config from chart values again. Because OpAMP Bridge owns the
+live `data.relay` field after applying remote config, use Helm's
+`--force-conflicts` flag with `resetFromHelm`:
+
+```bash
+helm upgrade <release> <chart> \
+  --set remoteManagement.collectorConfig.upgradeStrategy=resetFromHelm \
+  --force-conflicts
+```
+
 By default, the bridge is configured to manage every enabled collector workload
 installed by this chart: the agent, gateway, and cluster receiver. If you do not
 override `remoteManagement.opampBridge.workloads`, every installed chart-managed

--- a/functional_tests/remote_management/remote_management_test.go
+++ b/functional_tests/remote_management/remote_management_test.go
@@ -1,0 +1,239 @@
+// Copyright Splunk Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package remotemanagement
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/chart"
+	"helm.sh/helm/v4/pkg/chart/loader"
+	"helm.sh/helm/v4/pkg/kube"
+	"helm.sh/helm/v4/pkg/strvals"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/signalfx/splunk-otel-collector-chart/functional_tests/internal"
+)
+
+const (
+	agentConfigMapName               = internal.DefaultChartReleaseName + "-splunk-otel-collector-otel-agent"
+	remoteManagementConfigAnnotation = "splunk.com/remote-management-config"
+	remoteManagedRelay               = `receivers:
+  otlp:
+    protocols:
+      grpc:
+exporters:
+  debug:
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - otlp
+      exporters:
+        - debug
+remote_management_functional_marker: preserved
+`
+)
+
+type upgradeResult struct {
+	helmRenderedRelay string
+	upgradedRelay     string
+}
+
+func TestRemoteManagementConfigMapUpgrade(t *testing.T) {
+	testKubeConfig, ok := os.LookupEnv("KUBECONFIG")
+	require.True(t, ok, "the environment variable KUBECONFIG must be set")
+
+	if os.Getenv("TEARDOWN_BEFORE_SETUP") == "true" {
+		teardown(t, testKubeConfig)
+	}
+
+	if os.Getenv("SKIP_TESTS") == "true" {
+		t.Log("Skipping tests as SKIP_TESTS is set to true")
+		return
+	}
+
+	t.Run("preserves remote-managed relay on helm upgrade", func(t *testing.T) {
+		result := installMutateAndUpgrade(t, testKubeConfig, "", false)
+		require.Equal(t, remoteManagedRelay, result.upgradedRelay)
+	})
+
+	t.Run("resets remote-managed relay when resetFromHelm is set", func(t *testing.T) {
+		result := installMutateAndUpgrade(t, testKubeConfig, "remoteManagement.collectorConfig.upgradeStrategy=resetFromHelm", true)
+		require.Equal(t, result.helmRenderedRelay, result.upgradedRelay)
+	})
+}
+
+func installMutateAndUpgrade(t *testing.T, testKubeConfig string, upgradeSet string, forceConflicts bool) upgradeResult {
+	teardown(t, testKubeConfig)
+	t.Cleanup(func() {
+		if os.Getenv("SKIP_TEARDOWN") == "true" {
+			t.Log("Skipping teardown as SKIP_TEARDOWN is set to true")
+			return
+		}
+		teardown(t, testKubeConfig)
+	})
+
+	clientset, err := internal.GetKubeClient(testKubeConfig)
+	require.NoError(t, err)
+
+	installValues := remoteManagementValues(t)
+	installChart(t, testKubeConfig, installValues)
+
+	installedConfigMap := getAgentConfigMap(t, clientset)
+	require.Equal(t, "true", installedConfigMap.Annotations[remoteManagementConfigAnnotation])
+	helmRenderedRelay := installedConfigMap.Data["relay"]
+	require.NotEmpty(t, helmRenderedRelay)
+	require.NotContains(t, helmRenderedRelay, "remote_management_functional_marker")
+
+	applyAgentRelayAsOpAMPBridge(t, clientset, remoteManagedRelay)
+
+	upgradeValues := remoteManagementValues(t)
+	if upgradeSet != "" {
+		require.NoError(t, strvals.ParseInto(upgradeSet, upgradeValues))
+	}
+	upgradeChart(t, testKubeConfig, upgradeValues, forceConflicts)
+
+	upgradedRelay := getAgentConfigMap(t, clientset).Data["relay"]
+	return upgradeResult{
+		helmRenderedRelay: helmRenderedRelay,
+		upgradedRelay:     upgradedRelay,
+	}
+}
+
+func remoteManagementValues(t *testing.T) map[string]any {
+	t.Helper()
+
+	valuesYAML := `
+clusterName: remote-management-functional
+
+splunkObservability:
+  realm: fake-realm
+  accessToken: fake-token
+
+remoteManagement:
+  enabled: true
+  opampBridge:
+    nodeSelector:
+      remote-management-functional-test: "disabled"
+
+clusterReceiver:
+  enabled: false
+
+gateway:
+  enabled: false
+
+nodeSelector:
+  remote-management-functional-test: "disabled"
+
+agent:
+  controlPlaneMetrics:
+    apiserver:
+      enabled: false
+    controllerManager:
+      enabled: false
+    coredns:
+      enabled: false
+`
+
+	var values map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(valuesYAML), &values))
+	return values
+}
+
+func installChart(t *testing.T, testKubeConfig string, values map[string]any) {
+	t.Helper()
+
+	actionConfig := internal.InitHelmActionConfig(t, testKubeConfig)
+	install := action.NewInstall(actionConfig)
+	install.Namespace = internal.DefaultNamespace
+	install.ReleaseName = internal.DefaultChartReleaseName
+	install.WaitStrategy = kube.HookOnlyStrategy
+	install.Timeout = internal.HelmActionTimeout
+
+	t.Log("Running helm install")
+	_, err := install.Run(loadChart(t), values)
+	require.NoError(t, err)
+}
+
+func upgradeChart(t *testing.T, testKubeConfig string, values map[string]any, forceConflicts bool) {
+	t.Helper()
+
+	actionConfig := internal.InitHelmActionConfig(t, testKubeConfig)
+	upgrade := action.NewUpgrade(actionConfig)
+	upgrade.Namespace = internal.DefaultNamespace
+	upgrade.WaitStrategy = kube.HookOnlyStrategy
+	upgrade.Timeout = internal.HelmActionTimeout
+	upgrade.ForceConflicts = forceConflicts
+
+	t.Log("Running helm upgrade")
+	_, err := upgrade.Run(internal.DefaultChartReleaseName, loadChart(t), values)
+	require.NoError(t, err)
+}
+
+func getAgentConfigMap(t *testing.T, clientset *kubernetes.Clientset) *corev1.ConfigMap {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	configMap, err := clientset.CoreV1().ConfigMaps(internal.DefaultNamespace).Get(ctx, agentConfigMapName, metav1.GetOptions{})
+	require.NoError(t, err)
+	return configMap
+}
+
+func applyAgentRelayAsOpAMPBridge(t *testing.T, clientset *kubernetes.Clientset, relay string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		configMap := corev1apply.ConfigMap(agentConfigMapName, internal.DefaultNamespace).
+			WithData(map[string]string{"relay": relay})
+		_, err := clientset.CoreV1().ConfigMaps(internal.DefaultNamespace).Apply(ctx, configMap, metav1.ApplyOptions{
+			FieldManager: "opampbridge",
+			Force:        true,
+		})
+		if err != nil {
+			t.Logf("failed to apply agent ConfigMap relay as OpAMP Bridge: %v", err)
+			return false
+		}
+		return true
+	}, time.Minute, time.Second)
+}
+
+func teardown(t *testing.T, testKubeConfig string) {
+	t.Helper()
+
+	actionConfig := internal.InitHelmActionConfig(t, testKubeConfig)
+	uninstall := action.NewUninstall(actionConfig)
+	uninstall.IgnoreNotFound = true
+	uninstall.WaitStrategy = kube.StatusWatcherStrategy
+	uninstall.Timeout = internal.HelmActionTimeout
+
+	_, err := uninstall.Run(internal.DefaultChartReleaseName)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		require.NoError(t, err)
+	}
+}
+
+func loadChart(t *testing.T) chart.Charter {
+	t.Helper()
+
+	chartPath := filepath.Join("..", "..", "helm-charts", "splunk-otel-collector")
+	c, err := loader.Load(chartPath)
+	require.NoError(t, err)
+	return c
+}

--- a/helm-charts/splunk-otel-collector/templates/_opamp-bridge.tpl
+++ b/helm-charts/splunk-otel-collector/templates/_opamp-bridge.tpl
@@ -31,6 +31,47 @@ Whether collector workloads should open direct OpAMP sessions.
 {{- end -}}
 
 {{/*
+Remote management marker for collector ConfigMaps whose relay config is managed
+by OpAMP Bridge after Helm creates the bootstrap config.
+*/}}
+{{- define "splunk-otel-collector.remoteManagementConfigAnnotation" -}}
+splunk.com/remote-management-config
+{{- end -}}
+
+{{/*
+Render collector ConfigMap relay config.
+
+When remote management manages this workload, preserve live data.relay on
+upgrades only after the live ConfigMap is marked with the remote management
+annotation. This lets existing installs render the new Helm bootstrap config
+when remote management is enabled for the first time, then preserves OpAMP
+remote config on later upgrades.
+*/}}
+{{- define "splunk-otel-collector.collectorConfigMapRelay" -}}
+{{- $root := .root -}}
+{{- $configMapName := .configMapName -}}
+{{- $chartConfig := .chartConfig -}}
+{{- $managed := .managed -}}
+{{- $annotation := include "splunk-otel-collector.remoteManagementConfigAnnotation" $root -}}
+{{- $upgradeStrategy := dig "collectorConfig" "upgradeStrategy" "preserve" $root.Values.remoteManagement -}}
+{{- if and $managed (ne $upgradeStrategy "resetFromHelm") -}}
+{{- $namespace := include "splunk-otel-collector.namespace" $root -}}
+{{- $live := lookup "v1" "ConfigMap" $namespace $configMapName -}}
+{{- $alreadyManaged := false -}}
+{{- if and $live $live.metadata $live.metadata.annotations (eq (index $live.metadata.annotations $annotation) "true") -}}
+{{- $alreadyManaged = true -}}
+{{- end -}}
+{{- if and $alreadyManaged $live.data (hasKey $live.data "relay") -}}
+{{- index $live.data "relay" -}}
+{{- else -}}
+{{- $chartConfig -}}
+{{- end -}}
+{{- else -}}
+{{- $chartConfig -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get OpAMP Bridge endpoint.
 */}}
 {{- define "splunk-otel-collector.opampBridgeEndpoint" -}}
@@ -49,7 +90,7 @@ Whether the chart-created agent workload should be managed by the OpAMP Bridge.
 {{- define "splunk-otel-collector.opampBridge.agentManaged" -}}
 {{- $bridge := .Values.remoteManagement.opampBridge -}}
 {{- $agentEnabled := and .Values.agent.enabled (ne .Values.distribution "eks/fargate") -}}
-{{- if and $agentEnabled $bridge.workloads.agent.enabled -}}true{{- end -}}
+{{- if and .Values.remoteManagement.enabled $agentEnabled $bridge.workloads.agent.enabled -}}true{{- end -}}
 {{- end -}}
 
 {{/*
@@ -57,7 +98,7 @@ Whether the chart-created gateway workload should be managed by the OpAMP Bridge
 */}}
 {{- define "splunk-otel-collector.opampBridge.gatewayManaged" -}}
 {{- $bridge := .Values.remoteManagement.opampBridge -}}
-{{- if and .Values.gateway.enabled $bridge.workloads.gateway.enabled -}}true{{- end -}}
+{{- if and .Values.remoteManagement.enabled .Values.gateway.enabled $bridge.workloads.gateway.enabled -}}true{{- end -}}
 {{- end -}}
 
 {{/*
@@ -66,7 +107,7 @@ Whether the chart-created cluster receiver workload should be managed by the OpA
 {{- define "splunk-otel-collector.opampBridge.clusterReceiverManaged" -}}
 {{- $bridge := .Values.remoteManagement.opampBridge -}}
 {{- $clusterReceiverEnabled := eq (include "splunk-otel-collector.clusterReceiverEnabled" .) "true" -}}
-{{- if and $clusterReceiverEnabled $bridge.workloads.clusterReceiver.enabled -}}true{{- end -}}
+{{- if and .Values.remoteManagement.enabled $clusterReceiverEnabled $bridge.workloads.clusterReceiver.enabled -}}true{{- end -}}
 {{- end -}}
 
 {{/*
@@ -112,6 +153,7 @@ Render standalone OpAMP Bridge non-identifying attributes for a chart-managed wo
 */}}
 {{- define "splunk-otel-collector.opampBridgeWorkloadAttributes" -}}
 {{- $attrs := deepCopy (dig "description" "non_identifying_attributes" (dict) .workload) -}}
+{{- $_ := set $attrs "service.version" (.root.Values.image.otelcol.tag | default .root.Chart.AppVersion) -}}
 {{- $_ := set $attrs "otelcol.service.mode" .workload.serviceMode -}}
 {{- with .root.Values.clusterName -}}
 {{- $_ := set $attrs "k8s.cluster.name" . -}}

--- a/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-agent.yaml
@@ -3,20 +3,27 @@ Fargate doesn't support daemonsets so never use for that platform
 */}}
 {{- include "splunk-otel-collector.validateLogsToMetrics" . }}
 {{- if and .Values.agent.enabled (ne .Values.distribution "eks/fargate") }}
+{{- $configMapName := printf "%s-otel-agent" (include "splunk-otel-collector.fullname" .) }}
+{{- $remoteManagementConfigManaged := eq (include "splunk-otel-collector.opampBridge.agentManaged" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "splunk-otel-collector.fullname" . }}-otel-agent
+  name: {{ $configMapName }}
   namespace: {{ template "splunk-otel-collector.namespace" . }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}
     chart: {{ template "splunk-otel-collector.chart" . }}
     release: {{ .Release.Name }}
+  {{- if $remoteManagementConfigManaged }}
+  annotations:
+    {{ include "splunk-otel-collector.remoteManagementConfigAnnotation" . }}: "true"
+  {{- end }}
 data:
   relay: |
     {{- $defaultConfig := include "splunk-otel-collector.agentConfig" . | fromYaml }}
-    {{- .Values.agent.config | mustMergeOverwrite $defaultConfig | toYaml | nindent 4 }}
+    {{- $chartConfig := .Values.agent.config | mustMergeOverwrite $defaultConfig | toYaml }}
+    {{- include "splunk-otel-collector.collectorConfigMapRelay" (dict "root" . "configMapName" $configMapName "chartConfig" $chartConfig "managed" $remoteManagementConfigManaged) | nindent 4 }}
 {{- if .Values.agent.discovery.enabled }}
   discovery.properties: |
     splunk.discovery:

--- a/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-cluster-receiver.yaml
@@ -1,16 +1,23 @@
 {{ if eq (include "splunk-otel-collector.clusterReceiverEnabled" . ) "true" }}
+{{- $configMapName := printf "%s-otel-k8s-cluster-receiver" (include "splunk-otel-collector.fullname" .) }}
+{{- $remoteManagementConfigManaged := eq (include "splunk-otel-collector.opampBridge.clusterReceiverManaged" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "splunk-otel-collector.fullname" . }}-otel-k8s-cluster-receiver
+  name: {{ $configMapName }}
   namespace: {{ template "splunk-otel-collector.namespace" . }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}
     chart: {{ template "splunk-otel-collector.chart" . }}
     release: {{ .Release.Name }}
+  {{- if $remoteManagementConfigManaged }}
+  annotations:
+    {{ include "splunk-otel-collector.remoteManagementConfigAnnotation" . }}: "true"
+  {{- end }}
 data:
   relay: |
     {{- $defaultConfig := include "splunk-otel-collector.clusterReceiverConfig" . | fromYaml }}
-    {{- .Values.clusterReceiver.config | mustMergeOverwrite $defaultConfig | toYaml | nindent 4 }}
+    {{- $chartConfig := .Values.clusterReceiver.config | mustMergeOverwrite $defaultConfig | toYaml }}
+    {{- include "splunk-otel-collector.collectorConfigMapRelay" (dict "root" . "configMapName" $configMapName "chartConfig" $chartConfig "managed" $remoteManagementConfigManaged) | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
+++ b/helm-charts/splunk-otel-collector/templates/configmap-gateway.yaml
@@ -1,16 +1,23 @@
 {{ if .Values.gateway.enabled }}
+{{- $configMapName := printf "%s-otel-collector" (include "splunk-otel-collector.fullname" .) }}
+{{- $remoteManagementConfigManaged := eq (include "splunk-otel-collector.opampBridge.gatewayManaged" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "splunk-otel-collector.fullname" . }}-otel-collector
+  name: {{ $configMapName }}
   namespace: {{ template "splunk-otel-collector.namespace" . }}
   labels:
     {{- include "splunk-otel-collector.commonLabels" . | nindent 4 }}
     app: {{ template "splunk-otel-collector.name" . }}
     chart: {{ template "splunk-otel-collector.chart" . }}
     release: {{ .Release.Name }}
+  {{- if $remoteManagementConfigManaged }}
+  annotations:
+    {{ include "splunk-otel-collector.remoteManagementConfigAnnotation" . }}: "true"
+  {{- end }}
 data:
   relay: |
     {{- $defaultConfig := include "splunk-otel-collector.gatewayConfig" . | fromYaml }}
-    {{- .Values.gateway.config | mustMergeOverwrite $defaultConfig | toYaml | nindent 4 }}
+    {{- $chartConfig := .Values.gateway.config | mustMergeOverwrite $defaultConfig | toYaml }}
+    {{- include "splunk-otel-collector.collectorConfigMapRelay" (dict "root" . "configMapName" $configMapName "chartConfig" $chartConfig "managed" $remoteManagementConfigManaged) | nindent 4 }}
 {{- end }}

--- a/helm-charts/splunk-otel-collector/templates/opamp-bridge-deployment.yaml
+++ b/helm-charts/splunk-otel-collector/templates/opamp-bridge-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- toYaml $bridge.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ printf "%s\n%s\n%s\n%s" (toYaml $bridge) (include "splunk-otel-collector.opampBridgeEndpoint" .) .Values.clusterName .Values.environment | sha256sum }}
+        checksum/config: {{ printf "%s\n%s\n%s\n%s" (toYaml $bridge) (include "splunk-otel-collector.opampBridgeEndpoint" .) .Values.clusterName .Values.environment (.Values.image.otelcol.tag | default .Chart.AppVersion) | sha256sum }}
         {{- if $bridge.podAnnotations }}
         {{- toYaml $bridge.podAnnotations | nindent 8 }}
         {{- end }}

--- a/helm-charts/splunk-otel-collector/values.schema.json
+++ b/helm-charts/splunk-otel-collector/values.schema.json
@@ -1387,6 +1387,20 @@
           "description": "Deploy the OpAMP Bridge and configure it to manage chart-created collectors.",
           "type": "boolean"
         },
+        "collectorConfig": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "upgradeStrategy": {
+              "description": "Controls how Helm upgrades handle collector ConfigMaps managed by OpAMP Bridge.",
+              "type": "string",
+              "enum": [
+                "preserve",
+                "resetFromHelm"
+              ]
+            }
+          }
+        },
         "opampBridge": {
           "type": "object",
           "additionalProperties": false,

--- a/helm-charts/splunk-otel-collector/values.yaml
+++ b/helm-charts/splunk-otel-collector/values.yaml
@@ -974,6 +974,14 @@ remoteManagement:
   # Requires splunkObservability.realm and splunkObservability.accessToken.
   enabled: false
 
+  collectorConfig:
+    # Controls how Helm upgrades handle collector ConfigMaps managed by OpAMP Bridge.
+    # When set to preserve, Helm preserves live ConfigMap data after the ConfigMap
+    # has been marked as remote-managed. When set to resetFromHelm, Helm renders
+    # collector config from chart values even if the live ConfigMap was previously
+    # marked as remote-managed.
+    upgradeStrategy: preserve
+
   opampBridge:
     # OpAMP server endpoint for the bridge. When empty, the chart uses the
     # Splunk Observability ingest OpAMP endpoint:

--- a/unittests/remote_management_test.yaml
+++ b/unittests/remote_management_test.yaml
@@ -238,6 +238,9 @@ tests:
           pattern: 'otelcol.service.mode: agent'
       - matchRegex:
           path: data["config.yaml"]
+          pattern: 'service.version: [0-9]+\.[0-9]+\.[0-9]+'
+      - matchRegex:
+          path: data["config.yaml"]
           pattern: 'otelcol.service.mode: clusterReceiver'
 
   - it: should include gateway workload when gateway is enabled
@@ -291,6 +294,77 @@ tests:
           path: data["relay"]
           pattern: "opamp/splunk_o11y"
 
+  - it: should annotate remote-managed agent config map
+    template: configmap-agent.yaml
+    set:
+      remoteManagement:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["splunk.com/remote-management-config"]
+          value: "true"
+
+  - it: should annotate remote-managed gateway config map
+    template: configmap-gateway.yaml
+    set:
+      remoteManagement:
+        enabled: true
+      gateway:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["splunk.com/remote-management-config"]
+          value: "true"
+
+  - it: should annotate remote-managed cluster receiver config map
+    template: configmap-cluster-receiver.yaml
+    set:
+      remoteManagement:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["splunk.com/remote-management-config"]
+          value: "true"
+
+  - it: should not annotate collector config maps when remote management is disabled
+    template: configmap-agent.yaml
+    set:
+      gateway:
+        enabled: true
+    asserts:
+      - isNull:
+          path: metadata.annotations["splunk.com/remote-management-config"]
+
+  - it: should not annotate workloads excluded from remote management
+    template: configmap-gateway.yaml
+    set:
+      remoteManagement:
+        enabled: true
+        opampBridge:
+          workloads:
+            gateway:
+              enabled: false
+      gateway:
+        enabled: true
+    asserts:
+      - isNull:
+          path: metadata.annotations["splunk.com/remote-management-config"]
+
+  - it: should accept reset from Helm collector config upgrade strategy
+    template: configmap-agent.yaml
+    set:
+      remoteManagement:
+        enabled: true
+        collectorConfig:
+          upgradeStrategy: resetFromHelm
+    asserts:
+      - equal:
+          path: metadata.annotations["splunk.com/remote-management-config"]
+          value: "true"
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: "opamp/splunk_o11y"
+
   - it: should fail when remote management has no managed workloads
     template: opamp-bridge-serviceaccount.yaml
     set:
@@ -328,3 +402,17 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: "Authorization: Bearer custom-token"
+
+  - it: should report custom collector image tag as managed workload service version
+    template: opamp-bridge-configmap.yaml
+    documentIndex: 0
+    set:
+      remoteManagement:
+        enabled: true
+      image:
+        otelcol:
+          tag: 0.200.0
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'service.version: 0\.200\.0'


### PR DESCRIPTION
**Description:**
Preserve OpAMP-managed collector ConfigMap data.relay during Helm upgrades so remote configuration applied by the bridge is not overwritten after takeover. Adds `remoteManagement.collectorConfig.upgradeStrategy=resetFromHelm` as an escape hatch to force Helm-rendered collector config. Also added `service.version` non-identifying attr as an opportunistic update.


**Testing:** Tested manually & added functional tests.

**Documentation:** Mentioned the escape hatch in advanced configuration.
