### PR TITLE
Reject malformed Prometheus pod annotations

### DIFF
--- a/.chloggen/improve-lightprometheus-rule-creation.yaml
+++ b/.chloggen/improve-lightprometheus-rule-creation.yaml
@@ -1,0 +1,10 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+# The name of the component, or a single word describing the area of concern (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: chart
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reject malformed Prometheus pod annotations when using the Light Prometheus Receiver
+# One or more tracking issues related to this change
+issues: [2583]
+# (Optional) One or more lines of additional information to render under the primary note.
+subtext:

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-agent.tpl
@@ -113,10 +113,20 @@ receivers:
       {{- end }}
         {{- if .Values.autodetect.prometheus }}
         # Enable prometheus scraping for pods with standard prometheus annotations
+        {{- if .Values.featureGates.useLightPrometheusReceiver }}
+        # The light receiver concatenates these values into a URL, so only allow a numeric port and an absolute path.
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && (! ("prometheus.io/port" in annotations) || annotations["prometheus.io/port"] matches "^[0-9]+$") && (! ("prometheus.io/path" in annotations) || annotations["prometheus.io/path"] matches "^/(?:$|[^/].*)$")
+        {{- else }}
         rule: type == "pod" && annotations["prometheus.io/scrape"] == "true"
+        {{- end }}
         {{- else }}
         # Enable prometheus scraping for Istio pods only
+        {{- if .Values.featureGates.useLightPrometheusReceiver }}
+        # The light receiver concatenates these values into a URL, so only allow a numeric port and an absolute path.
+        rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && ("istio.io/rev" in labels or "istio.io/rev" in annotations or labels["istio"] == "pilot" or name matches "istio.*") && (! ("prometheus.io/port" in annotations) || annotations["prometheus.io/port"] matches "^[0-9]+$") && (! ("prometheus.io/path" in annotations) || annotations["prometheus.io/path"] matches "^/(?:$|[^/].*)$")
+        {{- else }}
         rule: type == "pod" && annotations["prometheus.io/scrape"] == "true" && ("istio.io/rev" in labels or "istio.io/rev" in annotations or labels["istio"] == "pilot" or name matches "istio.*")
+        {{- end }}
         {{- end }}
         config:
           {{- if .Values.featureGates.useLightPrometheusReceiver }}

--- a/unittests/light_prometheus_receiver_test.yaml
+++ b/unittests/light_prometheus_receiver_test.yaml
@@ -1,0 +1,83 @@
+suite: splunk-otel-collector.lightPrometheusReceiver
+values:
+  - ./values/basic.yaml
+release:
+  name: test-release
+  namespace: test-ns
+templates:
+  - configmap-agent.yaml
+
+tests:
+  - it: rejects malformed Prometheus annotations before creating the light receiver
+    set:
+      autodetect:
+        prometheus: true
+      featureGates:
+        useLightPrometheusReceiver: true
+    template: configmap-agent.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: 'lightprometheus:'
+      - matchRegex:
+          path: data["relay"]
+          pattern: '(?s)prometheus\.io/port.*matches'
+      - matchRegex:
+          path: data["relay"]
+          pattern: '(?s)prometheus\.io/path.*matches'
+
+  - it: anchors the port pattern to digits only, so a value like '9090@evil.com' can never match
+    set:
+      autodetect:
+        prometheus: true
+      featureGates:
+        useLightPrometheusReceiver: true
+    template: configmap-agent.yaml
+    asserts:
+      # helm-unittest only renders templates; it can't execute the `expr` rule engine against
+      # a live pod annotation. This asserts the rendered pattern is fully anchored (^...$) and
+      # restricted to the [0-9] character class, which by construction cannot match any string
+      # containing '@' (or any other non-digit character).
+      - matchRegex:
+          path: data["relay"]
+          pattern: '(?s)annotations\["prometheus\.io/port"\]\s+matches\s+"\^\[0-9\]\+\$"'
+
+  - it: keeps the standard receiver configuration unchanged when the light receiver is disabled
+    set:
+      autodetect:
+        prometheus: true
+      featureGates:
+        useLightPrometheusReceiver: false
+    template: configmap-agent.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: 'prometheus/autodetect:'
+      - notMatchRegex:
+          path: data["relay"]
+          pattern: 'lightprometheus:'
+      - matchRegex:
+          path: data["relay"]
+          pattern: 'rule: type == "pod" && annotations\["prometheus.io/scrape"\] == "true"'
+
+  - it: applies the annotation validation to Istio autodetection
+    set:
+      autodetect:
+        prometheus: false
+        istio: true
+      featureGates:
+        useLightPrometheusReceiver: true
+    template: configmap-agent.yaml
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: 'lightprometheus:'
+      - matchRegex:
+          path: data["relay"]
+          pattern: '(?s)prometheus\.io/port.*matches'
+      - matchRegex:
+          path: data["relay"]
+          pattern: '(?s)prometheus\.io/path.*matches'
+      - matchRegex:
+          path: data["relay"]
+          pattern: '(?s)prometheus\.io/scrape.*istio\.io/rev.*prometheus\.io/port.*matches'


### PR DESCRIPTION
Rejects malformed annotations that can have unexpected results, e.g.: scraping an unexpected destination. 
