### PR TITLE
[chore] Render examples with consistent use of blank lines

### DIFF
--- a/ci_scripts/render-examples.sh
+++ b/ci_scripts/render-examples.sh
@@ -81,6 +81,12 @@ render_task() {
     done
   fi
 
+  # Normalize blank lines: depending on the Helm version, an extra blank line can be
+  # left before a "---" document separator or at the end of a rendered file. Strip
+  # those so the rendered output doesn't depend on the Helm version used to render it.
+  find "${rendered_manifests_dir}" -type f -name "*.yaml" -not -path "*/splunk-otel-collector/*" \
+    -exec perl -0777 -pi -e 's/(?:\n[ \t]*)+\n(?=-{3}\n)/\n/g; s/\s+\z/\n/' {} +
+
   echo "[${example_name}] SUCCESS"
 }
 


### PR DESCRIPTION
I tried to rendered the examples in my machine and ended up with only differences in blank lines around `---` and the last few blank lines. Updated the script to be consistent independet of the Helm version in use.