### PR TITLE
[chore] switch test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,18 +316,27 @@ kind-delete: ## Delete kind cluster and remove kubeconfig
 	fi
 	@echo "=== Kind cluster cleanup complete ==="
 
-PYTHON_TEST_IMAGE ?= quay.io/splunko11ytest/python_test:latest
-NODEJS_TEST_IMAGE ?= quay.io/splunko11ytest/nodejs_test:latest
+TEST_IMAGE_PLATFORM ?= linux/amd64
+PYTHON_TEST_IMAGE ?= python_test:latest
+NODEJS_TEST_IMAGE ?= nodejs_test:latest
+JAVA_TEST_IMAGE ?= java_test:latest
+DOTNET_TEST_IMAGE ?= dotnet_test:latest
 
 .PHONY: kind-build-test-images
 kind-build-test-images: ## Build test app images and load them into kind cluster
 	@echo "Building Python test app image..."
-	docker build -t $(PYTHON_TEST_IMAGE) functional_tests/functional/testdata/python
+	docker build --platform=$(TEST_IMAGE_PLATFORM) -t $(PYTHON_TEST_IMAGE) functional_tests/functional/testdata/python
 	@echo "Building Node.js test app image..."
-	docker build -t $(NODEJS_TEST_IMAGE) functional_tests/functional/testdata/nodejs
+	docker build --platform=$(TEST_IMAGE_PLATFORM) -t $(NODEJS_TEST_IMAGE) functional_tests/functional/testdata/nodejs
+	@echo "Building Java test app image..."
+	docker build --platform=$(TEST_IMAGE_PLATFORM) -t $(JAVA_TEST_IMAGE) functional_tests/functional/testdata/java
+	@echo "Building .NET test app image..."
+	docker build --platform=$(TEST_IMAGE_PLATFORM) -t $(DOTNET_TEST_IMAGE) functional_tests/functional/testdata/dotnet
 	@echo "Loading test app images into kind cluster..."
 	kind load docker-image $(PYTHON_TEST_IMAGE) --name=$(KIND_CLUSTER_NAME)
 	kind load docker-image $(NODEJS_TEST_IMAGE) --name=$(KIND_CLUSTER_NAME)
+	kind load docker-image $(JAVA_TEST_IMAGE) --name=$(KIND_CLUSTER_NAME)
+	kind load docker-image $(DOTNET_TEST_IMAGE) --name=$(KIND_CLUSTER_NAME)
 	@echo "=== Test images loaded into kind ==="
 
 .PHONY: functionaltest-local

--- a/examples/enable-operator-and-auto-instrumentation/dotnet/deployment.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/dotnet/deployment.yaml
@@ -14,6 +14,6 @@ spec:
         app: dotnet-test
     spec:
       containers:
-        - image: quay.io/splunko11ytest/dotnet_test:latest
+        - image: dotnet_test:latest
           name: dotnet-test
           imagePullPolicy: IfNotPresent

--- a/examples/enable-operator-and-auto-instrumentation/otel-demo-dotnet.md
+++ b/examples/enable-operator-and-auto-instrumentation/otel-demo-dotnet.md
@@ -11,6 +11,15 @@ The .NET demo will create a dotnet-demo namespace and deploys the related .NET a
 If you have your own .NET application you want to instrument, you can still use the steps below as an example for how
 to instrument your application.
 
+Build the sample application image from the chart repository and load it into the Kind cluster before deploying it.
+Set `PLATFORM` to `linux/arm64` on an Apple Silicon Mac or `linux/amd64` for an x86 cluster:
+
+```bash
+PLATFORM=linux/arm64
+docker build --platform="$PLATFORM" -t dotnet_test:latest functional_tests/functional/testdata/dotnet
+kind load docker-image dotnet_test:latest
+```
+
 ```bash
 kubectl create namespace dotnet-demo
 ```

--- a/functional_tests/README.md
+++ b/functional_tests/README.md
@@ -56,23 +56,25 @@ kubectl get csr -o=jsonpath='{range.items[?(@.spec.signerName=="kubernetes.io/ku
 # Update helm dependencies
 make dep-update
 
-# Run functional tests (Kubernetes will pull images automatically)
+# Build and load the application test images into Kind
+make kind-build-test-images
+
+# Run functional tests
 make functionaltest SUITE=functional
 
 # Clean up when done
 kind delete cluster --name=kind
 ```
 
-## Optional: Pre-load Test Images
+## Build Test Images for a Different Platform
 
-If you want to pre-load images for faster test execution:
+`kind-build-test-images` builds the four application images used by the
+functional, secureapp, and OBI Kind suites and loads them into the cluster.
+It defaults to `linux/amd64`, matching GitHub-hosted Linux runners. Override
+the platform for an ARM64 local Kind cluster, such as on an Apple Silicon Mac:
 
 ```bash
-# Load application test images
-kind load docker-image quay.io/splunko11ytest/nodejs_test:latest --name kind
-kind load docker-image quay.io/splunko11ytest/java_test:latest --name kind
-kind load docker-image quay.io/splunko11ytest/dotnet_test:latest --name kind
-kind load docker-image quay.io/splunko11ytest/python_test:latest --name kind
+TEST_IMAGE_PLATFORM=linux/arm64 make kind-build-test-images
 
 # Load auto-instrumentation images (get the latest version from values.yaml) -
 # On Mac M1s, you can also push this image so kind doesn't get confused with the platform to use:

--- a/functional_tests/functional/testdata/dotnet/Makefile
+++ b/functional_tests/functional/testdata/dotnet/Makefile
@@ -1,8 +1,6 @@
-# Default image repository
-IMAGE_REPO ?= quay.io/splunko11ytest/dotnet_test
+PLATFORM ?= linux/amd64
+IMAGE ?= dotnet_test:latest
 
-# This .NET application cannot currently run on arm machines due to .NET runtime environment limitations
-# Was not able to use docker buildx with .NET
-.PHONY: push
-push:
-	docker build --file Dockerfile --no-cache	--tag $(IMAGE_REPO):latest --push .
+.PHONY: build
+build:
+	docker build --file Dockerfile --platform $(PLATFORM) --tag $(IMAGE) .

--- a/functional_tests/functional/testdata/dotnet/README.md
+++ b/functional_tests/functional/testdata/dotnet/README.md
@@ -2,7 +2,8 @@
 
 This image is used for testing the auto-instrumentation of .Net application through the OpenTelemetry Operator.
 
-This image is pushed to https://quay.io/repository/splunko11ytest/dotnet_test.
+This image is built locally by the chart repository's Kind functional-test
+setup.
 
 The container performs two separate functions:
 * It runs a .Net HTTP server on port 3000 of the container host.
@@ -12,12 +13,10 @@ Running this container inside a Kubernetes cluster under observation of the oper
 
 ## Develop
 
-Login to quay.io and push with `make push`
-Make sure for new image repositories you make the repository public
-- Arm based machines can have issues running docker/dockerx build commands that use QEMU virtualization and have .NET support, see: https://github.com/dotnet/dotnet-docker/issues/3832
-- On an arm M2 Mac running Docker Desktop 25.0.0, was able to get the docker/dockerx build for 1 arch images but not multi arch images.
-  - New versions of the OS with Docker may fix this issue.
-  - Dockerx related command:  `docker buildx create --use --name multi-arch-builder`
+Build this image directly with `make -C functional_tests/functional/testdata/dotnet build`.
+Set `PLATFORM=linux/arm64` when building for an ARM64 local Kind cluster. If
+the .NET build or runtime has ARM64 limitations, use the default
+`PLATFORM=linux/amd64` and run it with Docker's emulation support.
 
 ### Debugging .NET
 

--- a/functional_tests/functional/testdata/dotnet/deployment.yaml
+++ b/functional_tests/functional/testdata/dotnet/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: dotnet-test
       annotations:
         instrumentation.opentelemetry.io/inject-dotnet: "true"
-        instrumentation.opentelemetry.io/otel-dotnet-auto-runtime: "linux-musl-x64"
+        instrumentation.opentelemetry.io/otel-dotnet-auto-runtime: "linux-x64"
     spec:
       automountServiceAccountToken: false
       containers:

--- a/functional_tests/functional/testdata/dotnet/deployment.yaml
+++ b/functional_tests/functional/testdata/dotnet/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        - image: quay.io/splunko11ytest/dotnet_test:latest
+        - image: dotnet_test:latest
           name: dotnet-test
           imagePullPolicy: IfNotPresent
       nodeSelector:

--- a/functional_tests/functional/testdata/expected_kind_values/expected_dotnet_traces.yaml
+++ b/functional_tests/functional/testdata/expected_kind_values/expected_dotnet_traces.yaml
@@ -63,7 +63,7 @@ resourceSpans:
             stringValue: cb914065-3f8b-426f-a8f7-f50eaba5feb0
         - key: container.image.name
           value:
-            stringValue: quay.io/splunko11ytest/dotnet_test
+            stringValue: dotnet_test
         - key: container.image.tag
           value:
             stringValue: latest

--- a/functional_tests/functional/testdata/expected_kind_values/expected_java_traces.yaml
+++ b/functional_tests/functional/testdata/expected_kind_values/expected_java_traces.yaml
@@ -98,7 +98,7 @@ resourceSpans:
                   stringValue: 11.0.0.0
               - key: user_agent.original
                 value:
-                  stringValue: curl/7.81.0
+                  stringValue: curl/8.5.0
               - key: network.protocol.version
                 value:
                   stringValue: "1.1"
@@ -155,7 +155,7 @@ resourceSpans:
                   stringValue: 11.0.0.0
               - key: user_agent.original
                 value:
-                  stringValue: curl/7.81.0
+                  stringValue: curl/8.5.0
               - key: network.protocol.version
                 value:
                   stringValue: "1.1"
@@ -212,7 +212,7 @@ resourceSpans:
                   stringValue: 11.0.0.0
               - key: user_agent.original
                 value:
-                  stringValue: curl/7.81.0
+                  stringValue: curl/8.5.0
               - key: network.protocol.version
                 value:
                   stringValue: "1.1"
@@ -269,7 +269,7 @@ resourceSpans:
                   stringValue: 11.0.0.0
               - key: user_agent.original
                 value:
-                  stringValue: curl/7.81.0
+                  stringValue: curl/8.5.0
               - key: network.protocol.version
                 value:
                   stringValue: "1.1"
@@ -326,7 +326,7 @@ resourceSpans:
                   stringValue: 11.0.0.0
               - key: user_agent.original
                 value:
-                  stringValue: curl/7.81.0
+                  stringValue: curl/8.5.0
               - key: network.protocol.version
                 value:
                   stringValue: "1.1"

--- a/functional_tests/functional/testdata/expected_kind_values/expected_java_traces.yaml
+++ b/functional_tests/functional/testdata/expected_kind_values/expected_java_traces.yaml
@@ -57,7 +57,7 @@ resourceSpans:
             stringValue: java-test
         - key: container.image.name
           value:
-            stringValue: quay.io/splunko11ytest/java_test
+            stringValue: java_test
         - key: container.image.tag
           value:
             stringValue: latest

--- a/functional_tests/functional/testdata/expected_kind_values/expected_nodejs_traces.yaml
+++ b/functional_tests/functional/testdata/expected_kind_values/expected_nodejs_traces.yaml
@@ -99,7 +99,7 @@ resourceSpans:
             stringValue: nodejs-test
         - key: container.image.name
           value:
-            stringValue: quay.io/splunko11ytest/nodejs_test
+            stringValue: nodejs_test
         - key: container.image.tag
           value:
             stringValue: latest

--- a/functional_tests/functional/testdata/expected_kind_values/expected_python_traces.yaml
+++ b/functional_tests/functional/testdata/expected_kind_values/expected_python_traces.yaml
@@ -60,7 +60,7 @@ resourceSpans:
             stringValue: python-test
         - key: container.image.name
           value:
-            stringValue: quay.io/splunko11ytest/python_test
+            stringValue: python_test
         - key: container.image.tag
           value:
             stringValue: latest

--- a/functional_tests/functional/testdata/java/Dockerfile
+++ b/functional_tests/functional/testdata/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:11.0-jre21
+FROM tomcat:11.0.0-jre21
 
 COPY start.sh .
 

--- a/functional_tests/functional/testdata/java/Makefile
+++ b/functional_tests/functional/testdata/java/Makefile
@@ -1,3 +1,6 @@
-.PHONY: push
-push:
-	docker buildx build --file Dockerfile --platform linux/amd64,linux/arm64 --tag quay.io/splunko11ytest/java_test:latest --push .
+PLATFORM ?= linux/amd64
+IMAGE ?= java_test:latest
+
+.PHONY: build
+build:
+	docker build --file Dockerfile --platform $(PLATFORM) --tag $(IMAGE) .

--- a/functional_tests/functional/testdata/java/README.md
+++ b/functional_tests/functional/testdata/java/README.md
@@ -2,7 +2,8 @@
 
 This image is used for testing the auto-instrumentation of Java application through the OpenTelemetry Operator.
 
-This image is pushed to https://quay.io/repository/splunko11ytest/java_test.
+This image is built locally by the chart repository's Kind functional-test
+setup.
 
 The container performs two separate functions:
 * It runs an Apache Tomcat server on port 8080 of the container host.
@@ -12,4 +13,5 @@ Running this container inside a Kubernetes cluster under observation of the oper
 
 ## Develop
 
-Login to quay.io and push with `make push`
+Build this image directly with `make -C functional_tests/functional/testdata/java build`.
+Set `PLATFORM=linux/arm64` when building for an ARM64 local Kind cluster.

--- a/functional_tests/functional/testdata/java/deployment.yaml
+++ b/functional_tests/functional/testdata/java/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        - image: quay.io/splunko11ytest/java_test:latest
+        - image: java_test:latest
           name: java-test
           imagePullPolicy: IfNotPresent
       nodeSelector:

--- a/functional_tests/functional/testdata/java/start.sh
+++ b/functional_tests/functional/testdata/java/start.sh
@@ -14,6 +14,6 @@ function stop()
 trap stop SIGINT
 
 while [ $loop -eq 0 ]; do
-  curl -s http://127.0.0.1:8080 > /dev/null
+  curl -4 -s http://localhost:8080 > /dev/null
   sleep 1
 done

--- a/functional_tests/functional/testdata/java/start.sh
+++ b/functional_tests/functional/testdata/java/start.sh
@@ -14,6 +14,6 @@ function stop()
 trap stop SIGINT
 
 while [ $loop -eq 0 ]; do
-  curl -s http://localhost:8080 > /dev/null
+  curl -s http://127.0.0.1:8080 > /dev/null
   sleep 1
 done

--- a/functional_tests/functional/testdata/nodejs/Makefile
+++ b/functional_tests/functional/testdata/nodejs/Makefile
@@ -1,4 +1,7 @@
 
-.PHONY: push
-push: build
-	docker buildx build --file Dockerfile --platform linux/amd64,linux/arm64 --tag quay.io/splunko11ytest/nodejs_test:latest --push .
+PLATFORM ?= linux/amd64
+IMAGE ?= nodejs_test:latest
+
+.PHONY: build
+build:
+	docker build --file Dockerfile --platform $(PLATFORM) --tag $(IMAGE) .

--- a/functional_tests/functional/testdata/nodejs/README.md
+++ b/functional_tests/functional/testdata/nodejs/README.md
@@ -2,7 +2,8 @@
 
 This image is used for testing the auto-instrumentation of Node.js application through the OpenTelemetry Operator.
 
-This image is pushed to https://quay.io/repository/splunko11ytest/nodejs_test.
+This image is built locally by the chart repository's Kind functional-test
+setup.
 
 The container performs two separate functions:
 * It runs a Node.js HTTP server on port 3000 of the container host.
@@ -12,4 +13,5 @@ Running this container inside a Kubernetes cluster under observation of the oper
 
 ## Develop
 
-Login to quay.io and push with `make push`
+Build this image directly with `make -C functional_tests/functional/testdata/nodejs build`.
+Set `PLATFORM=linux/arm64` when building for an ARM64 local Kind cluster.

--- a/functional_tests/functional/testdata/nodejs/deployment.yaml
+++ b/functional_tests/functional/testdata/nodejs/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        - image: quay.io/splunko11ytest/nodejs_test:latest
+        - image: nodejs_test:latest
           name: nodejs-test
           imagePullPolicy: IfNotPresent
       nodeSelector:

--- a/functional_tests/functional/testdata/python/Makefile
+++ b/functional_tests/functional/testdata/python/Makefile
@@ -1,4 +1,7 @@
 
-.PHONY: push
-push:
-	docker buildx build --file Dockerfile --platform linux/amd64,linux/arm64 --tag quay.io/splunko11ytest/python_test:latest --push .
+PLATFORM ?= linux/amd64
+IMAGE ?= python_test:latest
+
+.PHONY: build
+build:
+	docker build --file Dockerfile --platform $(PLATFORM) --tag $(IMAGE) .

--- a/functional_tests/functional/testdata/python/README.md
+++ b/functional_tests/functional/testdata/python/README.md
@@ -2,7 +2,8 @@
 
 This image is used for testing the auto-instrumentation of Python application through the OpenTelemetry Operator.
 
-This image is pushed to https://quay.io/repository/splunko11ytest/python_test.
+This image is built locally by the chart repository's Kind functional-test
+setup.
 
 The container performs two separate functions:
 * It runs a Python HTTP server on port 8000 of the container host.
@@ -12,4 +13,5 @@ Running this container inside a Kubernetes cluster under observation of the oper
 
 ## Develop
 
-Login to quay.io and push with `make push`
+Build this image directly with `make -C functional_tests/functional/testdata/python build`.
+Set `PLATFORM=linux/arm64` when building for an ARM64 local Kind cluster.

--- a/functional_tests/functional/testdata/python/deployment.yaml
+++ b/functional_tests/functional/testdata/python/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        - image: quay.io/splunko11ytest/python_test:latest
+        - image: python_test:latest
           name: python-test
           imagePullPolicy: IfNotPresent
       nodeSelector:

--- a/functional_tests/obi/testdata/python/deployment.yaml
+++ b/functional_tests/obi/testdata/python/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-        - image: quay.io/splunko11ytest/python_test:latest
+        - image: python_test:latest
           name: python-test
           imagePullPolicy: IfNotPresent
       nodeSelector:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Switch functional tests and the .NET auto-instrumentation example from deleted quay.io/splunko11ytest images to locally built images. Kind now builds and loads Python, Node.js, Java, and .NET test images with configurable platform support for AMD64 and ARM64. Updated manifests, trace expectations, documentation, and secureapp coverage accordingly.
