### PR TITLE
OTL-4112 enable k8s.service metrics and resattr in chart

### DIFF
--- a/.chloggen/enable-k8s-service-metrics.yaml
+++ b/.chloggen/enable-k8s-service-metrics.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+# The name of the component, or a single word describing the area of concern, (e.g. agent, clusterReceiver, gateway, operator, chart, other)
+component: clusterReceiver
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable k8s.service metrics and resource attributes in the Kubernetes cluster receiver configuration.
+# One or more tracking issues related to the change
+issues: [2587]
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following service metrics are now enabled by default in the k8s_cluster receiver when sending to
+  Splunk Observability:
+    - k8s.service.endpoint.count
+    - k8s.service.load_balancer.ingress.count
+  The following resource attributes are also enabled to provide additional context for these metrics:
+    - k8s.service.publish_not_ready_addresses
+    - k8s.service.traffic_distribution

--- a/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
+++ b/examples/add-filter-processor/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/configmap-cluster-receiver.yaml
@@ -149,6 +149,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -157,6 +161,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       k8s_events:
         auth_type: serviceAccount

--- a/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-filter-processor/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 57c726928bb6aea8669ab0c786a644336e61ddc44074c8c50afd36f2f3960d1f
+        checksum/config: 092c7c5e86904c5a3f2295ca706f33ddc1e1951072ba8f0a0a0c3eb57a642b5f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/configmap-cluster-receiver.yaml
@@ -149,6 +149,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -157,6 +161,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       k8s_events:
         auth_type: serviceAccount

--- a/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-kafkametrics-receiver/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 57c726928bb6aea8669ab0c786a644336e61ddc44074c8c50afd36f2f3960d1f
+        checksum/config: 092c7c5e86904c5a3f2295ca706f33ddc1e1951072ba8f0a0a0c3eb57a642b5f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-receiver-creator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/add-sampler/rendered_manifests/clusterRole.yaml
+++ b/examples/add-sampler/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/add-sampler/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/configmap-cluster-receiver.yaml
@@ -149,6 +149,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -157,6 +161,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       k8s_events:
         auth_type: serviceAccount

--- a/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio-disable-histograms/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 57c726928bb6aea8669ab0c786a644336e61ddc44074c8c50afd36f2f3960d1f
+        checksum/config: 092c7c5e86904c5a3f2295ca706f33ddc1e1951072ba8f0a0a0c3eb57a642b5f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
+++ b/examples/autodetect-istio/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/configmap-cluster-receiver.yaml
@@ -149,6 +149,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -157,6 +161,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       k8s_events:
         auth_type: serviceAccount

--- a/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/autodetect-istio/rendered_manifests/deployment-cluster-receiver.yaml
@@ -31,7 +31,7 @@ spec:
         release: default
         sidecar.istio.io/inject: "false"
       annotations:
-        checksum/config: 57c726928bb6aea8669ab0c786a644336e61ddc44074c8c50afd36f2f3960d1f
+        checksum/config: 092c7c5e86904c5a3f2295ca706f33ddc1e1951072ba8f0a0a0c3eb57a642b5f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-agent-only/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-all-modes/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/collector-all-modes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5713e4ac96b5f973630a347acb2ff2a5a3ba5d1472777dd00f2290a9256062e5
+        checksum/config: 3654294382df7077512b8c6fa8b832154a0ff61281e4004ea681a494ba97252b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-cluster-receiver-only/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-only/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/collector-gateway-statefulset-only/rendered_manifests/clusterRole.yaml
+++ b/examples/collector-gateway-statefulset-only/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/controlplane-histogram-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/default/rendered_manifests/clusterRole.yaml
+++ b/examples/default/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/default/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/disable-persistence-queue-traces/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/discovery-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/discovery-mode/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/distribution-aks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-aks/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -90,6 +90,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -98,6 +102,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-aks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 7215a3e0ff44e2e2ebc496ad2e8ab4d0ca62d9fd74370af1af0f118ec6236b15
+        checksum/config: 5a88f3046ae86f6f625bc189bcb66ff3671961ada1515b228364a0857f21a691
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/clusterRole.yaml
@@ -89,6 +89,14 @@ rules:
   resourceNames:
   - aws-auth
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/configmap-cluster-receiver.yaml
@@ -126,6 +126,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -134,6 +138,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-auto-mode/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b69559bb2bc90b0e64bea910d1c662046013902ce97ae130c6198cbd4969df79
+        checksum/config: f7a04edeec33040b2c8320a53da9723e87bf827cddc63f95a1ca4f6c3fb62734
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/clusterRole.yaml
@@ -95,6 +95,14 @@ rules:
   resourceNames:
   - aws-auth
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/configmap-cluster-receiver.yaml
@@ -97,6 +97,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -105,6 +109,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks-fargate/rendered_manifests/deployment-cluster-receiver.yaml
@@ -32,7 +32,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: b70312efbe284867f79bca6d593ffe5c87d98de4461f40897d3efbe120944840
+        checksum/config: 3f5efe65c1d1a9c17dd0acf8e60a1076fd373a66eb5350e2f207b703d01cccc1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-eks/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-eks/rendered_manifests/clusterRole.yaml
@@ -89,6 +89,14 @@ rules:
   resourceNames:
   - aws-auth
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/configmap-cluster-receiver.yaml
@@ -113,6 +113,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -121,6 +125,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-eks/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: c7a1e73912829c6432c57420f537510de85e6b0236642b89d26b84a604293d48
+        checksum/config: 7e8c398ffeb8bca00a41dc5676cf380b0a481cae5ce8f774f7c02ef4ab73e9b6
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/configmap-cluster-receiver.yaml
@@ -129,6 +129,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -137,6 +141,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke-autopilot/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 11807d8857d190a65c46d1b2ec3bcb5dfedbbbe2cf15cabf4b159f3c8f3fd51e
+        checksum/config: 80813b640994e4e2c0fa70b49de56b7b2b2b588ef611c0e72664e5903462d2a1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-gke/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-gke/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/configmap-cluster-receiver.yaml
@@ -129,6 +129,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -137,6 +141,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-gke/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 11807d8857d190a65c46d1b2ec3bcb5dfedbbbe2cf15cabf4b159f3c8f3fd51e
+        checksum/config: 80813b640994e4e2c0fa70b49de56b7b2b2b588ef611c0e72664e5903462d2a1
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
+++ b/examples/distribution-openshift/rendered_manifests/clusterRole.yaml
@@ -98,6 +98,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/configmap-cluster-receiver.yaml
@@ -90,6 +90,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -98,6 +102,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/distribution-openshift/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: e45b684c04c8bd622d91ef8c845cb2d79833d815f0d0ff282f92424cfdc7b618
+        checksum/config: 3a1fc5db961f65f18db600f48ab218eb9c5977401e56303361f255974d500c8f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/ebpf-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/ebpf-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/ebpf-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/configmap-cluster-receiver.yaml
@@ -154,6 +154,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -162,6 +166,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       k8s_events:
         auth_type: serviceAccount

--- a/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enable-operator-and-auto-instrumentation/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: ff240e0afcd8881cef6f362ab2af0b2deac96c43f490e2d7f0aea240f33353a6
+        checksum/config: 3daa30fcf43780301e1ab1e69c6e133164d5603f112732318a7e21b8b18d9be8
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-persistence-queue/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
+++ b/examples/enable-trace-sampling/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/enabled-pprof-extension/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-disabled/rendered_manifests/clusterRole.yaml
+++ b/examples/histograms-disabled/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/configmap-cluster-receiver.yaml
@@ -210,6 +210,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -218,6 +222,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       k8s_events:
         auth_type: serviceAccount

--- a/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/histograms-disabled/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 1457d8b606d145c5cc36ab3d28a3211049c1f205f2ccb6725d7852346eeafb04
+        checksum/config: c75cae40a7d8010cf39bad89e6ad97d775beb842acc347b7b0930a6ff8f1ac35
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/histograms-with-splunk-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/histograms-with-splunk-platform/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/host-journalctl-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/host-journalctl-logs/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/clusterRole.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/configmap-cluster-receiver.yaml
@@ -129,6 +129,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -137,6 +141,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       k8s_events:
         auth_type: serviceAccount

--- a/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/k8s-events-o11y-pipeline/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 41de189f7e31b1568b1f126fb5d11c50e01ae316e6f47f06cdf05d86b4a246c1
+        checksum/config: f0b903401ff46ab2ad360400c2f981a9581771dba0549ea87361dbf54d4470f2
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/configmap-cluster-receiver.yaml
@@ -149,6 +149,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -157,6 +161,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       k8s_events:
         auth_type: serviceAccount

--- a/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/kubernetes-windows-nodes/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 57c726928bb6aea8669ab0c786a644336e61ddc44074c8c50afd36f2f3960d1f
+        checksum/config: 092c7c5e86904c5a3f2295ca706f33ddc1e1951072ba8f0a0a0c3eb57a642b5f
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/multi-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/multi-metrics/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/multiline-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/multiline-logs/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
+++ b/examples/only-logs-with-extra-file-logs/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics-platform/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/only-metrics/rendered_manifests/clusterRole.yaml
+++ b/examples/only-metrics/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/only-metrics/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/only-traces/rendered_manifests/clusterRole.yaml
+++ b/examples/only-traces/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/otlp-token-passthrough/rendered_manifests/clusterRole.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/otlp-token-passthrough/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 5713e4ac96b5f973630a347acb2ff2a5a3ba5d1472777dd00f2290a9256062e5
+        checksum/config: 3654294382df7077512b8c6fa8b832154a0ff61281e4004ea681a494ba97252b
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/route-data-through-gateway-deployed-separately/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: 19810ba1c33e4bc258d3296ffc34acf46fb5ac34dc30ba7e51c93543f2f3a82f
+        checksum/config: 6032673b631257cb40430d30bb69ffef479a03ba6dd8c6955d8010db56359301
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/secret-validation/rendered_manifests/clusterRole.yaml
+++ b/examples/secret-validation/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/secureapp-agent-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/secureapp-agent-mode/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/secureapp-gateway-mode/rendered_manifests/clusterRole.yaml
+++ b/examples/secureapp-gateway-mode/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/splunk-connect-for-otlp/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-connect-for-otlp/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-enterprise-index-routing/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
+++ b/examples/splunk-platform-with-sourcetypes/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/target-allocator/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/use-proxy/rendered_manifests/clusterRole.yaml
+++ b/examples/use-proxy/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/use-proxy/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
+++ b/examples/with-target-allocator/rendered_manifests/clusterRole.yaml
@@ -81,6 +81,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/configmap-cluster-receiver.yaml
@@ -88,6 +88,10 @@ data:
             enabled: true
           k8s.pod.status_reason:
             enabled: true
+          k8s.service.endpoint.count:
+            enabled: true
+          k8s.service.load_balancer.ingress.count:
+            enabled: true
         resource_attributes:
           k8s.hpa.scaletargetref.kind:
             enabled: true
@@ -96,6 +100,10 @@ data:
           k8s.kubelet.version:
             enabled: true
           k8s.pod.qos_class:
+            enabled: true
+          k8s.service.publish_not_ready_addresses:
+            enabled: true
+          k8s.service.traffic_distribution:
             enabled: true
       prometheus/k8s_cluster_receiver:
         config:

--- a/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
+++ b/examples/with-target-allocator/rendered_manifests/deployment-cluster-receiver.yaml
@@ -30,7 +30,7 @@ spec:
         component: otel-k8s-cluster-receiver
         release: default
       annotations:
-        checksum/config: a08d8488125c0a0b710498f88ddbec1ffdf1cc51436708743f9c277b5c51572b
+        checksum/config: bed75a344cb69d8b08fac487699a32ed9447859990b784342bfd1a848a10083d
     spec:
       serviceAccountName: default-splunk-otel-collector
       nodeSelector:

--- a/functional_tests/functional/functional_test.go
+++ b/functional_tests/functional/functional_test.go
@@ -447,6 +447,8 @@ func Test_Functions(t *testing.T) {
 
 		deployCharts(t, testKubeConfig, client, extensionsClient)
 		if !skipTests && kubeTestEnv == kindTestKubeEnv && os.Getenv("UPGRADE_FROM_VALUES") == "" {
+			deleteInstallationHookJob(t, client)
+			internal.ResetMetricsSink(t, globalSinks.k8sclusterReceiverMetricsConsumer)
 			t.Run("kubernetes cluster metrics", testK8sClusterReceiverMetrics)
 		}
 		deployTestResources(t, client, dynamicClient)
@@ -468,6 +470,24 @@ func Test_Functions(t *testing.T) {
 	} else {
 		runHostedClusterTests(t, kubeTestEnv)
 	}
+}
+
+func deleteInstallationHookJob(t *testing.T, client kubernetes.Interface) {
+	t.Helper()
+
+	jobs := client.BatchV1().Jobs(internal.DefaultNamespace)
+	propagation := metav1.DeletePropagationForeground
+	err := jobs.Delete(t.Context(), "sock-splunk-otel-collector-inst-hook", metav1.DeleteOptions{
+		PropagationPolicy: &propagation,
+	})
+	if k8serrors.IsNotFound(err) {
+		return
+	}
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		_, getErr := jobs.Get(t.Context(), "sock-splunk-otel-collector-inst-hook", metav1.GetOptions{})
+		return k8serrors.IsNotFound(getErr)
+	}, 30*time.Second, time.Second)
 }
 
 func runLocalClusterUpgradeTests(t *testing.T) {
@@ -877,6 +897,11 @@ func testK8sClusterReceiverMetrics(t *testing.T) {
 		internal.WithWaitForSnapshotMatch(),
 		internal.WithVolatileAttributes(existsAttrs...),
 		internal.WithRegexAttributes(internal.CommonK8sMetricAssertionRegexAttrs),
+		internal.WithSelectedNumberDatapoint("k8s.service.endpoint.count", map[string]string{
+			"k8s.namespace.name":             "default",
+			"k8s.service.endpoint.condition": "ready",
+			"k8s.service.name":               "kubernetes",
+		}),
 		internal.WithFirstDatapointOnly(
 			"k8s.container.ready",
 			"k8s.container.restarts",

--- a/functional_tests/functional/testdata/expected_kind_values/expected_cluster_receiver_assertion.yaml
+++ b/functional_tests/functional/testdata/expected_kind_values/expected_cluster_receiver_assertion.yaml
@@ -2895,5 +2895,23 @@ resources:
                     receiver: k8scluster
               name: k8s.replicaset.desired
               type: gauge
+            - datapoints:
+                - attributes:
+                    cluster_name: ci-k8s-cluster
+                    customfield1: customvalue1
+                    customfield2: customvalue2
+                    k8s.cluster.name: dev-operator
+                    k8s.namespace.name: default
+                    k8s.service.endpoint.address_type: IPv4
+                    k8s.service.endpoint.condition: ready
+                    k8s.service.endpoint.zone/exists: true
+                    k8s.service.name: kubernetes
+                    k8s.service.publish_not_ready_addresses: "false"
+                    k8s.service.type: ClusterIP
+                    k8s.service.uid/exists: true
+                    metric_source: kubernetes
+                    receiver: k8scluster
+              name: k8s.service.endpoint.count
+              type: gauge
 signal: metrics
 version: 1

--- a/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
+++ b/helm-charts/splunk-otel-collector/templates/clusterRole.yaml
@@ -113,6 +113,14 @@ rules:
   - aws-auth
 {{- end }}
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
+++ b/helm-charts/splunk-otel-collector/templates/config/_otel-k8s-cluster-receiver-config.tpl
@@ -36,12 +36,20 @@ receivers:
         enabled: true
       k8s.pod.qos_class:
         enabled: true
+      k8s.service.publish_not_ready_addresses:
+        enabled: true
+      k8s.service.traffic_distribution:
+        enabled: true
     metrics:
       k8s.container.status.reason:
         enabled: true
       k8s.node.condition:
         enabled: true
       k8s.pod.status_reason:
+        enabled: true
+      k8s.service.endpoint.count:
+        enabled: true
+      k8s.service.load_balancer.ingress.count:
         enabled: true
     {{- end }}
     {{- if eq .Values.distribution "openshift" }}

--- a/unittests/k8s_service_metrics_test.yaml
+++ b/unittests/k8s_service_metrics_test.yaml
@@ -1,0 +1,24 @@
+suite: splunk-otel-collector.k8sServiceMetrics
+values:
+  - ./values/basic.yaml
+release:
+  name: test-release
+  namespace: test-ns
+templates:
+  - configmap-cluster-receiver.yaml
+
+tests:
+  - it: enables all service metrics and resource attributes by default
+    asserts:
+      - matchRegex:
+          path: data["relay"]
+          pattern: "k8s\\.service\\.endpoint\\.count:\\n\\s+enabled: true"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "k8s\\.service\\.load_balancer\\.ingress\\.count:\\n\\s+enabled: true"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "k8s\\.service\\.publish_not_ready_addresses:\\n\\s+enabled: true"
+      - matchRegex:
+          path: data["relay"]
+          pattern: "k8s\\.service\\.traffic_distribution:\\n\\s+enabled: true"


### PR DESCRIPTION
**Description:** Enable k8s.service metrics and resource attributes

Enable the Kubernetes Service metrics required by the InfraMon content in
the k8s_cluster receiver configuration when Splunk Observability metrics are
enabled:

- k8s.service.endpoint.count
- k8s.service.load_balancer.ingress.count

Also enable the related optional resource attributes:

- k8s.service.publish_not_ready_addresses
- k8s.service.traffic_distribution

Grant the cluster receiver read access to discovery.k8s.io EndpointSlices,
which is required for collecting endpoint count metrics.

**Link to Splunk idea:** [OTL-4112](https://splunk.atlassian.net/browse/OTL-4112)

**Testing:**Add Helm unit-test coverage, update the functional cluster-metrics
expectations, regenerate the affected example manifests and deployment
checksums, and add the corresponding changelog entry.

- [x] EKS functional tests were run when recommended, or are not needed for this change.

**Documentation:** <Describe the documentation added.>
